### PR TITLE
Run style_and_lint CI job on macOS

### DIFF
--- a/.build/azure-pipelines.yml
+++ b/.build/azure-pipelines.yml
@@ -27,11 +27,9 @@ jobs:
     condition: eq(variables['Agent.OS'], 'Linux')
 - job: style_and_lint
   pool:
-    vmImage: 'ubuntu-20.04'
+    vmImage: 'macos-10.15'
   steps:
   - template: ./templates/install-common.yml
-  - script: sudo apt-get install clang-format-11 clang-tidy-11
-    displayName: Install Clang Format and Clang Tidy
   - script: |
       ./toolchain/style/clang_format.sh
       git diff --exit-code

--- a/.build/templates/install-common.yml
+++ b/.build/templates/install-common.yml
@@ -8,6 +8,7 @@ steps:
 - script: |
     brew update
     brew upgrade --force llvm@11
+    echo '##vso[task.prependpath]/usr/local/opt/llvm/bin'
   displayName: Install LLVM (macOS)
   condition: eq(variables['Agent.OS'], 'Darwin')
 - script: cp ./.build/ci.bazelrc ./.bazelrc


### PR DESCRIPTION
Run the `style_and_lint` CI job on macOS. We're experiencing difficulties with the Ubuntu CI environment where `clang-tidy` is emitting numerous false-positives. These issues don't seem to be present on macOS so the simple solution is to switch the job environment to one that consistently works.

The optimal solution would be to investigate and fix the Linux environment, but that work involves a lot of guess and check which is very time-consuming.