### PR TITLE
Circular slice buffer benchmark

### DIFF
--- a/.build/azure-pipelines.yml
+++ b/.build/azure-pipelines.yml
@@ -14,6 +14,8 @@ jobs:
     displayName: Build
   - script: bazel test //...
     displayName: Test
+  - script: ./toolchain/benchmark/run_benchmarks.sh
+    displayName: Benchmark
   - script: ./toolchain/compilation_database/generate_compilation_database.sh
     displayName: Generate compilation database
 - job: sanitizers

--- a/.build/ci.bazelrc
+++ b/.build/ci.bazelrc
@@ -25,3 +25,7 @@ build:ubsan --copt -g
 build:ubsan --copt -fno-omit-frame-pointer
 build:ubsan --linkopt -fsanitize=undefined
 build:ubsan --linkopt -lubsan
+
+build:benchmark --compilation_mode opt
+build:benchmark --copt -fno-omit-frame-pointer
+build:benchmark --copt -DNDEBUG

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -40,6 +40,13 @@ git_repository(
 )
 
 git_repository(
+    name = "com_google_benchmark",
+    commit = "73d4d5e8d6d449fc8663765a42aa8aeeee844489",  # v1.5.2
+    remote = "https://github.com/google/benchmark.git",
+    shallow_since = "1599818118 +0100",
+)
+
+git_repository(
     name = "com_bazelbuild_bazel",
     commit = "7cfe416c5b702967b63cb2d9e2a2a2aefb8d2cac",  # v3.4.1
     remote = "https://github.com/bazelbuild/bazel.git",

--- a/spoor/runtime/buffer/BUILD
+++ b/spoor/runtime/buffer/BUILD
@@ -1,4 +1,4 @@
-load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
 
 cc_library(
     name = "buffer",
@@ -119,5 +119,18 @@ cc_test(
         ":buffer",
         "//util:numeric",
         "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_binary(
+    name = "circular_slice_buffer_benchmark",
+    srcs = ["circular_slice_buffer_benchmark.cc"],
+    copts = ["-Werror"],
+    visibility = ["//visibility:private"],
+    deps = [
+        ":buffer",
+        "//util:numeric",
+        "@com_google_benchmark//:benchmark",
+        "@com_microsoft_gsl//:gsl",
     ],
 )

--- a/spoor/runtime/buffer/circular_slice_buffer_benchmark.cc
+++ b/spoor/runtime/buffer/circular_slice_buffer_benchmark.cc
@@ -1,0 +1,96 @@
+#include <limits>
+
+#include "benchmark/benchmark.h"
+#include "gsl/gsl"
+#include "spoor/runtime/buffer/circular_slice_buffer.h"
+#include "spoor/runtime/buffer/combined_buffer_slice_pool.h"
+#include "util/numeric.h"
+
+namespace {
+
+using Pool = spoor::runtime::buffer::CombinedBufferSlicePool<int8>;
+using ValueType = Pool::ValueType;
+using SizeType = Pool::SizeType;
+using CircularSliceBuffer =
+    spoor::runtime::buffer::CircularSliceBuffer<ValueType>;
+
+auto CustomArguments(benchmark::internal::Benchmark* benchmark) -> void {
+  for (SizeType circular_buffer_slice_capacity{8};
+       circular_buffer_slice_capacity <= (8ULL << 15ULL);
+       circular_buffer_slice_capacity *= 8) {
+    for (SizeType max_slice_capacity{circular_buffer_slice_capacity / 4};
+         max_slice_capacity <= circular_buffer_slice_capacity;
+         max_slice_capacity += circular_buffer_slice_capacity / 4) {
+      for (SizeType dynamic_pool_capacity{0};
+           dynamic_pool_capacity <= circular_buffer_slice_capacity;
+           dynamic_pool_capacity += circular_buffer_slice_capacity / 2) {
+        const auto reserved_pool_capacity =
+            circular_buffer_slice_capacity - dynamic_pool_capacity;
+        benchmark->Args(
+            {gsl::narrow_cast<int64>(circular_buffer_slice_capacity),
+             gsl::narrow_cast<int64>(max_slice_capacity),
+             gsl::narrow_cast<int64>(reserved_pool_capacity),
+             gsl::narrow_cast<int64>(dynamic_pool_capacity)});
+      }
+    }
+  }
+}
+
+// NOLINTNEXTLINE(google-runtime-references)
+auto BenchmarkCircularSliceBufferPush(benchmark::State& state) -> void {
+  const SizeType capacity{4096};
+  const auto dynamic_pool_capacity = static_cast<SizeType>(state.range(0));
+  const auto max_slice_capacity = static_cast<SizeType>(state.range(1));
+  const typename Pool::Options pool_options{
+      .reserved_pool_options = {.max_slice_capacity = max_slice_capacity,
+                                .capacity = capacity - dynamic_pool_capacity},
+      .dynamic_pool_options = {.max_slice_capacity = max_slice_capacity,
+                               .capacity = dynamic_pool_capacity,
+                               .borrow_cas_attempts =
+                                   std::numeric_limits<SizeType>::max()},
+  };
+  Pool pool{pool_options};
+  const typename CircularSliceBuffer::Options circular_slice_buffer_options{
+      .buffer_slice_pool = &pool,
+      .capacity = capacity,
+  };
+  CircularSliceBuffer circular_slice_buffer{circular_slice_buffer_options};
+  for (auto _ : state) {  // NOLINT(clang-analyzer-deadcode.DeadStores)
+    circular_slice_buffer.Push(42);
+  }
+}
+BENCHMARK(BenchmarkCircularSliceBufferPush)  // NOLINT
+    ->ArgsProduct({{0, 2048, 4096}, {8, 512, 1024}});
+
+// NOLINTNEXTLINE(google-runtime-references)
+auto BenchmarkCircularSliceBufferCreateFillClear(benchmark::State& state)
+    -> void {
+  const typename Pool::Options pool_options{
+      .reserved_pool_options = {.max_slice_capacity =
+                                    static_cast<SizeType>(state.range(1)),
+                                .capacity =
+                                    static_cast<SizeType>(state.range(2))},
+      .dynamic_pool_options =
+          {.max_slice_capacity = static_cast<SizeType>(state.range(1)),
+           .capacity = static_cast<SizeType>(state.range(3)),
+           .borrow_cas_attempts = std::numeric_limits<SizeType>::max()},
+  };
+  Pool pool{pool_options};
+  const typename CircularSliceBuffer::Options circular_slice_buffer_options{
+      .buffer_slice_pool = &pool,
+      .capacity = gsl::narrow_cast<SizeType>(state.range(0)),
+  };
+  for (auto _ : state) {  // NOLINT(clang-analyzer-deadcode.DeadStores)
+    CircularSliceBuffer circular_slice_buffer{circular_slice_buffer_options};
+    for (SizeType i{0}; i < circular_slice_buffer_options.capacity; ++i) {
+      circular_slice_buffer.Push(42);
+    }
+    circular_slice_buffer.Clear();
+  }
+}
+BENCHMARK(BenchmarkCircularSliceBufferCreateFillClear)  // NOLINT
+    ->Apply(CustomArguments);
+
+}  // namespace
+
+BENCHMARK_MAIN();  // NOLINT

--- a/toolchain/benchmark/run_benchmarks.sh
+++ b/toolchain/benchmark/run_benchmarks.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -eu
+
+bazel query 'kind(cc_binary, //...) intersect attr(name, ".*_benchmark", //...)' |
+  xargs bazel run --config=benchmark


### PR DESCRIPTION
Benchmarks for the circular slice buffer.

We don't have any quantifiable performance goals (yet) for the circular buffer but these benchmarks will give us a starting point when we do.

Running the benchmarks in CI ensures that they compile and run, and gives us another set of "unit tests". The benchmark results produced in CI are not meaningful because they're run in a shared environment and therefore should not be used for to test performance regressions.

Sample output on my Mac. Note that we'll need to benchmark on a physical device to get meaningful results for a mobile use case.
```
CPU Caches:
  L1 Data 32 KiB (x6)
  L1 Instruction 32 KiB (x6)
  L2 Unified 256 KiB (x6)
  L3 Unified 9216 KiB (x1)
Load Average: 2.79, 1.87, 1.85
------------------------------------------------------------------------------------------------------------------
Benchmark                                                                        Time             CPU   Iterations
------------------------------------------------------------------------------------------------------------------
BenchmarkCircularSliceBufferPush/0/8                                           133 ns          133 ns      5090465
BenchmarkCircularSliceBufferPush/2048/8                                        130 ns          130 ns      5355777
BenchmarkCircularSliceBufferPush/4096/8                                        125 ns          125 ns      5593780
BenchmarkCircularSliceBufferPush/0/512                                         128 ns          127 ns      5491100
BenchmarkCircularSliceBufferPush/2048/512                                      130 ns          128 ns      5629001
BenchmarkCircularSliceBufferPush/4096/512                                      121 ns          121 ns      5710603
BenchmarkCircularSliceBufferPush/0/1024                                        128 ns          128 ns      5483401
BenchmarkCircularSliceBufferPush/2048/1024                                     124 ns          124 ns      5634347
BenchmarkCircularSliceBufferPush/4096/1024                                     121 ns          120 ns      5745475
BenchmarkCircularSliceBufferCreateFillClear/8/2/8/0                           4846 ns         4841 ns       145417
BenchmarkCircularSliceBufferCreateFillClear/8/2/4/4                           6198 ns         6189 ns       113614
BenchmarkCircularSliceBufferCreateFillClear/8/2/0/8                           7147 ns         7138 ns       100314
BenchmarkCircularSliceBufferCreateFillClear/8/4/8/0                           3045 ns         3041 ns       231091
BenchmarkCircularSliceBufferCreateFillClear/8/4/4/4                           3768 ns         3764 ns       186942
BenchmarkCircularSliceBufferCreateFillClear/8/4/0/8                           4186 ns         4182 ns       156586
BenchmarkCircularSliceBufferCreateFillClear/8/6/8/0                           3025 ns         3023 ns       230841
BenchmarkCircularSliceBufferCreateFillClear/8/6/4/4                           3708 ns         3706 ns       188913
BenchmarkCircularSliceBufferCreateFillClear/8/6/0/8                           4191 ns         4186 ns       167098
BenchmarkCircularSliceBufferCreateFillClear/8/8/8/0                           2034 ns         2030 ns       345292
BenchmarkCircularSliceBufferCreateFillClear/8/8/4/4                           3770 ns         3764 ns       185169
BenchmarkCircularSliceBufferCreateFillClear/8/8/0/8                           2644 ns         2640 ns       265941
BenchmarkCircularSliceBufferCreateFillClear/64/16/64/0                       11862 ns        11856 ns        58444
BenchmarkCircularSliceBufferCreateFillClear/64/16/32/32                      13486 ns        13478 ns        52111
BenchmarkCircularSliceBufferCreateFillClear/64/16/0/64                       14317 ns        14309 ns        48249
BenchmarkCircularSliceBufferCreateFillClear/64/32/64/0                        9961 ns         9955 ns        69495
BenchmarkCircularSliceBufferCreateFillClear/64/32/32/32                      11295 ns        11277 ns        63049
BenchmarkCircularSliceBufferCreateFillClear/64/32/0/64                       11701 ns        11688 ns        59769
BenchmarkCircularSliceBufferCreateFillClear/64/48/64/0                       10171 ns        10152 ns        69432
BenchmarkCircularSliceBufferCreateFillClear/64/48/32/32                      11251 ns        11230 ns        62316
BenchmarkCircularSliceBufferCreateFillClear/64/48/0/64                       11692 ns        11673 ns        60130
BenchmarkCircularSliceBufferCreateFillClear/64/64/64/0                        9117 ns         9093 ns        75936
BenchmarkCircularSliceBufferCreateFillClear/64/64/32/32                      11362 ns        11314 ns        60146
BenchmarkCircularSliceBufferCreateFillClear/64/64/0/64                       10156 ns        10111 ns        70003
BenchmarkCircularSliceBufferCreateFillClear/512/128/512/0                    68766 ns        68678 ns        10126
BenchmarkCircularSliceBufferCreateFillClear/512/128/256/256                  69882 ns        69853 ns         9928
BenchmarkCircularSliceBufferCreateFillClear/512/128/0/512                    72409 ns        72382 ns         9627
BenchmarkCircularSliceBufferCreateFillClear/512/256/512/0                    67200 ns        67009 ns        10577
BenchmarkCircularSliceBufferCreateFillClear/512/256/256/256                  68849 ns        68726 ns        10059
BenchmarkCircularSliceBufferCreateFillClear/512/256/0/512                    70633 ns        70546 ns         9944
BenchmarkCircularSliceBufferCreateFillClear/512/384/512/0                    66483 ns        66416 ns        10483
BenchmarkCircularSliceBufferCreateFillClear/512/384/256/256                  67425 ns        67404 ns        10129
BenchmarkCircularSliceBufferCreateFillClear/512/384/0/512                    69667 ns        69601 ns        10113
BenchmarkCircularSliceBufferCreateFillClear/512/512/512/0                    64788 ns        64692 ns        10914
BenchmarkCircularSliceBufferCreateFillClear/512/512/256/256                  67738 ns        67682 ns        10423
BenchmarkCircularSliceBufferCreateFillClear/512/512/0/512                    70729 ns        70626 ns        10165
BenchmarkCircularSliceBufferCreateFillClear/4096/1024/4096/0                509180 ns       508725 ns         1371
BenchmarkCircularSliceBufferCreateFillClear/4096/1024/2048/2048             533813 ns       533157 ns         1322
BenchmarkCircularSliceBufferCreateFillClear/4096/1024/0/4096                546047 ns       545376 ns         1287
BenchmarkCircularSliceBufferCreateFillClear/4096/2048/4096/0                515531 ns       514907 ns         1360
BenchmarkCircularSliceBufferCreateFillClear/4096/2048/2048/2048             549448 ns       548816 ns         1325
BenchmarkCircularSliceBufferCreateFillClear/4096/2048/0/4096                532752 ns       532456 ns         1299
BenchmarkCircularSliceBufferCreateFillClear/4096/3072/4096/0                504557 ns       504345 ns         1387
BenchmarkCircularSliceBufferCreateFillClear/4096/3072/2048/2048             519603 ns       519199 ns         1346
BenchmarkCircularSliceBufferCreateFillClear/4096/3072/0/4096                535564 ns       535456 ns         1328
BenchmarkCircularSliceBufferCreateFillClear/4096/4096/4096/0                508123 ns       507942 ns         1373
BenchmarkCircularSliceBufferCreateFillClear/4096/4096/2048/2048             517994 ns       517906 ns         1336
BenchmarkCircularSliceBufferCreateFillClear/4096/4096/0/4096                530486 ns       530069 ns         1318
BenchmarkCircularSliceBufferCreateFillClear/32768/8192/32768/0             4146198 ns      4141598 ns          174
BenchmarkCircularSliceBufferCreateFillClear/32768/8192/16384/16384         4144747 ns      4143036 ns          168
BenchmarkCircularSliceBufferCreateFillClear/32768/8192/0/32768             4279894 ns      4276636 ns          165
BenchmarkCircularSliceBufferCreateFillClear/32768/16384/32768/0            4069807 ns      4066977 ns          171
BenchmarkCircularSliceBufferCreateFillClear/32768/16384/16384/16384        4188741 ns      4180309 ns          165
BenchmarkCircularSliceBufferCreateFillClear/32768/16384/0/32768            4296963 ns      4289817 ns          164
BenchmarkCircularSliceBufferCreateFillClear/32768/24576/32768/0            4095854 ns      4093259 ns          174
BenchmarkCircularSliceBufferCreateFillClear/32768/24576/16384/16384        4186710 ns      4182952 ns          168
BenchmarkCircularSliceBufferCreateFillClear/32768/24576/0/32768            4239127 ns      4238006 ns          166
BenchmarkCircularSliceBufferCreateFillClear/32768/32768/32768/0            4223377 ns      4213459 ns          170
BenchmarkCircularSliceBufferCreateFillClear/32768/32768/16384/16384        4136514 ns      4132912 ns          170
BenchmarkCircularSliceBufferCreateFillClear/32768/32768/0/32768            4235754 ns      4233169 ns          166
BenchmarkCircularSliceBufferCreateFillClear/262144/65536/262144/0         32188118 ns     32176545 ns           22
BenchmarkCircularSliceBufferCreateFillClear/262144/65536/131072/131072    32919018 ns     32902381 ns           21
BenchmarkCircularSliceBufferCreateFillClear/262144/65536/0/262144         34199294 ns     34172905 ns           21
BenchmarkCircularSliceBufferCreateFillClear/262144/131072/262144/0        32979813 ns     32904524 ns           21
BenchmarkCircularSliceBufferCreateFillClear/262144/131072/131072/131072   33751883 ns     33646095 ns           21
BenchmarkCircularSliceBufferCreateFillClear/262144/131072/0/262144        34382753 ns     34290600 ns           20
BenchmarkCircularSliceBufferCreateFillClear/262144/196608/262144/0        32136932 ns     32125227 ns           22
BenchmarkCircularSliceBufferCreateFillClear/262144/196608/131072/131072   32971836 ns     32961000 ns           21
BenchmarkCircularSliceBufferCreateFillClear/262144/196608/0/262144        33877031 ns     33855762 ns           21
BenchmarkCircularSliceBufferCreateFillClear/262144/262144/262144/0        33562435 ns     33554000 ns           22
BenchmarkCircularSliceBufferCreateFillClear/262144/262144/131072/131072   32947589 ns     32939381 ns           21
BenchmarkCircularSliceBufferCreateFillClear/262144/262144/0/262144        34664085 ns     34541800 ns           20
```