### PR TITLE
Return a `Result` from file system operations

### DIFF
--- a/spoor/runtime/runtime_manager/runtime_manager.h
+++ b/spoor/runtime/runtime_manager/runtime_manager.h
@@ -132,11 +132,11 @@ auto RuntimeManager::DeleteFlushedTraceFilesOlderThan(
               std::chrono::duration_cast<std::chrono::microseconds>(
                   std::chrono::nanoseconds{header.system_clock_timestamp})};
       if (timestamp < header_system_clock_timestamp) continue;
-      const auto file_size = file_system->FileSize(file->path());
-      const auto success = file_system->Remove(file->path());
-      if (success) {
+      const auto file_size_result = file_system->FileSize(file->path());
+      const auto success_result = file_system->Remove(file->path());
+      if (success_result.IsOk()) {
         ++deleted_files_info.deleted_files;
-        deleted_files_info.deleted_bytes += file_size;
+        deleted_files_info.deleted_bytes += file_size_result.OkOr(0);
       }
     }
     if (completion != nullptr) completion(deleted_files_info);

--- a/spoor/runtime/runtime_manager/runtime_manager_test.cc
+++ b/spoor/runtime/runtime_manager/runtime_manager_test.cc
@@ -4,6 +4,7 @@
 #include <chrono>
 #include <future>
 #include <map>
+#include <system_error>
 #include <thread>
 #include <utility>
 
@@ -34,6 +35,7 @@ using testing::ElementsAreArray;
 using testing::Return;
 using util::file_system::testing::DirectoryEntryMock;
 using util::file_system::testing::FileSystemMock;
+using util::result::None;
 using util::time::testing::MakeTimePoint;
 using util::time::testing::SteadyClockMock;
 using FlushQueueMock = spoor::runtime::flush_queue::testing::FlushQueueMock<
@@ -240,7 +242,9 @@ TEST(RuntimeManager, DeleteFlushedTraceFilesOlderThan) {  // NOLINT
   for (auto i{-1}; i < trace_files_size + 3; ++i) {
     for (auto j{0}; j < std::min(i, trace_files_size); ++j) {
       const auto path = make_path(j);
-      EXPECT_CALL(file_system, Remove(path)).WillOnce(Return(true));
+      EXPECT_CALL(file_system, Remove(path))
+          .WillOnce(
+              Return(util::result::Result<None, std::error_code>::Ok({})));
     }
     const auto timestamp = make_timestamp(i) - 1'000;
     std::promise<RuntimeManager::DeletedFilesInfo> promise{};

--- a/spoor/runtime/trace/trace_file_reader.cc
+++ b/spoor/runtime/trace/trace_file_reader.cc
@@ -18,7 +18,9 @@ TraceFileReader::TraceFileReader(Options options)
 
 auto TraceFileReader::MatchesTraceFileConvention(
     const std::filesystem::path& file) const -> bool {
-  return options_.file_system->IsRegularFile(file) &&
+  const auto result = options_.file_system->IsRegularFile(file);
+  const auto is_regular_file = result.OkOr(false);
+  return is_regular_file &&
          std::regex_match(file.filename().string(), kTraceFileNamePattern);
 }
 

--- a/util/file_system/BUILD
+++ b/util/file_system/BUILD
@@ -7,6 +7,7 @@ cc_library(
     ],
     copts = ["-Werror"],
     visibility = ["//visibility:public"],
+    deps = ["//util:result"],
 )
 
 cc_library(
@@ -20,6 +21,7 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":file_system",
+        "//util:result",
         "@com_google_googletest//:gtest",
     ],
 )

--- a/util/file_system/file_system.h
+++ b/util/file_system/file_system.h
@@ -2,6 +2,9 @@
 
 #include <cstdint>
 #include <filesystem>
+#include <system_error>
+
+#include "util/result.h"
 
 namespace util::file_system {
 
@@ -14,12 +17,12 @@ class FileSystem {
   auto operator=(FileSystem&&) noexcept -> FileSystem& = default;
   virtual ~FileSystem() = default;
 
-  [[nodiscard]] virtual auto IsRegularFile(
-      const std::filesystem::path& path) const noexcept -> bool = 0;
-  [[nodiscard]] virtual auto FileSize(
-      const std::filesystem::path& path) const noexcept -> std::uintmax_t = 0;
-  [[nodiscard]] virtual auto Remove(
-      const std::filesystem::path& path) const noexcept -> bool = 0;
+  [[nodiscard]] virtual auto IsRegularFile(const std::filesystem::path& path)
+      const -> util::result::Result<bool, std::error_code> = 0;
+  [[nodiscard]] virtual auto FileSize(const std::filesystem::path& path) const
+      -> util::result::Result<std::uintmax_t, std::error_code> = 0;
+  [[nodiscard]] virtual auto Remove(const std::filesystem::path& path) const
+      -> util::result::Result<util::result::None, std::error_code> = 0;
 };
 
 }  // namespace util::file_system

--- a/util/file_system/file_system_mock.h
+++ b/util/file_system/file_system_mock.h
@@ -2,23 +2,25 @@
 
 #include <cstdint>
 #include <filesystem>
+#include <system_error>
 
 #include "gmock/gmock.h"
 #include "util/file_system/file_system.h"
+#include "util/result.h"
 
 namespace util::file_system::testing {
 
 class FileSystemMock final : public FileSystem {
  public:
   MOCK_METHOD(  // NOLINT
-      bool, IsRegularFile, (const std::filesystem::path& path),
-      (const, noexcept, override));
+      (util::result::Result<bool, std::error_code>), IsRegularFile,
+      (const std::filesystem::path& path), (const, override));
   MOCK_METHOD(  // NOLINT
-      std::uintmax_t, FileSize, (const std::filesystem::path& path),
-      (const, noexcept, override));
+      (util::result::Result<std::uintmax_t, std::error_code>), FileSize,
+      (const std::filesystem::path& path), (const, override));
   MOCK_METHOD(  // NOLINT
-      bool, Remove, (const std::filesystem::path& path),
-      (const, noexcept, override));
+      (util::result::Result<util::result::None, std::error_code>), Remove,
+      (const std::filesystem::path& path), (const, override));
 };
 
 }  // namespace util::file_system::testing

--- a/util/file_system/local_file_system.cc
+++ b/util/file_system/local_file_system.cc
@@ -2,22 +2,40 @@
 
 #include <cstdint>
 #include <filesystem>
+#include <system_error>
+
+#include "util/result.h"
 
 namespace util::file_system {
 
-auto LocalFileSystem::IsRegularFile(
-    const std::filesystem::path& path) const noexcept -> bool {
-  return std::filesystem::is_regular_file(path);
+using util::result::None;
+
+auto LocalFileSystem::IsRegularFile(const std::filesystem::path& path) const
+    -> util::result::Result<bool, std::error_code> {
+  std::error_code error_code{};
+  const auto is_regular_file =
+      std::filesystem::is_regular_file(path, error_code);
+  const auto error = static_cast<bool>(error_code);
+  if (error) return error_code;
+  return is_regular_file;
 }
 
-auto LocalFileSystem::FileSize(const std::filesystem::path& path) const noexcept
-    -> std::uintmax_t {
-  return std::filesystem::file_size(path);
+auto LocalFileSystem::FileSize(const std::filesystem::path& path) const
+    -> util::result::Result<std::uintmax_t, std::error_code> {
+  std::error_code error_code{};
+  const auto file_size = std::filesystem::file_size(path, error_code);
+  const auto error = static_cast<bool>(error_code);
+  if (error) return error_code;
+  return file_size;
 }
 
-auto LocalFileSystem::Remove(const std::filesystem::path& path) const noexcept
-    -> bool {
-  return std::filesystem::remove(path);
+auto LocalFileSystem::Remove(const std::filesystem::path& path) const
+    -> util::result::Result<None, std::error_code> {
+  std::error_code error_code{};
+  const auto success = std::filesystem::remove(path, error_code);
+  const auto error = !success || static_cast<bool>(error_code);
+  if (error) return error_code;
+  return util::result::Result<None, std::error_code>::Ok({});
 }
 
 }  // namespace util::file_system

--- a/util/file_system/local_file_system.h
+++ b/util/file_system/local_file_system.h
@@ -2,19 +2,21 @@
 
 #include <cstdint>
 #include <filesystem>
+#include <system_error>
 
 #include "util/file_system/file_system.h"
+#include "util/result.h"
 
 namespace util::file_system {
 
 class LocalFileSystem final : public FileSystem {
  public:
-  [[nodiscard]] auto IsRegularFile(
-      const std::filesystem::path& path) const noexcept -> bool override;
-  [[nodiscard]] auto FileSize(const std::filesystem::path& path) const noexcept
-      -> std::uintmax_t override;
-  [[nodiscard]] auto Remove(const std::filesystem::path& path) const noexcept
-      -> bool override;
+  [[nodiscard]] auto IsRegularFile(const std::filesystem::path& path) const
+      -> util::result::Result<bool, std::error_code> override;
+  [[nodiscard]] auto FileSize(const std::filesystem::path& path) const
+      -> util::result::Result<std::uintmax_t, std::error_code> override;
+  [[nodiscard]] auto Remove(const std::filesystem::path& path) const
+      -> util::result::Result<util::result::None, std::error_code> override;
 };
 
 }  // namespace util::file_system


### PR DESCRIPTION
Supply an error_code to file system operations and return a `Result` which we can handle gracefully. Previously, we'd crash with an exception.