### PR TITLE
Sanitizers: Asan, tsan, and ubsan

### DIFF
--- a/.build/azure-pipelines.yml
+++ b/.build/azure-pipelines.yml
@@ -14,6 +14,19 @@ jobs:
     displayName: Build
   - script: bazel test //...
     displayName: Test
+  - script: ./toolchain/compilation_database/generate_compilation_database.sh
+    displayName: Generate compilation database
+- job: sanitizers
+  pool:
+    vmImage: 'ubuntu-20.04'
+  steps:
+  - template: ./templates/install-common.yml
+  - script: bazel test --config=asan //...
+    displayName: Address sanitizer
+  - script: bazel test --config=tsan //...
+    displayName: Thread sanitizer
+  - script: bazel test --config=ubsan //...
+    displayName: Undefined behavior sanitizer
 - job: style_and_lint
   pool:
     vmImage: 'ubuntu-20.04'

--- a/.build/ci.bazelrc
+++ b/.build/ci.bazelrc
@@ -2,3 +2,26 @@ build:llvm_config --crosstool_top=//toolchain/crosstool:llvm_toolchain
 build --config=llvm_config
 build --output_filter='^external/*'
 test --test_output=all
+
+build:asan --strip=never
+build:asan --copt -fsanitize=address
+build:asan --copt -O1
+build:asan --copt -g
+build:asan --copt -fno-omit-frame-pointer
+build:asan --linkopt -fsanitize=address
+
+build:tsan --strip=never
+build:tsan --copt -fsanitize=thread
+build:tsan --copt -O1
+build:tsan --copt -g
+build:tsan --copt -fno-omit-frame-pointer
+build:tsan --linkopt -fsanitize=thread
+
+build:ubsan --strip=never
+build:ubsan --copt -fsanitize=undefined
+build:ubsan --copt -fno-sanitize-recover=all
+build:ubsan --copt -O1
+build:ubsan --copt -g
+build:ubsan --copt -fno-omit-frame-pointer
+build:ubsan --linkopt -fsanitize=undefined
+build:ubsan --linkopt -lubsan


### PR DESCRIPTION
Run tests instrumented with three [sanitizers](https://github.com/google/sanitizers):
* Address sanitizer: Addressability issues, memory leaks, etc.
* Thread sanitizer: Data races and deadlocks
* Undefined behavior sanitizer: Signed integer overflow, etc.

I didn't include the memory sanitizer because our dependencies have uninitialized variables which emit warnings that are hard to silence with Bazel. Additionally, it doesn't work on macOS. Clang Tidy should help us here.

We now need to do an additional three clean builds as part of CI, however, I feel that the benefits these sanitizers provide outweigh the cost of waiting for CI. Of course, the effectiveness of the sanitizers are only as good as the tests under which they are run.