### PR TITLE
OwnedPtr

### DIFF
--- a/util/memory/BUILD
+++ b/util/memory/BUILD
@@ -1,0 +1,24 @@
+cc_library(
+    name = "memory",
+    hdrs = [
+        "owned_ptr.h",
+        "ptr_owner.h",
+    ],
+    copts = ["-Werror"],
+    visibility = ["//visibility:public"],
+    deps = ["//util:result"],
+)
+
+cc_test(
+    name = "memory_test",
+    size = "small",
+    srcs = ["memory_test.cc"],
+    copts = ["-Werror"],
+    visibility = ["//visibility:private"],
+    deps = [
+        ":memory",
+        "//util:numeric",
+        "//util:result",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/util/memory/memory_test.cc
+++ b/util/memory/memory_test.cc
@@ -1,0 +1,144 @@
+#include <utility>
+
+#include "gtest/gtest.h"
+#include "util/memory/owned_ptr.h"
+#include "util/memory/ptr_owner.h"
+#include "util/numeric.h"
+
+namespace {
+
+class Value;
+
+using PtrOwner = util::memory::PtrOwner<Value>;
+using OwnedPtr = util::memory::OwnedPtr<Value>;
+
+class Value {
+ public:
+  constexpr explicit Value(int32 value);
+  [[nodiscard]] constexpr auto Get() const -> int32;
+
+ private:
+  int32 value_;
+};
+
+class Owner : public PtrOwner {
+ public:
+  constexpr explicit Owner(int32 value);
+  constexpr auto Borrow() -> OwnedPtr;
+  auto Return(OwnedPtr&& owned_ptr) -> PtrOwner::Result override;
+  [[nodiscard]] constexpr auto BorrowedSize() const -> uint32;
+
+ protected:
+  auto Return(Value* value) -> PtrOwner::ReturnRawPtrResult override;
+
+ private:
+  uint32 borrowed_size_;
+  Value value_;
+};
+
+constexpr Value::Value(const int32 value) : value_{value} {}
+
+constexpr auto Value::Get() const -> int32 { return value_; };
+
+constexpr Owner::Owner(const int32 value) : borrowed_size_{0}, value_{value} {}
+
+constexpr auto Owner::Borrow() -> OwnedPtr {
+  ++borrowed_size_;
+  return {&value_, this};
+}
+
+auto Owner::Return(OwnedPtr&& owned_ptr) -> PtrOwner::Result {
+  if (owned_ptr.Owner() != this || owned_ptr.Ptr() != &value_) {
+    return std::move(owned_ptr);
+  }
+  --borrowed_size_;
+  return PtrOwner::Result::Ok({});
+}
+
+constexpr auto Owner::BorrowedSize() const -> uint32 { return borrowed_size_; }
+
+auto Owner::Return(Value* value) -> PtrOwner::ReturnRawPtrResult {
+  if (value != &value_) return PtrOwner::ReturnRawPtrResult::Err({});
+  --borrowed_size_;
+  return PtrOwner::ReturnRawPtrResult::Ok({});
+}
+
+TEST(OwnedPtr, MoveConstructor) {  // NOLINT
+  Owner owner{42};
+  auto owned_ptr = owner.Borrow();
+  const auto* value = owned_ptr.Ptr();
+  ASSERT_NE(value, nullptr);
+  ASSERT_EQ(owned_ptr.Owner(), &owner);
+  OwnedPtr new_owned_ptr{std::move(owned_ptr)};
+  ASSERT_EQ(new_owned_ptr.Ptr(), value);
+  ASSERT_EQ(new_owned_ptr.Owner(), &owner);
+  // NOLINTNEXTLINE(bugprone-use-after-move, clang-analyzer-cplusplus.Move)
+  ASSERT_EQ(owned_ptr.Ptr(), nullptr);
+  // NOLINTNEXTLINE(bugprone-use-after-move, clang-analyzer-cplusplus.Move)
+  ASSERT_EQ(owned_ptr.Owner(), nullptr);
+}
+
+TEST(OwnedPtr, MoveAssignmentOperator) {  // NOLINT
+  Owner owner{42};
+  auto owned_ptr = owner.Borrow();
+  const auto* value = owned_ptr.Ptr();
+  ASSERT_NE(value, nullptr);
+  ASSERT_EQ(owned_ptr.Owner(), &owner);
+  auto new_owned_ptr = std::move(owned_ptr);
+  ASSERT_EQ(new_owned_ptr.Ptr(), value);
+  ASSERT_EQ(new_owned_ptr.Owner(), &owner);
+  // NOLINTNEXTLINE(bugprone-use-after-move, clang-analyzer-cplusplus.Move)
+  ASSERT_EQ(owned_ptr.Ptr(), nullptr);
+  // NOLINTNEXTLINE(bugprone-use-after-move, clang-analyzer-cplusplus.Move)
+  ASSERT_EQ(owned_ptr.Owner(), nullptr);
+}
+
+TEST(OwnedPtr, ManualReturnToPool) {  // NOLINT
+  Owner owner{42};
+  ASSERT_EQ(owner.BorrowedSize(), 0);
+  auto owned_ptr = owner.Borrow();
+  ASSERT_EQ(owner.BorrowedSize(), 1);
+  auto result = owner.Return(std::move(owned_ptr));
+  ASSERT_TRUE(result.IsOk());
+  ASSERT_EQ(owner.BorrowedSize(), 0);
+}
+
+TEST(OwnedPtr, AutomaticReturnToPool) {  // NOLINT
+  Owner owner{42};
+  ASSERT_EQ(owner.BorrowedSize(), 0);
+  {
+    auto owned_ptr = owner.Borrow();
+    ASSERT_EQ(owner.BorrowedSize(), 1);
+  }
+  ASSERT_EQ(owner.BorrowedSize(), 0);
+}
+
+TEST(OwnedPtr, Take) {  // NOLINT
+  Owner owner{42};
+  ASSERT_EQ(owner.BorrowedSize(), 0);
+  auto owned_ptr = owner.Borrow();
+  auto* ptr = owned_ptr.Ptr();
+  ASSERT_NE(ptr, nullptr);
+  ASSERT_EQ(owned_ptr.Owner(), &owner);
+  auto* unowned_ptr = owned_ptr.Take();
+  ASSERT_EQ(owner.BorrowedSize(), 1);
+  ASSERT_EQ(unowned_ptr, ptr);
+  ASSERT_EQ(owned_ptr.Ptr(), nullptr);
+  ASSERT_EQ(owned_ptr.Owner(), nullptr);
+}
+
+TEST(OwnedPtr, DereferenceOperator) {  // NOLINT
+  constexpr int32 value{42};
+  Owner owner{value};
+  auto owned_ptr = owner.Borrow();
+  ASSERT_EQ((*owned_ptr).Get(), value);
+}
+
+TEST(OwnedPtr, ArrowOperator) {  // NOLINT
+  constexpr int32 value{42};
+  Owner owner{value};
+  auto owned_ptr = owner.Borrow();
+  ASSERT_EQ(owned_ptr->Get(), value);
+}
+
+}  // namespace

--- a/util/memory/owned_ptr.h
+++ b/util/memory/owned_ptr.h
@@ -1,0 +1,90 @@
+#pragma once
+
+#include "util/memory/ptr_owner.h"
+#include "util/result.h"
+
+namespace util::memory {
+
+template <class T>
+class OwnedPtr {
+ public:
+  using PtrOwner = PtrOwner<T>;
+
+  OwnedPtr() = delete;
+  constexpr OwnedPtr(T* ptr, PtrOwner* owner);
+  OwnedPtr(const OwnedPtr&) = delete;
+  constexpr OwnedPtr(OwnedPtr&& other) noexcept;
+  auto operator=(const OwnedPtr&) -> OwnedPtr& = delete;
+  constexpr auto operator=(OwnedPtr&& other) noexcept -> OwnedPtr&;
+  constexpr ~OwnedPtr();
+
+  [[nodiscard]] constexpr auto Ptr() const -> T*;
+  [[nodiscard]] constexpr auto Take() -> T*;
+  [[nodiscard]] constexpr auto Owner() const -> PtrOwner*;
+
+  constexpr auto operator*() const ->
+      typename ::std::add_lvalue_reference<T>::type;
+  constexpr auto operator->() const noexcept -> T*;
+
+ private:
+  T* ptr_;
+  PtrOwner* owner_;
+};
+
+template <class T>
+constexpr OwnedPtr<T>::OwnedPtr(T* ptr, PtrOwner* owner)
+    : ptr_{ptr}, owner_{owner} {}
+
+template <class T>
+constexpr OwnedPtr<T>::OwnedPtr(OwnedPtr&& other) noexcept
+    : ptr_{other.ptr_}, owner_{other.owner_} {
+  other.ptr_ = nullptr;
+  other.owner_ = nullptr;
+}
+
+template <class T>
+constexpr auto OwnedPtr<T>::operator=(OwnedPtr&& other) noexcept -> OwnedPtr& {
+  ptr_ = other.ptr_;
+  owner_ = other.owner_;
+  other.ptr_ = nullptr;
+  other.owner_ = nullptr;
+}
+
+template <class T>
+constexpr OwnedPtr<T>::~OwnedPtr() {
+  if (owner_ != nullptr) {
+    auto owner = owner_;
+    owner->Return(Take());
+  }
+}
+
+template <class T>
+constexpr auto OwnedPtr<T>::Ptr() const -> T* {
+  return ptr_;
+}
+
+template <class T>
+constexpr auto OwnedPtr<T>::Take() -> T* {
+  auto ptr = ptr_;
+  ptr_ = nullptr;
+  owner_ = nullptr;
+  return ptr;
+}
+
+template <class T>
+constexpr auto OwnedPtr<T>::Owner() const -> PtrOwner* {
+  return owner_;
+}
+
+template <class T>
+constexpr auto OwnedPtr<T>::operator*() const ->
+    typename std::add_lvalue_reference<T>::type {
+  return *ptr_;
+}
+
+template <class T>
+constexpr auto OwnedPtr<T>::operator->() const noexcept -> T* {
+  return ptr_;
+}
+
+}  // namespace util::memory

--- a/util/memory/ptr_owner.h
+++ b/util/memory/ptr_owner.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "util/result.h"
+
+namespace util::memory {
+
+template <class T>
+class OwnedPtr;
+
+template <class T>
+class PtrOwner {
+ public:
+  using Result = util::result::Result<util::result::None, OwnedPtr<T>>;
+
+  constexpr PtrOwner() = default;
+  constexpr PtrOwner(const PtrOwner&) = default;
+  PtrOwner(PtrOwner&&) noexcept = delete;
+  constexpr auto operator=(const PtrOwner&) -> PtrOwner& = default;
+  auto operator=(PtrOwner&&) noexcept -> PtrOwner& = delete;
+  virtual ~PtrOwner() = default;
+
+  virtual auto Return(OwnedPtr<T>&& ptr) -> Result = 0;
+
+ protected:
+  friend class OwnedPtr<T>;
+
+  using ReturnRawPtrResult =
+      util::result::Result<util::result::None, util::result::None>;
+
+  virtual auto Return(T* t) -> ReturnRawPtrResult = 0;
+};
+
+}  // namespace util::memory


### PR DESCRIPTION
Adds two data structures for memory management: `OwnedPtr` and `PtrOwner`.

`OwnedPtr` is an RAII wrapper around a pointer (similar to `unique_ptr` and `shared_ptr`) that returns the pointer to its `PtrOwner` on destruction. These will be used extensively for our buffer pool system. See the tests for example usage in the meantime.

This class is intended to improve the memory safety of the program but isn't bulletproof. The discussion I'm interested to have is if we think the benefits and added safety, while not perfect, outweigh the drawbacks (I think so).

Some caveats:
* If `PtrOwner` is moved or copied, then the ownership model breaks down. We could look into restricting `PtrOwner` to be non-movable and non-copyable, but that sacrifices a considerable amount of flexibility.
* The implementer is responsible for making sure that the return operation is cheap. It is easy to overlook that `Return` is called in the destructor and might be an expensive operation (e.g. do thread synchronization) which is bad practice.
* Some `PtrOwner` implementations might not be able to determine if they own the pointer being returned (e.g. if they decide not to keep a table of "borrowed" pointers as a memory optimization).
* An `OwnedPtr` can be constructed outside a `PtrOwner`. One of my original ideas was to make the `OwnedPtr` constructors private and make `PtrOwner` a friend class. This guarantees that an `OwnedPtr` can only be constructed inside a `PtrOwner`, however, does not allow us to store `OwnedPtrs` inside STL types (e.g. `std::vector`, etc.) so didn't go through with the idea.