### PR TITLE
Private member variable Clang Tidy config

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -112,10 +112,12 @@ CheckOptions:
     value: k
   - key: readability-identifier-naming.IgnoreMainLikeFunctions
     value: 1
-  - key: readability-identifier-naming.MemberSuffix
-    value: _
   - key: readability-identifier-naming.NamespaceCase
     value: lower_case
+  # Structs have public member variables. Classes should only have private
+  # member variables.
+  - key: readability-identifier-naming.PrivateMemberSuffix
+    value: _
   - key: readability-identifier-naming.StructCase
     value: CamelCase
   - key: readability-identifier-naming.TemplateParameterCase


### PR DESCRIPTION
Following the Style Guide's rules on [structs vs classes](https://google.github.io/styleguide/cppguide.html#Structs_vs._Classes) and [variable naming](https://google.github.io/styleguide/cppguide.html#Variable_Names), class data members should have a `_` suffix but struct data members should not. However, Clang Tidy cannot distinguish between class and struct member variables. Since classes should not contain public member variables, we can use Clang Tidy's `PrivateMemberSuffix` to implement the rule.