### PR TITLE
Upgrade to LLVM 11

### DIFF
--- a/.build/azure-pipelines.yml
+++ b/.build/azure-pipelines.yml
@@ -32,7 +32,7 @@ jobs:
     vmImage: 'ubuntu-20.04'
   steps:
   - template: ./templates/install-common.yml
-  - script: sudo apt-get install clang-format clang-tidy
+  - script: sudo apt-get install clang-format-11 clang-tidy-11
     displayName: Install Clang Format and Clang Tidy
   - script: |
       ./toolchain/style/clang_format.sh

--- a/.build/templates/install-common.yml
+++ b/.build/templates/install-common.yml
@@ -1,3 +1,14 @@
 steps:
+- script: |
+    wget https://apt.llvm.org/llvm.sh
+    chmod +x llvm.sh
+    sudo ./llvm.sh 11
+  displayName: Install LLVM (Linux)
+  condition: eq(variables['Agent.OS'], 'Linux')
+- script: |
+    brew update
+    brew upgrade --force llvm@11
+  displayName: Install LLVM (macOS)
+  condition: eq(variables['Agent.OS'], 'Darwin')
 - script: cp ./.build/ci.bazelrc ./.bazelrc
   displayName: Copy .bazelrc

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -12,6 +12,10 @@
 #   The check does not support configuration from the project root.
 # llvm-include-order
 #   Enforced by Clang Format.
+# llvmlibc-callee-namespace
+# llvmlibc-implementation-in-namespace
+# llvmlibc-restrict-system-libc-headers
+#   Not useful when developing outside LLVM libc.
 # readability-magic-numbers
 #   These warnings are generally unhelpful because the "magic numbers" are
 #   self-explanatory in the context of the code.
@@ -26,6 +30,9 @@ Checks: '
   -fuchsia-trailing-return,
   -llvm-header-guard,
   -llvm-include-order,
+  -llvmlibc-callee-namespace,
+  -llvmlibc-implementation-in-namespace,
+  -llvmlibc-restrict-system-libc-headers,
   -readability-magic-numbers,
 
   -cert-con36-c,

--- a/toolchain/crosstool/cc_toolchain_config.bzl
+++ b/toolchain/crosstool/cc_toolchain_config.bzl
@@ -59,44 +59,45 @@ def linux_llvm_toolchain_impl(ctx):
     tool_paths = [
         tool_path(
             name = "gcc",
-            path = "/usr/bin/clang-10",
+            path = "/usr/bin/clang-11",
         ),
         tool_path(
             name = "ld",
-            path = "/usr/bin/lld-10",
+            path = "/usr/bin/lld-11",
         ),
         tool_path(
             name = "ar",
-            path = "/usr/bin/llvm-ar-10",
+            path = "/usr/bin/llvm-ar-11",
         ),
         tool_path(
             name = "cpp",
-            path = "/usr/bin/clang++-10",
+            path = "/usr/bin/clang++-11",
         ),
         tool_path(
             name = "gcov",
-            path = "/usr/bin/llvm-cov-10",
+            path = "/usr/bin/llvm-cov-11",
         ),
         tool_path(
             name = "nm",
-            path = "/usr/bin/llvm-nm-10",
+            path = "/usr/bin/llvm-nm-11",
         ),
         tool_path(
             name = "objdump",
-            path = "/usr/bin/llvm-objdump-10",
+            path = "/usr/bin/llvm-objdump-11",
         ),
         tool_path(
             name = "strip",
-            path = "/usr/bin/llvm-strip-10",
+            path = "/usr/bin/llvm-strip-11",
         ),
     ]
     return cc_common.create_cc_toolchain_config_info(
         ctx = ctx,
         features = FEATURES,
         cxx_builtin_include_directories = [
-            "/usr/lib/llvm-10/lib/clang/10.0.0/include",
-            "/usr/lib/llvm-10/lib/clang/10.0.0/share",
             "/usr/include",
+            "/usr/lib/llvm-11/include/llvm",
+            "/usr/lib/llvm-11/lib/clang/11.0.0/include",
+            "/usr/lib/llvm-11/lib/clang/11.0.0/share",
         ],
         toolchain_identifier = "linux-llvm-toolchain",
         host_system_name = "local",
@@ -150,8 +151,9 @@ def darwin_llvm_toolchain_impl(ctx):
         features = FEATURES,
         cxx_builtin_include_directories = [
             "/usr/local/opt/llvm/include/c++/v1",
-            "/usr/local/Cellar/llvm/10.0.1_1/lib/clang/10.0.1/include",
-            "/usr/local/Cellar/llvm/10.0.1_1/lib/clang/10.0.1/share",
+            "/usr/local/Cellar/llvm/11.0.0/include/",
+            "/usr/local/Cellar/llvm/11.0.0/lib/clang/11.0.0/include",
+            "/usr/local/Cellar/llvm/11.0.0/lib/clang/11.0.0/share",
             "/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk/usr/include",
             "/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk/System/Library/Frameworks",
         ],

--- a/toolchain/style/clang_format.sh
+++ b/toolchain/style/clang_format.sh
@@ -4,6 +4,15 @@ set -eu
 
 WORKSPACE="$(bazel info workspace)"
 
+if command -v clang-format &> /dev/null; then
+  CLANG_TIDY="clang-format"
+elif command -v clang-format-11 &> /dev/null; then
+  CLANG_TIDY="clang-format-11"
+else
+  echo "clang-format not found"
+  exit 1
+fi
+
 function run_clang_format {
   echo "Formatting $1"
   clang-format \


### PR DESCRIPTION
Upgrade to LLVM 11. This allows us to compile LLVM dependencies using C++20 and supports changes to IR debug properties adopted by recent Swift versions.