### PR TITLE
Flush queue

### DIFF
--- a/spoor/runtime/flush_queue/BUILD
+++ b/spoor/runtime/flush_queue/BUILD
@@ -1,0 +1,50 @@
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+
+cc_library(
+    name = "flush_queue",
+    srcs = ["disk_flush_queue.cc"],
+    hdrs = [
+        "disk_flush_queue.h",
+        "flush_queue.h",
+    ],
+    copts = ["-Werror"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//spoor/runtime/buffer",
+        "//spoor/runtime/trace",
+        "//util:numeric",
+        "//util/time:clock",
+        "@com_google_absl//absl/strings:str_format",
+        "@com_microsoft_gsl//:gsl",
+    ],
+)
+
+cc_test(
+    name = "disk_flush_queue_test",
+    size = "small",
+    srcs = ["disk_flush_queue_test.cc"],
+    copts = ["-Werror"],
+    visibility = ["//visibility:private"],
+    deps = [
+        ":flush_queue",
+        "//spoor/runtime/buffer",
+        "//spoor/runtime/trace",
+        "//spoor/runtime/trace:trace_writer_mock",
+        "//util:numeric",
+        "//util/time:clock_mock",
+        "@com_google_absl//absl/strings:str_format",
+        "@com_google_googletest//:gtest_main",
+        "@com_microsoft_gsl//:gsl",
+    ],
+)
+
+cc_library(
+    name = "flush_queue_mock",
+    hdrs = ["flush_queue_mock.h"],
+    copts = ["-Werror"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":flush_queue",
+        "@com_google_googletest//:gtest",
+    ],
+)

--- a/spoor/runtime/flush_queue/disk_flush_queue.cc
+++ b/spoor/runtime/flush_queue/disk_flush_queue.cc
@@ -1,0 +1,180 @@
+#include "spoor/runtime/flush_queue/disk_flush_queue.h"
+
+#include <chrono>
+#include <filesystem>
+#include <functional>
+#include <mutex>
+#include <queue>
+#include <shared_mutex>
+#include <thread>
+
+#include "absl/strings/str_format.h"
+#include "gsl/gsl"
+#include "spoor/runtime/trace/trace.h"
+
+namespace spoor::runtime::flush_queue {
+
+using std::literals::chrono_literals::operator""ns;
+
+DiskFlushQueue::DiskFlushQueue(Options options)
+    : options_{std::move(options)},
+      flush_timestamp_{std::chrono::time_point<std::chrono::steady_clock>{0ns}},
+      next_flush_info_id_{0},
+      queue_size_{0},
+      running_{false},
+      draining_{false} {}
+
+DiskFlushQueue::~DiskFlushQueue() { DrainAndStop(); }
+
+auto DiskFlushQueue::Run() -> void {
+  if (running_.exchange(true)) return;
+  draining_ = false;
+  flush_thread_ = std::thread{[&] {
+    while (!draining_ || !Empty()) {
+      auto flush_info_optional = [&]() -> std::optional<FlushInfo> {
+        std::unique_lock lock{lock_};
+        if (queue_.empty()) return {};
+        auto flush_info = std::move(queue_.front());
+        queue_.pop_front();
+        return flush_info;
+      }();
+      if (!flush_info_optional.has_value()) {
+        std::this_thread::yield();
+        continue;
+      };
+      auto flush_info = std::move(flush_info_optional.value());
+      const bool retain{options_.steady_clock->Now() <
+                        flush_info.flush_timestamp +
+                            options_.buffer_retention_duration};
+      if (!options_.flush_all_events && !retain) {
+        std::unique_lock lock{lock_};
+        manual_flush_record_ids_.erase(flush_info.id);
+        --queue_size_;
+        continue;
+      }
+      const auto flush = [&] {
+        if (options_.flush_all_events) return true;
+        std::shared_lock lock{lock_};
+        return flush_info.flush_timestamp <= flush_timestamp_;
+      }();
+      if (!flush) {
+        std::unique_lock lock{lock_};
+        queue_.emplace_back(std::move(flush_info));
+        continue;
+      }
+      const auto result = options_.trace_writer->Write(
+          TraceFilePath(flush_info), TraceFileHeader(flush_info),
+          &flush_info.buffer, trace::Footer{});
+      --flush_info.remaining_flush_attempts;
+      if (result.IsErr() && 0 < flush_info.remaining_flush_attempts) {
+        std::unique_lock lock{lock_};
+        queue_.emplace_back(std::move(flush_info));
+      } else {
+        std::unique_lock lock{lock_};
+        manual_flush_record_ids_.erase(flush_info.id);
+        --queue_size_;
+      }
+      std::optional<std::function<void()>> flush_completion{};
+      {
+        std::unique_lock lock{lock_};
+        if (manual_flush_record_ids_.empty()) {
+          flush_completion_.swap(flush_completion);
+        }
+      }
+      if (flush_completion.has_value()) {
+        std::thread{[completion{std::move(flush_completion.value())}] {
+          completion();
+        }}.detach();
+      }
+    }
+    draining_ = false;
+    running_ = false;
+  }};
+}
+
+auto DiskFlushQueue::DrainAndStop() -> void {
+  if (!running_ || draining_.exchange(true)) return;
+  if (flush_thread_.joinable()) flush_thread_.join();
+}
+
+auto DiskFlushQueue::Enqueue(Buffer&& buffer) -> void {
+  const auto flush_timestamp = options_.steady_clock->Now();
+  if (!running_ || draining_) return;
+  const auto thread_id = static_cast<trace::ThreadId>(
+      std::hash<std::thread::id>{}(std::this_thread::get_id()));
+  std::unique_lock lock{lock_};
+  const auto id = next_flush_info_id_;
+  ++next_flush_info_id_;
+  FlushInfo flush_info{
+      .buffer = std::move(buffer),
+      .flush_timestamp = flush_timestamp,
+      .thread_id = thread_id,
+      .id = id,
+      .remaining_flush_attempts = options_.max_buffer_flush_attempts};
+  queue_.emplace_back(std::move(flush_info));
+  ++queue_size_;
+}
+
+auto DiskFlushQueue::Flush(std::function<void()> completion) -> void {
+  const auto now = options_.steady_clock->Now();
+  std::unique_lock lock{lock_};
+  flush_timestamp_ = now;
+  if (completion != nullptr) {
+    flush_completion_ = completion;
+    for (const auto& record : queue_) {
+      if (record.flush_timestamp <= now) {
+        manual_flush_record_ids_.emplace(record.id);
+      }
+    }
+  }
+}
+
+auto DiskFlushQueue::Clear() -> void {
+  std::deque<FlushInfo> empty{};
+  std::unique_lock lock{lock_};
+  std::swap(queue_, empty);
+  manual_flush_record_ids_.clear();
+  queue_size_ = 0;
+}
+
+auto DiskFlushQueue::Size() const -> DiskFlushQueue::SizeType {
+  return queue_size_;
+}
+
+auto DiskFlushQueue::Empty() const -> bool { return queue_size_ == 0; }
+
+auto DiskFlushQueue::TraceFilePath(const FlushInfo& flush_info) const
+    -> std::filesystem::path {
+  const auto timestamp = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                             flush_info.flush_timestamp.time_since_epoch())
+                             .count();
+  const auto file_name =
+      absl::StrFormat("%016x-%016x-%016x.spoor", options_.session_id,
+                      flush_info.thread_id, timestamp);
+  return options_.trace_file_path / file_name;
+}
+
+auto DiskFlushQueue::TraceFileHeader(const FlushInfo& flush_info) const
+    -> trace::Header {
+  const auto system_clock_now = options_.system_clock->Now();
+  const auto steady_clock_now = options_.steady_clock->Now();
+  const auto system_clock_timestamp =
+      std::chrono::duration_cast<std::chrono::nanoseconds>(
+          system_clock_now.time_since_epoch())
+          .count();
+  const auto steady_clock_timestamp =
+      std::chrono::duration_cast<std::chrono::nanoseconds>(
+          steady_clock_now.time_since_epoch())
+          .count();
+  const auto event_count =
+      gsl::narrow_cast<trace::EventCount>(flush_info.buffer.Size());
+  return trace::Header{.version = trace::kTraceFileVersion,
+                       .session_id = options_.session_id,
+                       .process_id = options_.process_id,
+                       .thread_id = flush_info.thread_id,
+                       .system_clock_timestamp = system_clock_timestamp,
+                       .steady_clock_timestamp = steady_clock_timestamp,
+                       .event_count = event_count};
+}
+
+}  // namespace spoor::runtime::flush_queue

--- a/spoor/runtime/flush_queue/disk_flush_queue.h
+++ b/spoor/runtime/flush_queue/disk_flush_queue.h
@@ -1,0 +1,88 @@
+#pragma once
+
+#include <atomic>
+#include <chrono>
+#include <cstddef>
+#include <deque>
+#include <filesystem>
+#include <mutex>
+#include <optional>
+#include <shared_mutex>
+#include <thread>
+#include <unordered_set>
+
+#include "spoor/runtime/buffer/circular_slice_buffer.h"
+#include "spoor/runtime/flush_queue/flush_queue.h"
+#include "spoor/runtime/trace/trace.h"
+#include "spoor/runtime/trace/trace_writer.h"
+#include "util/numeric.h"
+#include "util/time/clock.h"
+
+namespace spoor::runtime::flush_queue {
+
+class DiskFlushQueue final
+    : public FlushQueue<buffer::CircularSliceBuffer<trace::Event>> {
+ public:
+  using Buffer = buffer::CircularSliceBuffer<trace::Event>;
+  using SizeType = Buffer::SizeType;
+
+  struct Options {
+    std::filesystem::path trace_file_path;
+    std::chrono::nanoseconds buffer_retention_duration;
+    util::time::SystemClock* system_clock;
+    util::time::SteadyClock* steady_clock;
+    trace::TraceWriter* trace_writer;
+    trace::SessionId session_id;
+    trace::ProcessId process_id;
+    int32 max_buffer_flush_attempts;
+    bool flush_all_events;
+  };
+
+  DiskFlushQueue() = delete;
+  explicit DiskFlushQueue(Options options);
+  DiskFlushQueue(const DiskFlushQueue&) = delete;
+  DiskFlushQueue(DiskFlushQueue&&) noexcept = delete;
+  auto operator=(const DiskFlushQueue&) -> DiskFlushQueue& = delete;
+  auto operator=(DiskFlushQueue&&) noexcept -> DiskFlushQueue& = delete;
+  ~DiskFlushQueue() override;
+
+  auto Run() -> void override;
+  // Waits for the queue to empty synchronously. Buffers will be retained until
+  // the deadline or until the queue is flushed or cleared.
+  auto Enqueue(Buffer&& buffer) -> void override;
+  auto DrainAndStop() -> void override;
+  auto Flush(std::function<void()> completion) -> void override;
+  auto Clear() -> void override;
+
+  [[nodiscard]] auto Size() const -> SizeType;
+  [[nodiscard]] auto Empty() const -> bool;
+
+ private:
+  struct FlushInfo {
+    Buffer buffer;
+    std::chrono::time_point<std::chrono::steady_clock> flush_timestamp;
+    trace::ThreadId thread_id;
+    int64 id;
+    int32 remaining_flush_attempts{};
+  };
+
+  Options options_;
+  std::thread flush_thread_;
+  // Guards `queue_`, `flush_completion_`, `manual_flush_record_ids_`, and
+  // `flush_timestamp_`, and `next_flush_info_id_`.
+  mutable std::shared_mutex lock_;
+  std::deque<FlushInfo> queue_;
+  std::optional<std::function<void()>> flush_completion_;
+  std::unordered_set<int64> manual_flush_record_ids_;
+  std::chrono::time_point<std::chrono::steady_clock> flush_timestamp_;
+  int64 next_flush_info_id_;
+  std::atomic_size_t queue_size_;
+  std::atomic_bool running_;
+  std::atomic_bool draining_;
+
+  auto TraceFilePath(const FlushInfo& flush_info) const
+      -> std::filesystem::path;
+  auto TraceFileHeader(const FlushInfo& flush_info) const -> trace::Header;
+};
+
+}  // namespace spoor::runtime::flush_queue

--- a/spoor/runtime/flush_queue/disk_flush_queue_test.cc
+++ b/spoor/runtime/flush_queue/disk_flush_queue_test.cc
@@ -1,0 +1,469 @@
+#include "spoor/runtime/flush_queue/disk_flush_queue.h"
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <filesystem>
+#include <iterator>
+#include <vector>
+
+#include "absl/strings/str_format.h"
+#include "gmock/gmock.h"
+#include "gsl/gsl"
+#include "gtest/gtest.h"
+#include "spoor/runtime/buffer/circular_slice_buffer.h"
+#include "spoor/runtime/buffer/reserved_buffer_slice_pool.h"
+#include "spoor/runtime/trace/trace.h"
+#include "spoor/runtime/trace/trace_writer.h"
+#include "spoor/runtime/trace/trace_writer_mock.h"
+#include "util/numeric.h"
+#include "util/time/clock_mock.h"
+
+namespace {
+
+using spoor::runtime::flush_queue::DiskFlushQueue;
+using spoor::runtime::trace::Event;
+using spoor::runtime::trace::Footer;
+using spoor::runtime::trace::Header;
+using spoor::runtime::trace::TimestampNanoseconds;
+using spoor::runtime::trace::testing::TraceWriterMock;
+using std::literals::chrono_literals::operator""ns;
+using testing::_;
+using testing::InSequence;
+using testing::Invoke;
+using testing::MatchesRegex;
+using testing::Return;
+using testing::Truly;
+using util::time::testing::MakeTimePoint;
+using util::time::testing::SteadyClockMock;
+using util::time::testing::SystemClockMock;
+using Buffer = spoor::runtime::buffer::CircularSliceBuffer<Event>;
+using SizeType = typename Buffer::SizeType;
+using Pool = spoor::runtime::buffer::ReservedBufferSlicePool<Event>;
+using Result = util::result::Result<util::result::None, util::result::None>;
+
+// NOLINTNEXTLINE(fuchsia-statically-constructed-objects)
+const std::filesystem::path kTraceFilePath{"trace/file/path"};
+// NOLINTNEXTLINE(fuchsia-statically-constructed-objects)
+const std::string kTraceFilePattern{
+    R"(trace\/file\/path\/[0-9a-f]{16}-[0-9a-f]{16}-[0-9a-f]{16}\.spoor)"};
+constexpr spoor::runtime::trace::SessionId kSessionId{42};
+constexpr spoor::runtime::trace::ProcessId kProcessId{1729};
+constexpr Footer kExpectedFooter{};
+
+TEST(DiskFlushQueue, Enqueue) {  // NOLINT
+  constexpr SizeType capacity{0};
+  Pool pool{{.max_slice_capacity = capacity, .capacity = capacity}};
+  Buffer buffer_a{{.buffer_slice_pool = &pool, .capacity = capacity}};
+  Buffer buffer_b{{.buffer_slice_pool = &pool, .capacity = capacity}};
+
+  SystemClockMock system_clock{};
+  EXPECT_CALL(system_clock, Now())
+      .Times(2)
+      .WillRepeatedly(Return(MakeTimePoint<std::chrono::system_clock>(0)));
+  SteadyClockMock steady_clock{};
+  std::atomic<TimestampNanoseconds> time{1};
+  EXPECT_CALL(steady_clock, Now()).WillRepeatedly(Invoke([&time]() {
+    return MakeTimePoint<std::chrono::steady_clock>(time);
+  }));
+
+  TraceWriterMock trace_writer{};
+  EXPECT_CALL(trace_writer, Write(MatchesRegex(kTraceFilePattern), _, _, _))
+      .Times(2)
+      .WillRepeatedly(Return(Result::Ok({})));
+
+  DiskFlushQueue flush_queue{{.trace_file_path = kTraceFilePath,
+                              .buffer_retention_duration = 2ns,
+                              .system_clock = &system_clock,
+                              .steady_clock = &steady_clock,
+                              .trace_writer = &trace_writer,
+                              .session_id = kSessionId,
+                              .process_id = kProcessId,
+                              .max_buffer_flush_attempts = 1,
+                              .flush_all_events = false}};
+  flush_queue.Run();
+  ASSERT_TRUE(flush_queue.Empty());
+  flush_queue.Enqueue(std::move(buffer_a));
+  ASSERT_EQ(flush_queue.Size(), 1);
+  flush_queue.Enqueue(std::move(buffer_b));
+  ASSERT_EQ(flush_queue.Size(), 2);
+  ++time;
+  flush_queue.Flush({});
+  flush_queue.DrainAndStop();
+  ASSERT_TRUE(flush_queue.Empty());
+}
+
+TEST(DiskFlushQueue, WritesEvents) {  // NOLINT
+  const std::vector events{Event(Event::Type::kFunctionEntry, 1, 0),
+                           Event(Event::Type::kFunctionEntry, 2, 1),
+                           Event(Event::Type::kFunctionEntry, 3, 2),
+                           Event(Event::Type::kFunctionExit, 3, 3),
+                           Event(Event::Type::kFunctionEntry, 3, 4),
+                           Event(Event::Type::kFunctionExit, 3, 5),
+                           Event(Event::Type::kFunctionExit, 2, 6),
+                           Event(Event::Type::kFunctionExit, 1, 7)};
+  const SizeType capacity{events.size()};
+  Pool pool{{.max_slice_capacity = capacity, .capacity = capacity}};
+  Buffer buffer{{.buffer_slice_pool = &pool, .capacity = capacity}};
+  for (const auto event : events) {
+    buffer.Push(event);
+  }
+
+  SystemClockMock system_clock{};
+  constexpr TimestampNanoseconds system_clock_timestamp{100'000};
+  EXPECT_CALL(system_clock, Now())
+      .WillOnce(Return(
+          MakeTimePoint<std::chrono::system_clock>(system_clock_timestamp)));
+  SteadyClockMock steady_clock{};
+  constexpr TimestampNanoseconds steady_clock_timestamp{42};
+  EXPECT_CALL(steady_clock, Now())
+      .WillRepeatedly(Return(
+          MakeTimePoint<std::chrono::steady_clock>(steady_clock_timestamp)));
+
+  const std::string trace_file_pattern =
+      absl::StrFormat(R"(trace\/file\/path\/%016x-[0-9a-f]{16}-%016x\.spoor)",
+                      kSessionId, steady_clock_timestamp);
+  const auto matches_header = [&](const Header& header) {
+    // Ignore the `thread_id` because it reflects the hash of the true value
+    // which cannot be determined.
+    return header.version == spoor::runtime::trace::kTraceFileVersion &&
+           header.session_id == kSessionId && header.process_id == kProcessId &&
+           header.system_clock_timestamp == system_clock_timestamp &&
+           header.steady_clock_timestamp == steady_clock_timestamp &&
+           gsl::narrow_cast<SizeType>(header.event_count) == events.size();
+  };
+  const auto matches_events = [expected_events = &events](Buffer* buffer) {
+    const auto chunks = buffer->ContiguousMemoryChunks();
+    if (chunks.size() != 1) return false;
+    const auto events = chunks.front();
+    if (events.size() != expected_events->size()) return false;
+    return std::equal(std::cbegin(events), std::cend(events),
+                      std::cbegin(*expected_events));
+  };
+  TraceWriterMock trace_writer{};
+  EXPECT_CALL(trace_writer,
+              Write(MatchesRegex(trace_file_pattern), Truly(matches_header),
+                    Truly(matches_events), kExpectedFooter))
+      .WillOnce(Return(Result::Ok({})));
+
+  DiskFlushQueue flush_queue{{.trace_file_path = kTraceFilePath,
+                              .buffer_retention_duration = 0ns,
+                              .system_clock = &system_clock,
+                              .steady_clock = &steady_clock,
+                              .trace_writer = &trace_writer,
+                              .session_id = kSessionId,
+                              .process_id = kProcessId,
+                              .max_buffer_flush_attempts = 1,
+                              .flush_all_events = true}};
+  flush_queue.Run();
+  ASSERT_TRUE(flush_queue.Empty());
+  flush_queue.Enqueue(std::move(buffer));
+  flush_queue.DrainAndStop();
+  ASSERT_TRUE(flush_queue.Empty());
+}
+
+TEST(DiskFlushQueue, Flush) {  // NOLINT
+  constexpr SizeType capacity{0};
+  Pool pool{{.max_slice_capacity = capacity, .capacity = capacity}};
+  Buffer buffer{{.buffer_slice_pool = &pool, .capacity = capacity}};
+
+  SystemClockMock system_clock{};
+  EXPECT_CALL(system_clock, Now())
+      .WillOnce(Return(MakeTimePoint<std::chrono::system_clock>(0)));
+  SteadyClockMock steady_clock{};
+  std::atomic<TimestampNanoseconds> time{1};
+  EXPECT_CALL(steady_clock, Now()).WillRepeatedly(Invoke([&time]() {
+    return MakeTimePoint<std::chrono::steady_clock>(time);
+  }));
+
+  TraceWriterMock trace_writer{};
+  EXPECT_CALL(trace_writer,
+              Write(MatchesRegex(kTraceFilePattern), _, _, kExpectedFooter))
+      .WillOnce(Return(Result::Ok({})));
+
+  DiskFlushQueue flush_queue{{.trace_file_path = kTraceFilePath,
+                              .buffer_retention_duration = 4ns,
+                              .system_clock = &system_clock,
+                              .steady_clock = &steady_clock,
+                              .trace_writer = &trace_writer,
+                              .session_id = kSessionId,
+                              .process_id = kProcessId,
+                              .max_buffer_flush_attempts = 1,
+                              .flush_all_events = false}};
+  flush_queue.Run();
+  ASSERT_TRUE(flush_queue.Empty());
+  flush_queue.Enqueue(std::move(buffer));
+  ASSERT_EQ(flush_queue.Size(), 1);
+  ++time;
+  flush_queue.Flush({});
+  ++time;
+  flush_queue.DrainAndStop();
+  ASSERT_TRUE(flush_queue.Empty());
+}
+
+TEST(DiskFlushQueue, FlushCallback) {  // NOLINT
+  constexpr SizeType capacity{0};
+  Pool pool{{.max_slice_capacity = capacity, .capacity = capacity}};
+  Buffer buffer_a{{.buffer_slice_pool = &pool, .capacity = capacity}};
+  Buffer buffer_b{{.buffer_slice_pool = &pool, .capacity = capacity}};
+
+  SystemClockMock system_clock{};
+  EXPECT_CALL(system_clock, Now())
+      .WillOnce(Return(MakeTimePoint<std::chrono::system_clock>(0)));
+  SteadyClockMock steady_clock{};
+  std::atomic<TimestampNanoseconds> time{1};
+  EXPECT_CALL(steady_clock, Now()).WillRepeatedly(Invoke([&time]() {
+    return MakeTimePoint<std::chrono::steady_clock>(time);
+  }));
+
+  TraceWriterMock trace_writer{};
+  EXPECT_CALL(trace_writer, Write(MatchesRegex(kTraceFilePattern), _, _, _))
+      .WillOnce(Return(Result::Ok({})));
+
+  DiskFlushQueue flush_queue{{.trace_file_path = kTraceFilePath,
+                              .buffer_retention_duration = 3ns,
+                              .system_clock = &system_clock,
+                              .steady_clock = &steady_clock,
+                              .trace_writer = &trace_writer,
+                              .session_id = kSessionId,
+                              .process_id = kProcessId,
+                              .max_buffer_flush_attempts = 1,
+                              .flush_all_events = false}};
+  flush_queue.Run();
+  ASSERT_TRUE(flush_queue.Empty());
+  flush_queue.Enqueue(std::move(buffer_a));
+  ASSERT_EQ(flush_queue.Size(), 1);
+  ++time;
+  {
+    std::mutex mutex{};
+    std::condition_variable condition_variable{};
+    flush_queue.Flush([&mutex, &condition_variable] {
+      std::unique_lock lock{mutex};
+      condition_variable.notify_all();
+    });
+    ++time;
+    flush_queue.Enqueue(std::move(buffer_b));
+    std::unique_lock lock{mutex};
+    condition_variable.wait(lock);
+  }
+  ASSERT_EQ(flush_queue.Size(), 1);
+  flush_queue.Clear();
+  ASSERT_TRUE(flush_queue.Empty());
+  flush_queue.DrainAndStop();
+}
+
+TEST(DiskFlushQueue, Clear) {  // NOLINT
+  constexpr SizeType capacity{0};
+  Pool pool{{.max_slice_capacity = capacity, .capacity = capacity}};
+  Buffer buffer{{.buffer_slice_pool = &pool, .capacity = capacity}};
+
+  SystemClockMock system_clock{};
+  EXPECT_CALL(system_clock, Now()).Times(0);
+  SteadyClockMock steady_clock{};
+  std::atomic<TimestampNanoseconds> time{1};
+  EXPECT_CALL(steady_clock, Now()).WillRepeatedly(Invoke([&time]() {
+    return MakeTimePoint<std::chrono::steady_clock>(time);
+  }));
+
+  TraceWriterMock trace_writer{};
+  EXPECT_CALL(trace_writer, Write(_, _, _, _)).Times(0);
+
+  DiskFlushQueue flush_queue{{.trace_file_path = kTraceFilePath,
+                              .buffer_retention_duration = 1'000ns,
+                              .system_clock = &system_clock,
+                              .steady_clock = &steady_clock,
+                              .trace_writer = &trace_writer,
+                              .session_id = kSessionId,
+                              .process_id = kProcessId,
+                              .max_buffer_flush_attempts = 1,
+                              .flush_all_events = false}};
+  flush_queue.Run();
+  ASSERT_TRUE(flush_queue.Empty());
+  flush_queue.Enqueue(std::move(buffer));
+  ASSERT_EQ(flush_queue.Size(), 1);
+  ++time;
+  flush_queue.Clear();
+  ASSERT_TRUE(flush_queue.Empty());
+  ++time;
+  ASSERT_TRUE(flush_queue.Empty());
+  flush_queue.DrainAndStop();
+  ASSERT_TRUE(flush_queue.Empty());
+}
+
+TEST(DiskFlushQueue, RetainsEventsUntilTimePoint) {  // NOLINT
+  constexpr SizeType capacity{0};
+  Pool pool{{.max_slice_capacity = capacity, .capacity = capacity}};
+  Buffer buffer{{.buffer_slice_pool = &pool, .capacity = capacity}};
+
+  SystemClockMock system_clock{};
+  EXPECT_CALL(system_clock, Now()).Times(0);
+  SteadyClockMock steady_clock{};
+  std::atomic<TimestampNanoseconds> time{1};
+  EXPECT_CALL(steady_clock, Now()).WillRepeatedly(Invoke([&time]() {
+    return MakeTimePoint<std::chrono::steady_clock>(time);
+  }));
+
+  TraceWriterMock trace_writer{};
+  EXPECT_CALL(trace_writer, Write(_, _, _, _)).Times(0);
+
+  constexpr auto retention_duration = 3ns;
+  DiskFlushQueue flush_queue{{.trace_file_path = kTraceFilePath,
+                              .buffer_retention_duration = retention_duration,
+                              .system_clock = &system_clock,
+                              .steady_clock = &steady_clock,
+                              .trace_writer = &trace_writer,
+                              .session_id = kSessionId,
+                              .process_id = kProcessId,
+                              .max_buffer_flush_attempts = 1,
+                              .flush_all_events = false}};
+  flush_queue.Run();
+  ASSERT_TRUE(flush_queue.Empty());
+  flush_queue.Enqueue(std::move(buffer));
+  ASSERT_EQ(flush_queue.Size(), 1);
+  time += retention_duration.count();
+  flush_queue.DrainAndStop();
+  ASSERT_TRUE(flush_queue.Empty());
+}
+
+TEST(DiskFlushQueue, DropsEventsWhenNotRunning) {  // NOLINT
+  constexpr SizeType capacity{0};
+  Pool pool{{.max_slice_capacity = capacity, .capacity = capacity}};
+  Buffer buffer{{.buffer_slice_pool = &pool, .capacity = capacity}};
+
+  SystemClockMock system_clock{};
+  EXPECT_CALL(system_clock, Now()).Times(0);
+  SteadyClockMock steady_clock{};
+  EXPECT_CALL(steady_clock, Now())
+      .WillOnce(Return(MakeTimePoint<std::chrono::steady_clock>(0)));
+
+  TraceWriterMock trace_writer{};
+  EXPECT_CALL(trace_writer, Write(_, _, _, _)).Times(0);
+
+  DiskFlushQueue flush_queue{{.trace_file_path = kTraceFilePath,
+                              .buffer_retention_duration = 1'000ns,
+                              .system_clock = &system_clock,
+                              .steady_clock = &steady_clock,
+                              .trace_writer = &trace_writer,
+                              .session_id = kSessionId,
+                              .process_id = kProcessId,
+                              .max_buffer_flush_attempts = 1,
+                              .flush_all_events = false}};
+  ASSERT_TRUE(flush_queue.Empty());
+  flush_queue.Enqueue(std::move(buffer));
+  ASSERT_TRUE(flush_queue.Empty());
+}
+
+TEST(DiskFlushQueue, FlushesOnLastAttempt) {  // NOLINT
+  constexpr SizeType capacity{0};
+  Pool pool{{.max_slice_capacity = capacity, .capacity = capacity}};
+
+  SystemClockMock system_clock{};
+  EXPECT_CALL(system_clock, Now())
+      .WillRepeatedly(Return(MakeTimePoint<std::chrono::system_clock>(0)));
+  SteadyClockMock steady_clock{};
+  EXPECT_CALL(steady_clock, Now())
+      .WillRepeatedly(Return(MakeTimePoint<std::chrono::steady_clock>(0)));
+
+  for (const auto max_attempts : {0, 1, 3, 5, 10}) {
+    Buffer buffer{{.buffer_slice_pool = &pool, .capacity = capacity}};
+
+    TraceWriterMock trace_writer{};
+    InSequence in_sequence{};
+    if (1 < max_attempts) {
+      EXPECT_CALL(trace_writer, Write(MatchesRegex(kTraceFilePattern), _, _, _))
+          .Times(max_attempts - 1)
+          .WillRepeatedly(Return(Result::Err({})))
+          .RetiresOnSaturation();
+    }
+    EXPECT_CALL(trace_writer, Write(MatchesRegex(kTraceFilePattern), _, _, _))
+        .WillOnce(Return(Result::Ok({})))
+        .RetiresOnSaturation();
+
+    DiskFlushQueue flush_queue{{.trace_file_path = kTraceFilePath,
+                                .buffer_retention_duration = 0ns,
+                                .system_clock = &system_clock,
+                                .steady_clock = &steady_clock,
+                                .trace_writer = &trace_writer,
+                                .session_id = kSessionId,
+                                .process_id = kProcessId,
+                                .max_buffer_flush_attempts = max_attempts,
+                                .flush_all_events = true}};
+    flush_queue.Run();
+    flush_queue.Enqueue(std::move(buffer));
+    flush_queue.DrainAndStop();
+  }
+}
+
+TEST(DiskFlushQueue, DropsEventsAfterMaxFlushAttempts) {  // NOLINT
+  constexpr SizeType capacity{0};
+  Pool pool{{.max_slice_capacity = capacity, .capacity = capacity}};
+
+  SystemClockMock system_clock{};
+  EXPECT_CALL(system_clock, Now())
+      .WillRepeatedly(Return(MakeTimePoint<std::chrono::system_clock>(0)));
+  SteadyClockMock steady_clock{};
+  EXPECT_CALL(steady_clock, Now())
+      .WillRepeatedly(Return(MakeTimePoint<std::chrono::steady_clock>(0)));
+
+  for (const auto max_attempts : {0, 1, 3, 5, 10}) {
+    Buffer buffer{{.buffer_slice_pool = &pool, .capacity = capacity}};
+
+    TraceWriterMock trace_writer{};
+    InSequence in_sequence{};
+    EXPECT_CALL(trace_writer, Write(MatchesRegex(kTraceFilePattern), _, _, _))
+        .Times(std::max(1, max_attempts))
+        .WillRepeatedly(Return(Result::Err({})))
+        .RetiresOnSaturation();
+
+    DiskFlushQueue flush_queue{{.trace_file_path = kTraceFilePath,
+                                .buffer_retention_duration = 0ns,
+                                .system_clock = &system_clock,
+                                .steady_clock = &steady_clock,
+                                .trace_writer = &trace_writer,
+                                .session_id = kSessionId,
+                                .process_id = kProcessId,
+                                .max_buffer_flush_attempts = max_attempts,
+                                .flush_all_events = true}};
+    flush_queue.Run();
+    flush_queue.Enqueue(std::move(buffer));
+    flush_queue.DrainAndStop();
+  }
+}
+
+TEST(DiskFlushQueue, HandlesConsecutiveCallsToRunAndDrainAndStop) {  // NOLINT
+  constexpr SizeType capacity{0};
+  Pool pool{{.max_slice_capacity = capacity, .capacity = capacity}};
+  Buffer buffer{{.buffer_slice_pool = &pool, .capacity = capacity}};
+
+  SystemClockMock system_clock{};
+  EXPECT_CALL(system_clock, Now()).Times(0);
+  SteadyClockMock steady_clock{};
+  EXPECT_CALL(steady_clock, Now()).Times(0);
+
+  TraceWriterMock trace_writer{};
+  EXPECT_CALL(trace_writer, Write(MatchesRegex(kTraceFilePattern), _, _, _))
+      .Times(0);
+
+  DiskFlushQueue flush_queue{{.trace_file_path = kTraceFilePath,
+                              .buffer_retention_duration = 0ns,
+                              .system_clock = &system_clock,
+                              .steady_clock = &steady_clock,
+                              .trace_writer = &trace_writer,
+                              .session_id = kSessionId,
+                              .process_id = kProcessId,
+                              .max_buffer_flush_attempts = 1,
+                              .flush_all_events = true}};
+  flush_queue.Run();
+  flush_queue.Run();
+  flush_queue.Run();
+  flush_queue.Run();
+  flush_queue.Run();
+  flush_queue.DrainAndStop();
+  flush_queue.DrainAndStop();
+  flush_queue.DrainAndStop();
+  flush_queue.DrainAndStop();
+  flush_queue.DrainAndStop();
+  flush_queue.DrainAndStop();
+}
+
+}  // namespace

--- a/spoor/runtime/flush_queue/flush_queue.h
+++ b/spoor/runtime/flush_queue/flush_queue.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <functional>
+
+namespace spoor::runtime::flush_queue {
+
+template <class T>
+class FlushQueue {
+ public:
+  virtual ~FlushQueue() = default;
+
+  virtual auto Run() -> void = 0;
+  virtual auto Enqueue(T&& item) -> void = 0;
+  virtual auto DrainAndStop() -> void = 0;
+  virtual auto Flush(std::function<void()> completion) -> void = 0;
+  virtual auto Clear() -> void = 0;
+
+ protected:
+  FlushQueue() = default;
+  FlushQueue(const FlushQueue&) = default;
+  FlushQueue(FlushQueue&&) noexcept = default;
+  auto operator=(const FlushQueue&) -> FlushQueue& = default;
+  auto operator=(FlushQueue&&) noexcept -> FlushQueue& = default;
+};
+
+}  // namespace spoor::runtime::flush_queue

--- a/spoor/runtime/flush_queue/flush_queue_mock.h
+++ b/spoor/runtime/flush_queue/flush_queue_mock.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <functional>
+
+#include "gmock/gmock.h"
+#include "spoor/runtime/flush_queue/flush_queue.h"
+
+namespace spoor::runtime::flush_queue::testing {
+
+template <class T>
+class FlushQueueMock : public FlushQueue<T> {
+ public:
+  MOCK_METHOD(void, Run, (), (override));
+  MOCK_METHOD(void, Enqueue, (T && item), (override));
+  MOCK_METHOD(void, DrainAndStop, (), (override));
+  MOCK_METHOD(void, Flush, (std::function<void()>), (override));
+  MOCK_METHOD(void, Clear, (), (override));
+};
+
+}  // namespace spoor::runtime::flush_queue::testing

--- a/toolchain/style/clang_tidy.sh
+++ b/toolchain/style/clang_tidy.sh
@@ -46,10 +46,13 @@ echo "Building C++ targets"
 bazel build $(bazel query 'kind(cc_.*, //...)')
 
 if [ $# -eq 0 ]; then
-  # TODO(#34): Do not exclude `trace_writer_mock.h`.
+  # TODO(#34): Do not exclude `flush_queue_mock.h`.
+  # TODO(#37): Do not exclude `flush_queue_mock.h`.
   find "$WORKSPACE" \
-    -type f -name "trace_writer_mock.h" -prune -o \
-    -type f \( -iname "*.h" -o -iname "*.cc" \) \
+    -type f \
+    \( -iname "*.h" -o -iname "*.cc" \) \
+    ! -name "flush_queue_mock.h" \
+    ! -name "trace_writer_mock.h" \
     -print0 |
       while read -d $'\0' file_name; do
         run_clang_tidy "$file_name"


### PR DESCRIPTION
Accepts flushed event buffers and flushes them to disk if necessary. A buffer can be flushed manually by the program, when the buffer is at capacity in "log everything" mode, or when a thread dies. Buffers remain in the flush queue until their retention deadline.

Introduces #37.