### PR TITLE
Fix Clang Tidy in CI, shorten CI times, and gardening

### DIFF
--- a/.build/azure-pipelines.yml
+++ b/.build/azure-pipelines.yml
@@ -3,7 +3,7 @@ jobs:
   strategy:
     matrix:
       linux:
-        imageName: 'ubuntu-18.04'
+        imageName: 'ubuntu-20.04'
       mac:
         imageName: 'macos-10.15'
   pool:
@@ -16,9 +16,11 @@ jobs:
     displayName: Test
 - job: style_and_lint
   pool:
-    vmImage: 'ubuntu-18.04'
+    vmImage: 'ubuntu-20.04'
   steps:
   - template: ./templates/install-common.yml
+  - script: sudo apt-get install clang-format clang-tidy
+    displayName: Install Clang Format and Clang Tidy
   - script: |
       ./toolchain/style/clang_format.sh
       git diff --exit-code
@@ -29,3 +31,5 @@ jobs:
     displayName: Buildifier
   - script: ./toolchain/style/clang_tidy.sh
     displayName: Clang Tidy
+    env:
+      AZURE_PIPELINES_OS: $(Agent.OS)

--- a/.build/templates/install-common.yml
+++ b/.build/templates/install-common.yml
@@ -1,12 +1,3 @@
 steps:
-- script: |
-    wget https://apt.llvm.org/llvm.sh
-    chmod +x llvm.sh
-    sudo ./llvm.sh 10
-    sudo apt-get update
-    sudo apt-get install clang-format-10 clang-tidy-10
-  displayName: Install LLVM (Linux)
-  condition: eq(variables['Agent.OS'], 'Linux')
-# LLVM 10 is already installed on the Azure Pipelines macOS image via Homebrew.
 - script: cp ./.build/ci.bazelrc ./.bazelrc
   displayName: Copy .bazelrc

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -14,7 +14,7 @@
 #   Enforced by Clang Format.
 # readability-magic-numbers
 #   These warnings are generally unhelpful because the "magic numbers" are
-#   self-explanatory in the context of the code).
+#   self-explanatory in the context of the code.
 # Other checks are aliases which are disable so only one NOLINT is required.
 #   https://clang.llvm.org/extra/clang-tidy/checks/list.html#id117
 Checks: '

--- a/spoor/lib_test.cc
+++ b/spoor/lib_test.cc
@@ -1,6 +1,6 @@
 #include "spoor/lib.h"
 
-#include <gtest/gtest.h>
+#include "gtest/gtest.h"
 
 namespace {
 

--- a/toolchain/crosstool/cc_toolchain_config.bzl
+++ b/toolchain/crosstool/cc_toolchain_config.bzl
@@ -38,11 +38,14 @@ FEATURES = [
                     flag_group(
                         flags = [
                             "-std=c++20",
-                            "-Wall",
-                            "-Wextra",
-                            "-Wpedantic",
+                            "-pthread",
                             "-fno-exceptions",
                             "-fno-rtti",
+                            "-Wall",
+                            "-Wextra",
+                            "-pedantic",
+                            "-Wno-gnu-zero-variadic-macro-arguments",  # gMock
+                            "-Wno-gcc-compat",  # absl::StrFormat.
                         ],
                     ),
                 ]),
@@ -91,7 +94,8 @@ def linux_llvm_toolchain_impl(ctx):
         ctx = ctx,
         features = FEATURES,
         cxx_builtin_include_directories = [
-            "/usr/lib/llvm-10/lib/clang/10.0.1/include",
+            "/usr/lib/llvm-10/lib/clang/10.0.0/include",
+            "/usr/lib/llvm-10/lib/clang/10.0.0/share",
             "/usr/include",
         ],
         toolchain_identifier = "linux-llvm-toolchain",
@@ -147,6 +151,7 @@ def darwin_llvm_toolchain_impl(ctx):
         cxx_builtin_include_directories = [
             "/usr/local/opt/llvm/include/c++/v1",
             "/usr/local/Cellar/llvm/10.0.1_1/lib/clang/10.0.1/include",
+            "/usr/local/Cellar/llvm/10.0.1_1/lib/clang/10.0.1/share",
             "/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk/usr/include",
             "/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk/System/Library/Frameworks",
         ],

--- a/toolchain/style/clang_format.sh
+++ b/toolchain/style/clang_format.sh
@@ -3,18 +3,10 @@
 set -eu
 
 WORKSPACE="$(bazel info workspace)"
-if command -v clang-format &> /dev/null; then
-  CLANG_FORMAT="clang-format"
-elif command -v clang-format-10 &> /dev/null; then
-  CLANG_FORMAT="clang-format-10"
-else
-  echo "clang-format not found"
-  exit 1
-fi
 
 function run_clang_format {
   echo "Formatting $1"
-  "$CLANG_FORMAT" \
+  clang-format \
     -style=file \
     -i \
     "$1"

--- a/toolchain/style/clang_tidy.sh
+++ b/toolchain/style/clang_tidy.sh
@@ -1,23 +1,29 @@
 #!/usr/bin/env bash
 
-set -eu
+set -e
 
 WORKSPACE="$(bazel info workspace)"
 
-if command -v clang-tidy &> /dev/null; then
-  CLANG_TIDY="clang-tidy"
-elif command -v clang-tidy-10 &> /dev/null; then
-  CLANG_TIDY="clang-tidy-10"
+if [[ "$AZURE_PIPELINES_OS" == "Linux" ]]; then
+  echo "Detected Linux CI environment"
+  # TODO(#17): Remove CI-specific warnings as errors.
+  # Clang Tidy is mysteriously emitting the following violation in CI for most
+  # source files the following error:
+  # `error: invalid case style for template parameter 'expr-type'`.
+  # The does not make sense because 'expr-type' is invalid template parameter
+  # syntax and does not reproduce locally (on macOS or Ubuntu). The check will
+  # not be treated as an error for not to unblock development.
+  WARNING_AS_ERRORS="-readability-identifier-naming"
 else
-  echo "clang-tidy not found"
-  exit 1
+  WARNING_AS_ERRORS=""
 fi
 
 function run_clang_tidy {
   echo "Tidying $1"
-  "$CLANG_TIDY" \
+  clang-tidy \
     -p="$WORKSPACE" \
     --checks='' \
+    --warnings-as-errors="$WARNING_AS_ERRORS" \
     --config="$(cat "$WORKSPACE"/.clang-tidy)" \
     "$1"
 }
@@ -26,7 +32,7 @@ echo "Generating compilation database"
 ./toolchain/compilation_database/generate_compilation_database.sh
 
 echo "Building C++ targets"
-# Building all C++ targets before running clang-tidy ensures that
+# Building all C++ targets before running Clang Tidy ensures that
 # $(bazel info execution_root) contains the necessary dependencies.
 bazel build $(bazel query 'kind(cc_.*, //...)')
 

--- a/util/result_test.cc
+++ b/util/result_test.cc
@@ -1,7 +1,6 @@
 #include "util/result.h"
 
-#include <gtest/gtest.h>
-
+#include "gtest/gtest.h"
 #include "util/numeric.h"
 
 namespace {
@@ -118,14 +117,12 @@ TEST(Result, OkLvalue) {  // NOLINT
 
 TEST(Result, OkConstRvalue) {  // NOLINT
   Result<int64, ErrType> result{42};
-  // NOLINTNEXTLINE(performance-move-const-arg)
-  ASSERT_EQ(std::move(result).Ok(), 42);
+  ASSERT_EQ(std::move(result).Ok(), 42);  // NOLINT(performance-move-const-arg)
 }
 
 TEST(Result, OkRvalue) {  // NOLINT
   const Result<int64, ErrType> result{42};
-  // NOLINTNEXTLINE(performance-move-const-arg)
-  ASSERT_EQ(std::move(result).Ok(), 42);
+  ASSERT_EQ(std::move(result).Ok(), 42);  // NOLINT(performance-move-const-arg)
 }
 
 TEST(Result, ErrConstLvalue) {  // NOLINT
@@ -142,14 +139,12 @@ TEST(Result, ErrLvalue) {  // NOLINT
 
 TEST(Result, ErrConstRvalue) {  // NOLINT
   const Result<OkType, int64> result{42};
-  // NOLINTNEXTLINE(performance-move-const-arg)
-  ASSERT_EQ(std::move(result).Err(), 42);
+  ASSERT_EQ(std::move(result).Err(), 42);  // NOLINT(performance-move-const-arg)
 }
 
 TEST(Result, ErrRvalue) {  // NOLINT
   Result<OkType, int64> result{42};
-  // NOLINTNEXTLINE(performance-move-const-arg)
-  ASSERT_EQ(std::move(result).Err(), 42);
+  ASSERT_EQ(std::move(result).Err(), 42);  // NOLINT(performance-move-const-arg)
 }
 
 TEST(Result, OkOrLvalue) {  // NOLINT


### PR DESCRIPTION
* Adds an exception in `clang_tidy.sh` not to treat this warning as an error to unblock development. Clang Tidy mysteriously started incorrectly reporting `readability-identifier-naming` violations for most source files. Bug: #17.
* Upgrades the Linux CI image from Ubuntu 18.04 to Ubuntu 20.04. LLVM 10 is now the default version on Azure Pipeline's 20.04 image (as of September 23, 2020) meaning that we no longer need to install it ourselves, thus shortening CI times for every Linux build.
* Miscellaneous gardening updates.