### PR TITLE
Run sanitizers on all platforms

### DIFF
--- a/.build/azure-pipelines.yml
+++ b/.build/azure-pipelines.yml
@@ -18,17 +18,13 @@ jobs:
     displayName: Benchmark
   - script: ./toolchain/compilation_database/generate_compilation_database.sh
     displayName: Generate compilation database
-- job: sanitizers
-  pool:
-    vmImage: 'ubuntu-20.04'
-  steps:
-  - template: ./templates/install-common.yml
   - script: bazel test --config=asan //...
     displayName: Address sanitizer
   - script: bazel test --config=tsan //...
     displayName: Thread sanitizer
   - script: bazel test --config=ubsan //...
     displayName: Undefined behavior sanitizer
+    condition: eq(variables['Agent.OS'], 'Linux')
 - job: style_and_lint
   pool:
     vmImage: 'ubuntu-20.04'


### PR DESCRIPTION
Runs the address, thread, and undefined behavior sanitizers on all platforms in CI instead of just Linux.

#38 reveals that the sanitizers might behave differently on different platforms (tsan passes locally on macOS but not in the Linux CI environment).