### PR TITLE
#pragma once

### DIFF
--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -30,6 +30,26 @@ auto Add(const int64 a, const int64 b) -> int64;
 int64 Add(const int64 a, const int64 b);
 ```
 
+### Header guard
+
+Exception: Use `#pragma once` instead of `#define` guard for header files. This
+project's tooling does not support automatically enforcing the header guard
+convention where the `#define` guard's identifier mirrors the file's path to
+guarantee uniqueness. Despite being non-standard, `#pragma once` carries
+advantages such as reducing the maintenance burden when renaming and moving
+files, and in some cases improves compilation speed.
+
+```c++
+// ✅ Do this
+#pragma once
+
+// ❌ Not this
+#ifndef SPOOR_PATH_TO_HEADER_H_
+#define SPOOR_PATH_TO_HEADER_H_
+...
+#endif
+```
+
 ### Initialization
 
 Prefer list (curly brace) initialization over other forms. List initialization

--- a/spoor/lib.h
+++ b/spoor/lib.h
@@ -1,5 +1,4 @@
-#ifndef SPOOR_SPOOR_LIB_H_
-#define SPOOR_SPOOR_LIB_H_
+#pragma once
 
 #include "util/numeric.h"
 
@@ -8,5 +7,3 @@ namespace spoor::lib {
 auto Add(int64 a, int64 b) -> int64;
 
 }  // namespace spoor::lib
-
-#endif

--- a/util/numeric.h
+++ b/util/numeric.h
@@ -1,5 +1,4 @@
-#ifndef SPOOR_UTIL_NUMERIC_H_
-#define SPOOR_UTIL_NUMERIC_H_
+#pragma once
 
 #include <cstdint>
 
@@ -18,5 +17,3 @@ static_assert(
 static_assert(
     sizeof(double) == 8,
     "This platform does not define `double` as a 64-bit floating-point value.");
-
-#endif

--- a/util/result.h
+++ b/util/result.h
@@ -1,5 +1,4 @@
-#ifndef SPOOR_UTIL_RESULT_H_
-#define SPOOR_UTIL_RESULT_H_
+#pragma once
 
 #include <optional>
 #include <type_traits>
@@ -196,5 +195,3 @@ constexpr auto operator==(const Result<T1, E1>& lhs, const Result<T2, E2>& rhs)
 }
 
 }  // namespace util::result
-
-#endif


### PR DESCRIPTION
Replaces the include guard with `#pragma once` and updates the style guide (including rationale).

Resolves #8.