### PR TITLE
Compiler instrumentation pass

### DIFF
--- a/spoor/instrumentation/BUILD
+++ b/spoor/instrumentation/BUILD
@@ -1,0 +1,44 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_proto_library", "cc_test")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
+proto_library(
+    name = "instrumentation_map_proto",
+    srcs = ["instrumentation_map.proto"],
+    visibility = ["//visibility:public"],
+)
+
+cc_proto_library(
+    name = "instrumentation_map_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":instrumentation_map_proto"],
+)
+
+cc_library(
+    name = "instrumentation",
+    srcs = [
+        "instrumentation.h",
+        "register_pass.cc",
+    ],
+    copts = ["-Werror"],
+    visibility = ["//visibility:private"],
+    deps = [
+        "//spoor/instrumentation/inject_runtime",
+        "@llvm//11.0.0",
+    ],
+)
+
+cc_test(
+    name = "register_pass_test",
+    size = "small",
+    srcs = ["register_pass_test.cc"],
+    copts = ["-Werror"],
+    visibility = ["//visibility:private"],
+    deps = [
+        ":instrumentation",
+        "@com_google_googletest//:gtest_main",
+        "@llvm//11.0.0",
+    ],
+)

--- a/spoor/instrumentation/inject_runtime/BUILD
+++ b/spoor/instrumentation/inject_runtime/BUILD
@@ -1,0 +1,38 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+
+cc_library(
+    name = "inject_runtime",
+    srcs = ["inject_runtime.cc"],
+    hdrs = ["inject_runtime.h"],
+    copts = ["-Werror"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//spoor/instrumentation:instrumentation_map_cc_proto",
+        "//util:numeric",
+        "@com_apple_swift//:demangle",
+        "@com_google_absl//absl/strings:str_format",
+        "@com_microsoft_gsl//:gsl",
+        "@llvm//11.0.0",
+    ],
+)
+
+cc_test(
+    name = "inject_runtime_test",
+    size = "small",
+    srcs = ["inject_runtime_test.cc"],
+    copts = ["-Werror"],
+    data = ["//spoor/instrumentation/inject_runtime/test_data"],
+    visibility = ["//visibility:private"],
+    deps = [
+        ":inject_runtime",
+        "//spoor/instrumentation:instrumentation_map_cc_proto",
+        "//util:numeric",
+        "@com_google_googletest//:gtest_main",
+        "@com_google_protobuf//:protobuf",
+        "@com_microsoft_gsl//:gsl",
+        "@llvm//11.0.0",
+    ],
+)

--- a/spoor/instrumentation/inject_runtime/inject_runtime.cc
+++ b/spoor/instrumentation/inject_runtime/inject_runtime.cc
@@ -1,0 +1,162 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "spoor/instrumentation/inject_runtime/inject_runtime.h"
+
+#include <algorithm>
+#include <cctype>
+#include <functional>
+#include <iterator>
+#include <string_view>
+#include <unordered_map>
+#include <utility>
+
+#include "gsl/gsl"
+#include "llvm/ADT/APInt.h"
+#include "llvm/Demangle/Demangle.h"
+#include "llvm/IR/DebugInfoMetadata.h"
+#include "llvm/IR/DerivedTypes.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/Module.h"
+#include "llvm/IR/PassManager.h"
+#include "llvm/IR/Type.h"
+#include "llvm/Passes/PassPlugin.h"
+#include "spoor/instrumentation/instrumentation_map.pb.h"
+#include "swift/Demangling/Demangle.h"
+#include "swift/Demangling/Demangler.h"
+
+namespace spoor::instrumentation::inject_runtime {
+
+constexpr std::string_view kMainFunctionName{"main"};
+constexpr std::string_view kInitializeRuntimeFunctionName{
+    "_spoor_runtime_InitializeRuntime"};
+constexpr std::string_view kDeinitializeRuntimeFunctionName{
+    "_spoor_runtime_DeinitializeRuntime"};
+constexpr std::string_view kEnableRuntimeFunctionName{
+    "_spoor_runtime_EnableRuntime"};
+constexpr std::string_view kLogFunctionEntryFunctionName{
+    "_spoor_runtime_LogFunctionEntry"};
+constexpr std::string_view kLogFunctionExitFunctionName{
+    "_spoor_runtime_LogFunctionExit"};
+
+InjectRuntime::InjectRuntime(Options options) : options_{std::move(options)} {}
+
+auto InjectRuntime::run(llvm::Module& llvm_module, llvm::ModuleAnalysisManager&
+                        /*unused*/) -> llvm::PreservedAnalyses {
+  const auto [instrumented_function_map, modified] =
+      InstrumentModule(&llvm_module);
+  instrumented_function_map.SerializeToOstream(options_.ostream);
+
+  if (modified) return llvm::PreservedAnalyses::none();
+  return llvm::PreservedAnalyses::all();
+}
+
+auto InjectRuntime::InstrumentModule(gsl::not_null<llvm::Module*> llvm_module)
+    const -> std::pair<InstrumentedFunctionMap, bool> {
+  InstrumentedFunctionMap instrumented_function_map{};
+  instrumented_function_map.set_module_id(llvm_module->getModuleIdentifier());
+  auto& function_map = *instrumented_function_map.mutable_function_map();
+
+  auto& context = llvm_module->getContext();
+  auto* void_return_type = llvm::Type::getVoidTy(context);
+  constexpr bool variadic{true};
+
+  auto* initialization_function_type =
+      llvm::FunctionType::get(void_return_type, {}, !variadic);
+  const auto initialize_runtime = llvm_module->getOrInsertFunction(
+      kInitializeRuntimeFunctionName.data(), initialization_function_type);
+  const auto deinitialize_runtime = llvm_module->getOrInsertFunction(
+      kDeinitializeRuntimeFunctionName.data(), initialization_function_type);
+
+  auto* enable_function_type =
+      llvm::FunctionType::get(void_return_type, {}, !variadic);
+  const auto enable_runtime = llvm_module->getOrInsertFunction(
+      kEnableRuntimeFunctionName.data(), enable_function_type);
+
+  auto* log_function_type = llvm::FunctionType::get(
+      void_return_type, {llvm::Type::getInt64Ty(context)}, !variadic);
+  const auto log_function_entry = llvm_module->getOrInsertFunction(
+      kLogFunctionEntryFunctionName.data(), log_function_type);
+  const auto log_function_exit = llvm_module->getOrInsertFunction(
+      kLogFunctionExitFunctionName.data(), log_function_type);
+
+  uint64 function_id{0};
+  bool modified{false};
+  for (auto& function : llvm_module->functions()) {
+    if (function.isDeclaration()) continue;
+    const auto finally = gsl::finally([&] { ++function_id; });
+
+    const auto function_name = function.getName().str();
+    const auto demangled_name = [function_name] {
+      if (swift::Demangle::isSwiftSymbol(function_name)) {
+        return swift::Demangle::demangleSymbolAsString(
+            function_name.c_str(), function_name.size(), {});
+      }
+      std::string sanitized_function_name{};
+      std::copy_if(
+          std::cbegin(function_name), std::cend(function_name),
+          std::back_inserter(sanitized_function_name),
+          [](const auto character) { return !std::iscntrl(character); });
+      return llvm::demangle(sanitized_function_name);
+    }();
+
+    const auto is_main = function_name == kMainFunctionName;
+    const auto instrument_function = [&] {
+      if (is_main ||
+          std::find(std::cbegin(options_.function_allow_list),
+                    std::cend(options_.function_allow_list),
+                    function_name) != std::cend(options_.function_allow_list)) {
+        return true;
+      }
+      const auto instruction_count = function.getInstructionCount();
+      if (instruction_count < options_.min_instruction_count_to_instrument) {
+        return false;
+      }
+      return std::find(std::cbegin(options_.function_blocklist),
+                       std::cend(options_.function_blocklist),
+                       function_name) == std::cend(options_.function_blocklist);
+    }();
+
+    FunctionInfo function_info{};
+    function_info.set_linkage_name(function_name);
+    function_info.set_demangled_name(demangled_name);
+    const auto* subprogram = function.getSubprogram();
+    if (subprogram != nullptr) {
+      function_info.set_file_name(subprogram->getFilename().str());
+      function_info.set_directory(subprogram->getDirectory().str());
+      function_info.set_line(subprogram->getLine());
+    }
+    function_info.set_instrumented(instrument_function);
+    function_map[function_id] = function_info;
+
+    modified |= instrument_function;
+    if (!instrument_function) continue;
+
+    llvm::IRBuilder builder{context};
+    builder.SetInsertPoint(&*function.getEntryBlock().getFirstInsertionPt());
+    if (is_main) {
+      if (options_.initialize_runtime) {
+        builder.CreateCall(initialize_runtime);
+        if (options_.enable_runtime) builder.CreateCall(enable_runtime);
+      }
+    }
+    builder.CreateCall(log_function_entry, {builder.getInt64(function_id)});
+    for (auto& basic_block : function) {
+      for (auto& instruction : basic_block) {
+        const auto is_return_instruction =
+            llvm::ReturnInst::classof(&instruction);
+        if (is_return_instruction) {
+          builder.SetInsertPoint(&instruction);
+          (void)log_function_exit;
+          builder.CreateCall(log_function_exit,
+                             {builder.getInt64(function_id)});
+          if (is_main) builder.CreateCall(deinitialize_runtime);
+        }
+      }
+    }
+  }
+  return {instrumented_function_map, modified};
+}
+
+}  // namespace spoor::instrumentation::inject_runtime

--- a/spoor/instrumentation/inject_runtime/inject_runtime.h
+++ b/spoor/instrumentation/inject_runtime/inject_runtime.h
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Instrument an IR module by injecting calls to Spoor's runtime library and
+// write the generated instrumented function map to the supplied output stream.
+
+#pragma once
+
+#include <filesystem>
+#include <ostream>
+#include <string>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "gsl/gsl"
+#include "llvm/IR/Module.h"
+#include "llvm/IR/PassManager.h"
+#include "llvm/Passes/PassPlugin.h"
+#include "spoor/instrumentation/instrumentation_map.pb.h"
+#include "util/numeric.h"
+
+namespace spoor::instrumentation::inject_runtime {
+
+class InjectRuntime : public llvm::PassInfoMixin<InjectRuntime> {
+ public:
+  struct Options {
+    std::filesystem::path instrumented_function_map_path;
+    std::unordered_set<std::string> function_blocklist;
+    std::unordered_set<std::string> function_allow_list;
+    std::ostream* ostream;
+    uint32 min_instruction_count_to_instrument;
+    bool initialize_runtime;
+    bool enable_runtime;
+  };
+
+  InjectRuntime() = delete;
+  explicit InjectRuntime(Options options);
+  InjectRuntime(const InjectRuntime&) = default;
+  InjectRuntime(InjectRuntime&&) noexcept = default;
+  auto operator=(const InjectRuntime&) -> InjectRuntime& = default;
+  auto operator=(InjectRuntime&&) noexcept -> InjectRuntime& = default;
+  ~InjectRuntime() = default;
+
+  // NOLINTNEXTLINE(google-runtime-references, readability-identifier-naming)
+  auto run(llvm::Module& llvm_module,
+           // NOLINTNEXTLINE(google-runtime-references)
+           llvm::ModuleAnalysisManager& module_analysis_manager)
+      -> llvm::PreservedAnalyses;
+
+ private:
+  [[nodiscard]] auto InstrumentModule(gsl::not_null<llvm::Module*> llvm_module)
+      const -> std::pair<InstrumentedFunctionMap, bool>;
+
+  Options options_;
+};
+
+}  // namespace spoor::instrumentation::inject_runtime

--- a/spoor/instrumentation/inject_runtime/inject_runtime_test.cc
+++ b/spoor/instrumentation/inject_runtime/inject_runtime_test.cc
@@ -1,0 +1,522 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "spoor/instrumentation/inject_runtime/inject_runtime.h"
+
+#include <filesystem>
+#include <limits>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <unordered_set>
+#include <vector>
+
+#include "google/protobuf/util/message_differencer.h"
+#include "gsl/gsl"
+#include "gtest/gtest.h"
+#include "llvm/IR/LLVMContext.h"
+#include "llvm/IR/Module.h"
+#include "llvm/IRReader/IRReader.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/SourceMgr.h"
+#include "llvm/Support/raw_ostream.h"
+#include "spoor/instrumentation/instrumentation_map.pb.h"
+#include "util/numeric.h"
+
+namespace {
+
+using google::protobuf::util::MessageDifferencer;
+using spoor::instrumentation::FunctionInfo;
+using spoor::instrumentation::InstrumentedFunctionMap;
+using spoor::instrumentation::inject_runtime::InjectRuntime;
+
+constexpr std::string_view kUninstrumentedIrFile{
+    "spoor/instrumentation/inject_runtime/test_data/fib.ll"};
+constexpr std::string_view kUninstrumentedIrWithDebugInfoCSourceFile{
+    "spoor/instrumentation/inject_runtime/test_data/fib_debug_c.ll"};
+constexpr std::string_view kUninstrumentedIrWithDebugInfoCppSourceFile{
+    "spoor/instrumentation/inject_runtime/test_data/fib_debug_cpp.ll"};
+constexpr std::string_view kUninstrumentedIrWithDebugInfoObjcSourceFile{
+    "spoor/instrumentation/inject_runtime/test_data/fib_debug_objc.ll"};
+constexpr std::string_view kUninstrumentedIrWithDebugInfoSwiftSourceFile{
+    "spoor/instrumentation/inject_runtime/test_data/fib_debug_swift.ll"};
+constexpr std::string_view kInstrumentedIrFile{
+    "spoor/instrumentation/inject_runtime/test_data/fib_instrumented.ll"};
+constexpr std::string_view kInstrumentedInitializedIrFile{
+    "spoor/instrumentation/inject_runtime/test_data/"
+    "fib_instrumented_initialized.ll"};
+constexpr std::string_view kInstrumentedInitializedEnabledIrFile{
+    "spoor/instrumentation/inject_runtime/test_data/"
+    "fib_instrumented_initialized_enabled.ll"};
+constexpr std::string_view kOnlyMainFunctionInstrumentedIrFile{
+    "spoor/instrumentation/inject_runtime/test_data/"
+    "fib_only_main_instrumented.ll"};
+
+auto AssertModulesEqual(gsl::not_null<llvm::Module*> module_a,
+                        gsl::not_null<llvm::Module*> module_b) -> void {
+  // Hack: Modules are equal if their IR string representations are equal,
+  // except for the module identifier and source file name. A nice side effect
+  // of this approach is that we get a diff in the error message.
+  const std::string module_a_id{module_a->getModuleIdentifier()};
+  module_a->setModuleIdentifier({});
+  const std::string module_a_source_file{module_a->getSourceFileName()};
+  module_a->setSourceFileName({});
+  const std::string module_b_id{module_b->getModuleIdentifier()};
+  module_b->setModuleIdentifier({});
+  const std::string module_b_source_file{module_b->getSourceFileName()};
+  module_b->setSourceFileName({});
+
+  std::string module_a_ir{};
+  llvm::raw_string_ostream module_a_ostream{module_a_ir};
+  module_a_ostream << *module_a;
+
+  std::string module_b_ir{};
+  llvm::raw_string_ostream module_b_ostream{module_b_ir};
+  module_b_ostream << *module_b;
+
+  ASSERT_EQ(module_a_ir, module_b_ir);
+
+  module_a->setModuleIdentifier(module_a_id);
+  module_a->setSourceFileName(module_a_source_file);
+  module_b->setModuleIdentifier(module_b_id);
+  module_b->setSourceFileName(module_b_source_file);
+}
+
+TEST(InjectRuntime, InstrumentsModule) {  // NOLINT
+  struct TestCaseConfig {
+    std::string_view expected_ir_file;
+    bool initialize_runtime;
+    bool enable_runtime;
+  };
+  const std::vector<TestCaseConfig> configs{
+      {kInstrumentedIrFile, false, false},
+      {kInstrumentedIrFile, false, true},
+      {kInstrumentedInitializedIrFile, true, false},
+      {kInstrumentedInitializedEnabledIrFile, true, true}};
+
+  for (const auto& config : configs) {
+    llvm::SMDiagnostic instrumented_module_diagnostic{};
+    llvm::LLVMContext instrumented_module_context{};
+    auto expected_instrumented_module = llvm::parseIRFile(
+        config.expected_ir_file.data(), instrumented_module_diagnostic,
+        instrumented_module_context);
+    ASSERT_NE(expected_instrumented_module, nullptr);
+
+    llvm::SMDiagnostic uninstrumented_module_diagnostic{};
+    llvm::LLVMContext uninstrumented_module_context{};
+    auto parsed_module = llvm::parseIRFile(kUninstrumentedIrFile.data(),
+                                           uninstrumented_module_diagnostic,
+                                           uninstrumented_module_context);
+    ASSERT_NE(parsed_module, nullptr);
+
+    const std::filesystem::path file_path{};
+    std::ostringstream ostream{};
+    const std::unordered_set<std::string> function_blocklist{};
+    const std::unordered_set<std::string> function_allow_list{};
+    constexpr uint32 min_instruction_count_to_instrument{0};
+    const InjectRuntime::Options options{file_path,
+                                         function_blocklist,
+                                         function_allow_list,
+                                         &ostream,
+                                         min_instruction_count_to_instrument,
+                                         config.initialize_runtime,
+                                         config.enable_runtime};
+    InjectRuntime inject_runtime{options};
+    llvm::ModuleAnalysisManager module_analysis_manager{};
+    inject_runtime.run(*parsed_module, module_analysis_manager);
+    {
+      SCOPED_TRACE("Modules are not equal.");
+      AssertModulesEqual(parsed_module.get(),
+                         expected_instrumented_module.get());
+    }
+  }
+}
+
+TEST(InjectRuntime, OutputsInstrumentedFunctionMap) {  // NOLINT
+  std::vector<std::pair<std::string_view, InstrumentedFunctionMap>> test_cases{
+      {
+          kUninstrumentedIrFile,
+          [&] {
+            InstrumentedFunctionMap expected_instrumented_function_map{};
+            expected_instrumented_function_map.set_module_id(
+                kUninstrumentedIrFile.data());
+            auto& function_map =
+                *expected_instrumented_function_map.mutable_function_map();
+
+            FunctionInfo fibonacci_function_info{};
+            fibonacci_function_info.set_linkage_name("_Z9Fibonaccii");
+            fibonacci_function_info.set_demangled_name("Fibonacci(int)");
+            fibonacci_function_info.set_instrumented(true);
+            function_map[0] = fibonacci_function_info;
+
+            FunctionInfo main_function_info{};
+            main_function_info.set_linkage_name("main");
+            main_function_info.set_demangled_name("main");
+            main_function_info.set_instrumented(true);
+            function_map[1] = main_function_info;
+
+            return expected_instrumented_function_map;
+          }(),
+      },
+      {
+          kUninstrumentedIrWithDebugInfoCSourceFile,
+          [&] {
+            InstrumentedFunctionMap expected_instrumented_function_map{};
+            expected_instrumented_function_map.set_module_id(
+                kUninstrumentedIrWithDebugInfoCSourceFile.data());
+            auto& function_map =
+                *expected_instrumented_function_map.mutable_function_map();
+
+            FunctionInfo fibonacci_function_info{};
+            fibonacci_function_info.set_linkage_name("Fibonacci");
+            fibonacci_function_info.set_demangled_name("Fibonacci");
+            fibonacci_function_info.set_file_name("fibonacci.c");
+            fibonacci_function_info.set_directory("/path/to/file");
+            fibonacci_function_info.set_line(1);
+            fibonacci_function_info.set_instrumented(true);
+            function_map[0] = fibonacci_function_info;
+
+            FunctionInfo main_function_info{};
+            main_function_info.set_linkage_name("main");
+            main_function_info.set_demangled_name("main");
+            main_function_info.set_file_name("fibonacci.c");
+            main_function_info.set_directory("/path/to/file");
+            main_function_info.set_line(6);
+            main_function_info.set_instrumented(true);
+            function_map[1] = main_function_info;
+
+            return expected_instrumented_function_map;
+          }(),
+      },
+      {
+          kUninstrumentedIrWithDebugInfoCppSourceFile,
+          [&] {
+            InstrumentedFunctionMap expected_instrumented_function_map{};
+            expected_instrumented_function_map.set_module_id(
+                kUninstrumentedIrWithDebugInfoCppSourceFile.data());
+            auto& function_map =
+                *expected_instrumented_function_map.mutable_function_map();
+
+            FunctionInfo fibonacci_function_info{};
+            fibonacci_function_info.set_linkage_name("_Z9Fibonaccii");
+            fibonacci_function_info.set_demangled_name("Fibonacci(int)");
+            fibonacci_function_info.set_file_name("fibonacci.cc");
+            fibonacci_function_info.set_directory("/path/to/file");
+            fibonacci_function_info.set_line(1);
+            fibonacci_function_info.set_instrumented(true);
+            function_map[0] = fibonacci_function_info;
+
+            FunctionInfo main_function_info{};
+            main_function_info.set_linkage_name("main");
+            main_function_info.set_demangled_name("main");
+            main_function_info.set_file_name("fibonacci.cc");
+            main_function_info.set_directory("/path/to/file");
+            main_function_info.set_line(6);
+            main_function_info.set_instrumented(true);
+            function_map[1] = main_function_info;
+
+            return expected_instrumented_function_map;
+          }(),
+      },
+      {
+          kUninstrumentedIrWithDebugInfoObjcSourceFile,
+          [&] {
+            InstrumentedFunctionMap expected_instrumented_function_map{};
+            expected_instrumented_function_map.set_module_id(
+                kUninstrumentedIrWithDebugInfoObjcSourceFile.data());
+            auto& function_map =
+                *expected_instrumented_function_map.mutable_function_map();
+
+            FunctionInfo fibonacci_function_info{};
+            fibonacci_function_info.set_linkage_name(
+                "\001+[Fibonacci compute:]");
+            fibonacci_function_info.set_demangled_name("+[Fibonacci compute:]");
+            fibonacci_function_info.set_file_name("fibonacci.m");
+            fibonacci_function_info.set_directory("/path/to/file");
+            fibonacci_function_info.set_line(6);
+            fibonacci_function_info.set_instrumented(true);
+            function_map[0] = fibonacci_function_info;
+
+            FunctionInfo main_function_info{};
+            main_function_info.set_linkage_name("main");
+            main_function_info.set_demangled_name("main");
+            main_function_info.set_file_name("fibonacci.m");
+            main_function_info.set_directory("/path/to/file");
+            main_function_info.set_line(12);
+            main_function_info.set_instrumented(true);
+            function_map[1] = main_function_info;
+
+            return expected_instrumented_function_map;
+          }(),
+      },
+      {
+          kUninstrumentedIrWithDebugInfoSwiftSourceFile,
+          [&] {
+            InstrumentedFunctionMap expected_instrumented_function_map{};
+            expected_instrumented_function_map.set_module_id(
+                kUninstrumentedIrWithDebugInfoSwiftSourceFile.data());
+            auto& function_map =
+                *expected_instrumented_function_map.mutable_function_map();
+
+            FunctionInfo fibonacci_function_info{};
+            fibonacci_function_info.set_linkage_name("$s9fibonacciAAyS2iF");
+            fibonacci_function_info.set_demangled_name(
+                "fibonacci.fibonacci(Swift.Int) -> Swift.Int");
+            fibonacci_function_info.set_file_name("fibonacci.swift");
+            fibonacci_function_info.set_directory("/path/to/file");
+            fibonacci_function_info.set_line(1);
+            fibonacci_function_info.set_instrumented(true);
+            function_map[1] = fibonacci_function_info;
+
+            FunctionInfo main_function_info{};
+            main_function_info.set_linkage_name("main");
+            main_function_info.set_demangled_name("main");
+            main_function_info.set_file_name("fibonacci.swift");
+            main_function_info.set_directory("/path/to/file");
+            // Swift automatically adds a `main` function and picks the line
+            // number.
+            main_function_info.set_line(1);
+            main_function_info.set_instrumented(true);
+            function_map[0] = main_function_info;
+
+            return expected_instrumented_function_map;
+          }(),
+      },
+  };
+  for (const auto& [ir_file, expected_instrumented_function_map] : test_cases) {
+    llvm::SMDiagnostic instrumented_module_diagnostic{};
+    llvm::LLVMContext instrumented_module_context{};
+    auto parsed_module =
+        llvm::parseIRFile(ir_file.data(), instrumented_module_diagnostic,
+                          instrumented_module_context);
+    ASSERT_NE(parsed_module, nullptr);
+
+    const std::filesystem::path file_path{};
+    std::stringstream stream{};
+    const std::unordered_set<std::string> function_blocklist{};
+    const std::unordered_set<std::string> function_allow_list{};
+    constexpr uint32 min_instruction_count_to_instrument{0};
+    constexpr bool initialize_runtime{false};
+    constexpr bool enable_runtime{true};
+    const InjectRuntime::Options options{file_path,
+                                         function_blocklist,
+                                         function_allow_list,
+                                         &stream,
+                                         min_instruction_count_to_instrument,
+                                         initialize_runtime,
+                                         enable_runtime};
+    InjectRuntime inject_runtime{options};
+    llvm::ModuleAnalysisManager module_analysis_manager{};
+    inject_runtime.run(*parsed_module, module_analysis_manager);
+
+    InstrumentedFunctionMap instrumented_function_map{};
+    instrumented_function_map.ParseFromIstream(&stream);
+
+    ASSERT_TRUE(MessageDifferencer::Equals(instrumented_function_map,
+                                           expected_instrumented_function_map));
+  }
+}
+
+TEST(InjectRuntime, FunctionBlocklist) {  // NOLINT
+  llvm::SMDiagnostic expected_module_diagnostic{};
+  llvm::LLVMContext expected_module_context{};
+  auto expected_instrumented_module =
+      llvm::parseIRFile(kOnlyMainFunctionInstrumentedIrFile.data(),
+                        expected_module_diagnostic, expected_module_context);
+  ASSERT_NE(expected_instrumented_module, nullptr);
+
+  llvm::SMDiagnostic uninstrumented_module_diagnostic{};
+  llvm::LLVMContext uninstrumented_module_context{};
+  auto parsed_module = llvm::parseIRFile(kUninstrumentedIrFile.data(),
+                                         uninstrumented_module_diagnostic,
+                                         uninstrumented_module_context);
+  ASSERT_NE(parsed_module, nullptr);
+
+  const std::filesystem::path file_path{};
+  std::ostringstream ostream{};
+  const std::unordered_set<std::string> function_blocklist{"_Z9Fibonaccii"};
+  const std::unordered_set<std::string> function_allow_list{};
+  constexpr uint32 min_instruction_count_to_instrument{0};
+  constexpr bool initialize_runtime{false};
+  constexpr bool enable_runtime{false};
+  const InjectRuntime::Options options{file_path,
+                                       function_blocklist,
+                                       function_allow_list,
+                                       &ostream,
+                                       min_instruction_count_to_instrument,
+                                       initialize_runtime,
+                                       enable_runtime};
+  InjectRuntime inject_runtime{options};
+  llvm::ModuleAnalysisManager module_analysis_manager{};
+  inject_runtime.run(*parsed_module, module_analysis_manager);
+  {
+    SCOPED_TRACE("Modules are not equal.");
+    AssertModulesEqual(parsed_module.get(), expected_instrumented_module.get());
+  }
+}
+
+TEST(InjectRuntime, FunctionAllowList) {  // NOLINT
+  llvm::SMDiagnostic expected_module_diagnostic{};
+  llvm::LLVMContext expected_module_context{};
+  auto expected_instrumented_module =
+      llvm::parseIRFile(kInstrumentedIrFile.data(), expected_module_diagnostic,
+                        expected_module_context);
+  ASSERT_NE(expected_instrumented_module, nullptr);
+
+  llvm::SMDiagnostic uninstrumented_module_diagnostic{};
+  llvm::LLVMContext uninstrumented_module_context{};
+  auto parsed_module = llvm::parseIRFile(kUninstrumentedIrFile.data(),
+                                         uninstrumented_module_diagnostic,
+                                         uninstrumented_module_context);
+  ASSERT_NE(parsed_module, nullptr);
+
+  const std::filesystem::path file_path{};
+  std::ostringstream ostream{};
+  const std::unordered_set<std::string> function_blocklist{};
+  const std::unordered_set<std::string> function_allow_list{"_Z9Fibonaccii"};
+  constexpr auto min_instruction_count_to_instrument =
+      std::numeric_limits<uint32>::max();
+  constexpr bool initialize_runtime{false};
+  constexpr bool enable_runtime{false};
+  const InjectRuntime::Options options{file_path,
+                                       function_blocklist,
+                                       function_allow_list,
+                                       &ostream,
+                                       min_instruction_count_to_instrument,
+                                       initialize_runtime,
+                                       enable_runtime};
+  InjectRuntime inject_runtime{options};
+  llvm::ModuleAnalysisManager module_analysis_manager{};
+  inject_runtime.run(*parsed_module, module_analysis_manager);
+  {
+    SCOPED_TRACE("Modules are not equal.");
+    AssertModulesEqual(parsed_module.get(), expected_instrumented_module.get());
+  }
+}
+
+TEST(InjectRuntime, FunctionAllowListOverridesBlocklist) {  // NOLINT
+  llvm::SMDiagnostic expected_module_diagnostic{};
+  llvm::LLVMContext expected_module_context{};
+  auto expected_instrumented_module =
+      llvm::parseIRFile(kInstrumentedIrFile.data(), expected_module_diagnostic,
+                        expected_module_context);
+  ASSERT_NE(expected_instrumented_module, nullptr);
+
+  llvm::SMDiagnostic uninstrumented_module_diagnostic{};
+  llvm::LLVMContext uninstrumented_module_context{};
+  auto parsed_module = llvm::parseIRFile(kUninstrumentedIrFile.data(),
+                                         uninstrumented_module_diagnostic,
+                                         uninstrumented_module_context);
+  ASSERT_NE(parsed_module, nullptr);
+
+  const std::filesystem::path file_path{};
+  std::ostringstream ostream{};
+  const std::unordered_set<std::string> function_blocklist{"_Z9Fibonaccii"};
+  const std::unordered_set<std::string> function_allow_list{"_Z9Fibonaccii"};
+  constexpr uint32 min_instruction_count_to_instrument{0};
+  constexpr bool initialize_runtime{false};
+  constexpr bool enable_runtime{false};
+  const InjectRuntime::Options options{file_path,
+                                       function_blocklist,
+                                       function_allow_list,
+                                       &ostream,
+                                       min_instruction_count_to_instrument,
+                                       initialize_runtime,
+                                       enable_runtime};
+  InjectRuntime inject_runtime{options};
+  llvm::ModuleAnalysisManager module_analysis_manager{};
+  inject_runtime.run(*parsed_module, module_analysis_manager);
+  {
+    SCOPED_TRACE("Modules are not equal.");
+    AssertModulesEqual(parsed_module.get(), expected_instrumented_module.get());
+  }
+}
+
+TEST(InjectRuntime, InstructionThreshold) {  // NOLINT
+  struct TestCaseConfig {
+    std::string_view expected_ir_file;
+    uint32 instruction_threshold;
+  };
+  const std::vector<TestCaseConfig> configs{
+      {kInstrumentedIrFile, 0},
+      {kInstrumentedIrFile, 8},
+      {kInstrumentedIrFile, 9},
+      {kOnlyMainFunctionInstrumentedIrFile, 10},
+      {kOnlyMainFunctionInstrumentedIrFile, 11}};
+  for (const auto& config : configs) {
+    llvm::SMDiagnostic expected_module_diagnostic{};
+    llvm::LLVMContext expected_module_context{};
+    auto expected_instrumented_module =
+        llvm::parseIRFile(config.expected_ir_file.data(),
+                          expected_module_diagnostic, expected_module_context);
+    ASSERT_NE(expected_instrumented_module, nullptr);
+
+    llvm::SMDiagnostic uninstrumented_module_diagnostic{};
+    llvm::LLVMContext uninstrumented_module_context{};
+    auto parsed_module = llvm::parseIRFile(kUninstrumentedIrFile.data(),
+                                           uninstrumented_module_diagnostic,
+                                           uninstrumented_module_context);
+    ASSERT_NE(parsed_module, nullptr);
+
+    const std::filesystem::path file_path{};
+    std::ostringstream ostream{};
+    const std::unordered_set<std::string> function_blocklist{};
+    const std::unordered_set<std::string> function_allow_list{};
+    constexpr bool initialize_runtime{false};
+    constexpr bool enable_runtime{false};
+    const InjectRuntime::Options options{
+        file_path,     function_blocklist,           function_allow_list,
+        &ostream,      config.instruction_threshold, initialize_runtime,
+        enable_runtime};
+    InjectRuntime inject_runtime{options};
+    llvm::ModuleAnalysisManager module_analysis_manager{};
+    inject_runtime.run(*parsed_module, module_analysis_manager);
+    {
+      SCOPED_TRACE("Modules are not equal.");
+      AssertModulesEqual(parsed_module.get(),
+                         expected_instrumented_module.get());
+    }
+  }
+}
+
+TEST(InjectRuntime, AlwaysInstrumentsMain) {  // NOLINT
+  llvm::SMDiagnostic expected_module_diagnostic{};
+  llvm::LLVMContext expected_module_context{};
+  auto expected_instrumented_module =
+      llvm::parseIRFile(kOnlyMainFunctionInstrumentedIrFile.data(),
+                        expected_module_diagnostic, expected_module_context);
+  ASSERT_NE(expected_instrumented_module, nullptr);
+
+  llvm::SMDiagnostic uninstrumented_module_diagnostic{};
+  llvm::LLVMContext uninstrumented_module_context{};
+  auto parsed_module = llvm::parseIRFile(kUninstrumentedIrFile.data(),
+                                         uninstrumented_module_diagnostic,
+                                         uninstrumented_module_context);
+  ASSERT_NE(parsed_module, nullptr);
+
+  const std::filesystem::path file_path{};
+  std::ostringstream ostream{};
+  const std::unordered_set<std::string> function_blocklist{"main",
+                                                           "_Z9Fibonaccii"};
+  const std::unordered_set<std::string> function_allow_list{};
+  constexpr auto min_instruction_count_to_instrument =
+      std::numeric_limits<uint32>::max();
+  constexpr bool initialize_runtime{false};
+  constexpr bool enable_runtime{false};
+  const InjectRuntime::Options options{file_path,
+                                       function_blocklist,
+                                       function_allow_list,
+                                       &ostream,
+                                       min_instruction_count_to_instrument,
+                                       initialize_runtime,
+                                       enable_runtime};
+  InjectRuntime inject_runtime{options};
+  llvm::ModuleAnalysisManager module_analysis_manager{};
+  inject_runtime.run(*parsed_module, module_analysis_manager);
+  {
+    SCOPED_TRACE("Modules are not equal.");
+    AssertModulesEqual(parsed_module.get(), expected_instrumented_module.get());
+  }
+}
+
+}  // namespace

--- a/spoor/instrumentation/inject_runtime/test_data/BUILD
+++ b/spoor/instrumentation/inject_runtime/test_data/BUILD
@@ -1,0 +1,18 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+filegroup(
+    name = "test_data",
+    srcs = [
+        "fib.ll",
+        "fib_debug_c.ll",
+        "fib_debug_cpp.ll",
+        "fib_debug_objc.ll",
+        "fib_debug_swift.ll",
+        "fib_instrumented.ll",
+        "fib_instrumented_initialized.ll",
+        "fib_instrumented_initialized_enabled.ll",
+        "fib_only_main_instrumented.ll",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/spoor/instrumentation/inject_runtime/test_data/fib.ll
+++ b/spoor/instrumentation/inject_runtime/test_data/fib.ll
@@ -1,0 +1,29 @@
+; Copyright (c) Microsoft Corporation.
+; Licensed under the MIT License.
+
+; // Source C++
+; auto Fibonacci(int n) -> int {
+;   if (n < 2) return n;
+;   return Fibonacci(n - 1) + Fibonacci(n - 2);
+; }
+;
+; auto main() -> int { return Fibonacci(7); }
+
+define i32 @_Z9Fibonaccii(i32 %0) {
+  %2 = icmp slt i32 %0, 2
+  br i1 %2, label %9, label %3
+3:
+  %4 = add nsw i32 %0, -1
+  %5 = tail call i32 @_Z9Fibonaccii(i32 %4)
+  %6 = add nsw i32 %0, -2
+  %7 = tail call i32 @_Z9Fibonaccii(i32 %6)
+  %8 = add nsw i32 %7, %5
+  ret i32 %8
+9:
+  ret i32 %0
+}
+
+define i32 @main() {
+  %1 = tail call i32 @_Z9Fibonaccii(i32 7)
+  ret i32 %1
+}

--- a/spoor/instrumentation/inject_runtime/test_data/fib_debug_c.ll
+++ b/spoor/instrumentation/inject_runtime/test_data/fib_debug_c.ll
@@ -1,0 +1,99 @@
+; Copyright (c) Microsoft Corporation.
+; Licensed under the MIT License.
+
+; Source program: fibonacci.c
+; 1: int Fibonacci(int n) {
+; 2:   if (n < 2) return n;
+; 3:   return Fibonacci(n - 1) + Fibonacci(n - 2);
+; 4: }
+; 5:
+; 6: int main() { return Fibonacci(7); }
+
+; ModuleID = 'fibonacci.c'
+source_filename = "fibonacci.c"
+target datalayout = "e-m:o-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-apple-macosx10.15.0"
+
+; Function Attrs: noinline nounwind optnone ssp uwtable
+define i32 @Fibonacci(i32 %0) #0 !dbg !8 {
+  %2 = alloca i32, align 4
+  %3 = alloca i32, align 4
+  store i32 %0, i32* %3, align 4
+  call void @llvm.dbg.declare(metadata i32* %3, metadata !12, metadata !DIExpression()), !dbg !13
+  %4 = load i32, i32* %3, align 4, !dbg !14
+  %5 = icmp slt i32 %4, 2, !dbg !16
+  br i1 %5, label %6, label %8, !dbg !17
+
+6:                                                ; preds = %1
+  %7 = load i32, i32* %3, align 4, !dbg !18
+  store i32 %7, i32* %2, align 4, !dbg !19
+  br label %16, !dbg !19
+
+8:                                                ; preds = %1
+  %9 = load i32, i32* %3, align 4, !dbg !20
+  %10 = sub nsw i32 %9, 1, !dbg !21
+  %11 = call i32 @Fibonacci(i32 %10), !dbg !22
+  %12 = load i32, i32* %3, align 4, !dbg !23
+  %13 = sub nsw i32 %12, 2, !dbg !24
+  %14 = call i32 @Fibonacci(i32 %13), !dbg !25
+  %15 = add nsw i32 %11, %14, !dbg !26
+  store i32 %15, i32* %2, align 4, !dbg !27
+  br label %16, !dbg !27
+
+16:                                               ; preds = %8, %6
+  %17 = load i32, i32* %2, align 4, !dbg !28
+  ret i32 %17, !dbg !28
+}
+
+; Function Attrs: nounwind readnone speculatable willreturn
+declare void @llvm.dbg.declare(metadata, metadata, metadata) #1
+
+; Function Attrs: noinline nounwind optnone ssp uwtable
+define i32 @main() #0 !dbg !29 {
+  %1 = alloca i32, align 4
+  store i32 0, i32* %1, align 4
+  %2 = call i32 @Fibonacci(i32 7), !dbg !32
+  ret i32 %2, !dbg !33
+}
+
+attributes #0 = { noinline nounwind optnone ssp uwtable "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="penryn" "target-features"="+cx16,+cx8,+fxsr,+mmx,+sahf,+sse,+sse2,+sse3,+sse4.1,+ssse3,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { nounwind readnone speculatable willreturn }
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!3, !4, !5, !6}
+!llvm.ident = !{!7}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 11.0.0", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: None, sysroot: "/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk", sdk: "MacOSX10.15.sdk")
+!1 = !DIFile(filename: "fibonacci.c", directory: "/path/to/file")
+!2 = !{}
+!3 = !{i32 7, !"Dwarf Version", i32 4}
+!4 = !{i32 2, !"Debug Info Version", i32 3}
+!5 = !{i32 1, !"wchar_size", i32 4}
+!6 = !{i32 7, !"PIC Level", i32 2}
+!7 = !{!"clang version 11.0.0"}
+!8 = distinct !DISubprogram(name: "Fibonacci", scope: !1, file: !1, line: 1, type: !9, scopeLine: 1, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
+!9 = !DISubroutineType(types: !10)
+!10 = !{!11, !11}
+!11 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!12 = !DILocalVariable(name: "n", arg: 1, scope: !8, file: !1, line: 1, type: !11)
+!13 = !DILocation(line: 1, column: 19, scope: !8)
+!14 = !DILocation(line: 2, column: 7, scope: !15)
+!15 = distinct !DILexicalBlock(scope: !8, file: !1, line: 2, column: 7)
+!16 = !DILocation(line: 2, column: 9, scope: !15)
+!17 = !DILocation(line: 2, column: 7, scope: !8)
+!18 = !DILocation(line: 2, column: 21, scope: !15)
+!19 = !DILocation(line: 2, column: 14, scope: !15)
+!20 = !DILocation(line: 3, column: 20, scope: !8)
+!21 = !DILocation(line: 3, column: 22, scope: !8)
+!22 = !DILocation(line: 3, column: 10, scope: !8)
+!23 = !DILocation(line: 3, column: 39, scope: !8)
+!24 = !DILocation(line: 3, column: 41, scope: !8)
+!25 = !DILocation(line: 3, column: 29, scope: !8)
+!26 = !DILocation(line: 3, column: 27, scope: !8)
+!27 = !DILocation(line: 3, column: 3, scope: !8)
+!28 = !DILocation(line: 4, column: 1, scope: !8)
+!29 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 6, type: !30, scopeLine: 6, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
+!30 = !DISubroutineType(types: !31)
+!31 = !{!11}
+!32 = !DILocation(line: 6, column: 21, scope: !29)
+!33 = !DILocation(line: 6, column: 14, scope: !29)

--- a/spoor/instrumentation/inject_runtime/test_data/fib_debug_cpp.ll
+++ b/spoor/instrumentation/inject_runtime/test_data/fib_debug_cpp.ll
@@ -1,0 +1,101 @@
+; Copyright (c) Microsoft Corporation.
+; Licensed under the MIT License.
+
+; Source program: fibonacci.cc
+; 1: auto Fibonacci(int n) -> int {
+; 2:   if (n < 2) return n;
+; 3:   return Fibonacci(n - 1) + Fibonacci(n - 2);
+; 4: }
+; 5: 
+; 6: auto main() -> int { return Fibonacci(7); }
+
+; ModuleID = 'fibonacci.cc'
+source_filename = "fibonacci.cc"
+target datalayout = "e-m:o-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-apple-macosx10.15.0"
+
+; Function Attrs: noinline optnone ssp uwtable
+define i32 @_Z9Fibonaccii(i32 %0) #0 !dbg !8 {
+  %2 = alloca i32, align 4
+  %3 = alloca i32, align 4
+  store i32 %0, i32* %3, align 4
+  call void @llvm.dbg.declare(metadata i32* %3, metadata !12, metadata !DIExpression()), !dbg !13
+  %4 = load i32, i32* %3, align 4, !dbg !14
+  %5 = icmp slt i32 %4, 2, !dbg !16
+  br i1 %5, label %6, label %8, !dbg !17
+
+6:                                                ; preds = %1
+  %7 = load i32, i32* %3, align 4, !dbg !18
+  store i32 %7, i32* %2, align 4, !dbg !19
+  br label %16, !dbg !19
+
+8:                                                ; preds = %1
+  %9 = load i32, i32* %3, align 4, !dbg !20
+  %10 = sub nsw i32 %9, 1, !dbg !21
+  %11 = call i32 @_Z9Fibonaccii(i32 %10), !dbg !22
+  %12 = load i32, i32* %3, align 4, !dbg !23
+  %13 = sub nsw i32 %12, 2, !dbg !24
+  %14 = call i32 @_Z9Fibonaccii(i32 %13), !dbg !25
+  %15 = add nsw i32 %11, %14, !dbg !26
+  store i32 %15, i32* %2, align 4, !dbg !27
+  br label %16, !dbg !27
+
+16:                                               ; preds = %8, %6
+  %17 = load i32, i32* %2, align 4, !dbg !28
+  ret i32 %17, !dbg !28
+}
+
+; Function Attrs: nounwind readnone speculatable willreturn
+declare void @llvm.dbg.declare(metadata, metadata, metadata) #1
+
+; Function Attrs: noinline norecurse optnone ssp uwtable
+define i32 @main() #2 !dbg !29 {
+  %1 = alloca i32, align 4
+  store i32 0, i32* %1, align 4
+  %2 = call i32 @_Z9Fibonaccii(i32 7), !dbg !32
+  ret i32 %2, !dbg !33
+}
+
+attributes #0 = { noinline optnone ssp uwtable "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "target-cpu"="penryn" "target-features"="+cx16,+cx8,+fxsr,+mmx,+sahf,+sse,+sse2,+sse3,+sse4.1,+ssse3,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { nounwind readnone speculatable willreturn }
+attributes #2 = { noinline norecurse optnone ssp uwtable "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "target-cpu"="penryn" "target-features"="+cx16,+cx8,+fxsr,+mmx,+sahf,+sse,+sse2,+sse3,+sse4.1,+ssse3,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+
+!llvm.dbg.cu = !{!0}
+!llvm.linker.options = !{}
+!llvm.module.flags = !{!3, !4, !5, !6}
+!llvm.ident = !{!7}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus_14, file: !1, producer: "clang version 10.0.1 ", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: None)
+!1 = !DIFile(filename: "fibonacci.cc", directory: "/path/to/file")
+!2 = !{}
+!3 = !{i32 7, !"Dwarf Version", i32 4}
+!4 = !{i32 2, !"Debug Info Version", i32 3}
+!5 = !{i32 1, !"wchar_size", i32 4}
+!6 = !{i32 7, !"PIC Level", i32 2}
+!7 = !{!"clang version 10.0.1 "}
+!8 = distinct !DISubprogram(name: "Fibonacci", linkageName: "_Z9Fibonaccii", scope: !1, file: !1, line: 1, type: !9, scopeLine: 1, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
+!9 = !DISubroutineType(types: !10)
+!10 = !{!11, !11}
+!11 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!12 = !DILocalVariable(name: "n", arg: 1, scope: !8, file: !1, line: 1, type: !11)
+!13 = !DILocation(line: 1, column: 20, scope: !8)
+!14 = !DILocation(line: 2, column: 7, scope: !15)
+!15 = distinct !DILexicalBlock(scope: !8, file: !1, line: 2, column: 7)
+!16 = !DILocation(line: 2, column: 9, scope: !15)
+!17 = !DILocation(line: 2, column: 7, scope: !8)
+!18 = !DILocation(line: 2, column: 21, scope: !15)
+!19 = !DILocation(line: 2, column: 14, scope: !15)
+!20 = !DILocation(line: 3, column: 20, scope: !8)
+!21 = !DILocation(line: 3, column: 22, scope: !8)
+!22 = !DILocation(line: 3, column: 10, scope: !8)
+!23 = !DILocation(line: 3, column: 39, scope: !8)
+!24 = !DILocation(line: 3, column: 41, scope: !8)
+!25 = !DILocation(line: 3, column: 29, scope: !8)
+!26 = !DILocation(line: 3, column: 27, scope: !8)
+!27 = !DILocation(line: 3, column: 3, scope: !8)
+!28 = !DILocation(line: 4, column: 1, scope: !8)
+!29 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 6, type: !30, scopeLine: 6, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
+!30 = !DISubroutineType(types: !31)
+!31 = !{!11}
+!32 = !DILocation(line: 6, column: 29, scope: !29)
+!33 = !DILocation(line: 6, column: 22, scope: !29)

--- a/spoor/instrumentation/inject_runtime/test_data/fib_debug_objc.ll
+++ b/spoor/instrumentation/inject_runtime/test_data/fib_debug_objc.ll
@@ -1,0 +1,168 @@
+; Copyright (c) Microsoft Corporation.
+; Licensed under the MIT License.
+
+; Source program: fibonacci.m
+;  1: @interface Fibonacci
+;  2: +(int)compute:(int)n;
+;  3: @end
+;  4:
+;  5: @implementation Fibonacci
+;  6: +(int)compute:(int)n {
+;  7:   if (n < 2) return n;
+;  8:   return [Fibonacci compute:n - 1] + [Fibonacci compute:n - 2];
+;  9: }
+; 10: @end
+; 11:
+; 12: int main() { return [Fibonacci compute:7]; }
+
+; ModuleID = 'fibonacci.m'
+source_filename = "fibonacci.m"
+target datalayout = "e-m:o-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-apple-macosx10.15.0"
+
+%struct._class_t = type { %struct._class_t*, %struct._class_t*, %struct._objc_cache*, i8* (i8*, i8*)**, %struct._class_ro_t* }
+%struct._objc_cache = type opaque
+%struct._class_ro_t = type { i32, i32, i32, i8*, i8*, %struct.__method_list_t*, %struct._objc_protocol_list*, %struct._ivar_list_t*, i8*, %struct._prop_list_t* }
+%struct.__method_list_t = type { i32, i32, [0 x %struct._objc_method] }
+%struct._objc_method = type { i8*, i8*, i8* }
+%struct._objc_protocol_list = type { i64, [0 x %struct._protocol_t*] }
+%struct._protocol_t = type { i8*, i8*, %struct._objc_protocol_list*, %struct.__method_list_t*, %struct.__method_list_t*, %struct.__method_list_t*, %struct.__method_list_t*, %struct._prop_list_t*, i32, i32, i8**, i8*, %struct._prop_list_t* }
+%struct._ivar_list_t = type { i32, i32, [0 x %struct._ivar_t] }
+%struct._ivar_t = type { i64*, i8*, i8*, i32, i32 }
+%struct._prop_list_t = type { i32, i32, [0 x %struct._prop_t] }
+%struct._prop_t = type { i8*, i8* }
+
+@"OBJC_CLASS_$_Fibonacci" = global %struct._class_t { %struct._class_t* @"OBJC_METACLASS_$_Fibonacci", %struct._class_t* null, %struct._objc_cache* @_objc_empty_cache, i8* (i8*, i8*)** null, %struct._class_ro_t* @"_OBJC_CLASS_RO_$_Fibonacci" }, section "__DATA, __objc_data", align 8
+@"OBJC_CLASSLIST_REFERENCES_$_" = internal global %struct._class_t* @"OBJC_CLASS_$_Fibonacci", section "__DATA,__objc_classrefs,regular,no_dead_strip", align 8
+@OBJC_METH_VAR_NAME_ = private unnamed_addr constant [9 x i8] c"compute:\00", section "__TEXT,__objc_methname,cstring_literals", align 1
+@OBJC_SELECTOR_REFERENCES_ = internal externally_initialized global i8* getelementptr inbounds ([9 x i8], [9 x i8]* @OBJC_METH_VAR_NAME_, i32 0, i32 0), section "__DATA,__objc_selrefs,literal_pointers,no_dead_strip", align 8
+@_objc_empty_cache = external global %struct._objc_cache
+@"OBJC_METACLASS_$_Fibonacci" = global %struct._class_t { %struct._class_t* @"OBJC_METACLASS_$_Fibonacci", %struct._class_t* @"OBJC_CLASS_$_Fibonacci", %struct._objc_cache* @_objc_empty_cache, i8* (i8*, i8*)** null, %struct._class_ro_t* @"_OBJC_METACLASS_RO_$_Fibonacci" }, section "__DATA, __objc_data", align 8
+@OBJC_CLASS_NAME_ = private unnamed_addr constant [10 x i8] c"Fibonacci\00", section "__TEXT,__objc_classname,cstring_literals", align 1
+@OBJC_METH_VAR_TYPE_ = private unnamed_addr constant [11 x i8] c"i20@0:8i16\00", section "__TEXT,__objc_methtype,cstring_literals", align 1
+@"_OBJC_$_CLASS_METHODS_Fibonacci" = internal global { i32, i32, [1 x %struct._objc_method] } { i32 24, i32 1, [1 x %struct._objc_method] [%struct._objc_method { i8* getelementptr inbounds ([9 x i8], [9 x i8]* @OBJC_METH_VAR_NAME_, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @OBJC_METH_VAR_TYPE_, i32 0, i32 0), i8* bitcast (i32 (i8*, i8*, i32)* @"\01+[Fibonacci compute:]" to i8*) }] }, section "__DATA, __objc_const", align 8
+@"_OBJC_METACLASS_RO_$_Fibonacci" = internal global %struct._class_ro_t { i32 3, i32 40, i32 40, i8* null, i8* getelementptr inbounds ([10 x i8], [10 x i8]* @OBJC_CLASS_NAME_, i32 0, i32 0), %struct.__method_list_t* bitcast ({ i32, i32, [1 x %struct._objc_method] }* @"_OBJC_$_CLASS_METHODS_Fibonacci" to %struct.__method_list_t*), %struct._objc_protocol_list* null, %struct._ivar_list_t* null, i8* null, %struct._prop_list_t* null }, section "__DATA, __objc_const", align 8
+@"_OBJC_CLASS_RO_$_Fibonacci" = internal global %struct._class_ro_t { i32 2, i32 0, i32 0, i8* null, i8* getelementptr inbounds ([10 x i8], [10 x i8]* @OBJC_CLASS_NAME_, i32 0, i32 0), %struct.__method_list_t* null, %struct._objc_protocol_list* null, %struct._ivar_list_t* null, i8* null, %struct._prop_list_t* null }, section "__DATA, __objc_const", align 8
+@"OBJC_LABEL_CLASS_$" = private global [1 x i8*] [i8* bitcast (%struct._class_t* @"OBJC_CLASS_$_Fibonacci" to i8*)], section "__DATA,__objc_classlist,regular,no_dead_strip", align 8
+@llvm.compiler.used = appending global [7 x i8*] [i8* bitcast (%struct._class_t** @"OBJC_CLASSLIST_REFERENCES_$_" to i8*), i8* getelementptr inbounds ([9 x i8], [9 x i8]* @OBJC_METH_VAR_NAME_, i32 0, i32 0), i8* bitcast (i8** @OBJC_SELECTOR_REFERENCES_ to i8*), i8* getelementptr inbounds ([10 x i8], [10 x i8]* @OBJC_CLASS_NAME_, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @OBJC_METH_VAR_TYPE_, i32 0, i32 0), i8* bitcast ({ i32, i32, [1 x %struct._objc_method] }* @"_OBJC_$_CLASS_METHODS_Fibonacci" to i8*), i8* bitcast ([1 x i8*]* @"OBJC_LABEL_CLASS_$" to i8*)], section "llvm.metadata"
+
+; Function Attrs: noinline optnone ssp uwtable
+define internal i32 @"\01+[Fibonacci compute:]"(i8* %0, i8* %1, i32 %2) #0 !dbg !15 {
+  %4 = alloca i32, align 4
+  %5 = alloca i8*, align 8
+  %6 = alloca i8*, align 8
+  %7 = alloca i32, align 4
+  store i8* %0, i8** %5, align 8
+  call void @llvm.dbg.declare(metadata i8** %5, metadata !25, metadata !DIExpression()), !dbg !27
+  store i8* %1, i8** %6, align 8
+  call void @llvm.dbg.declare(metadata i8** %6, metadata !28, metadata !DIExpression()), !dbg !27
+  store i32 %2, i32* %7, align 4
+  call void @llvm.dbg.declare(metadata i32* %7, metadata !30, metadata !DIExpression()), !dbg !31
+  %8 = load i32, i32* %7, align 4, !dbg !32
+  %9 = icmp slt i32 %8, 2, !dbg !34
+  br i1 %9, label %10, label %12, !dbg !35
+
+10:                                               ; preds = %3
+  %11 = load i32, i32* %7, align 4, !dbg !36
+  store i32 %11, i32* %4, align 4, !dbg !37
+  br label %26, !dbg !37
+
+12:                                               ; preds = %3
+  %13 = load %struct._class_t*, %struct._class_t** @"OBJC_CLASSLIST_REFERENCES_$_", align 8, !dbg !38
+  %14 = load i32, i32* %7, align 4, !dbg !39
+  %15 = sub nsw i32 %14, 1, !dbg !40
+  %16 = load i8*, i8** @OBJC_SELECTOR_REFERENCES_, align 8, !dbg !38, !invariant.load !2
+  %17 = bitcast %struct._class_t* %13 to i8*, !dbg !38
+  %18 = call i32 bitcast (i8* (i8*, i8*, ...)* @objc_msgSend to i32 (i8*, i8*, i32)*)(i8* %17, i8* %16, i32 %15), !dbg !38
+  %19 = load %struct._class_t*, %struct._class_t** @"OBJC_CLASSLIST_REFERENCES_$_", align 8, !dbg !41
+  %20 = load i32, i32* %7, align 4, !dbg !42
+  %21 = sub nsw i32 %20, 2, !dbg !43
+  %22 = load i8*, i8** @OBJC_SELECTOR_REFERENCES_, align 8, !dbg !41, !invariant.load !2
+  %23 = bitcast %struct._class_t* %19 to i8*, !dbg !41
+  %24 = call i32 bitcast (i8* (i8*, i8*, ...)* @objc_msgSend to i32 (i8*, i8*, i32)*)(i8* %23, i8* %22, i32 %21), !dbg !41
+  %25 = add nsw i32 %18, %24, !dbg !44
+  store i32 %25, i32* %4, align 4, !dbg !45
+  br label %26, !dbg !45
+
+26:                                               ; preds = %12, %10
+  %27 = load i32, i32* %4, align 4, !dbg !46
+  ret i32 %27, !dbg !46
+}
+
+; Function Attrs: nounwind readnone speculatable willreturn
+declare void @llvm.dbg.declare(metadata, metadata, metadata) #1
+
+; Function Attrs: nonlazybind
+declare i8* @objc_msgSend(i8*, i8*, ...) #2
+
+; Function Attrs: noinline optnone ssp uwtable
+define i32 @main() #0 !dbg !47 {
+  %1 = alloca i32, align 4
+  store i32 0, i32* %1, align 4
+  %2 = load %struct._class_t*, %struct._class_t** @"OBJC_CLASSLIST_REFERENCES_$_", align 8, !dbg !50
+  %3 = load i8*, i8** @OBJC_SELECTOR_REFERENCES_, align 8, !dbg !50, !invariant.load !2
+  %4 = bitcast %struct._class_t* %2 to i8*, !dbg !50
+  %5 = call i32 bitcast (i8* (i8*, i8*, ...)* @objc_msgSend to i32 (i8*, i8*, i32)*)(i8* %4, i8* %3, i32 7), !dbg !50
+  ret i32 %5, !dbg !51
+}
+
+attributes #0 = { noinline optnone ssp uwtable "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="penryn" "target-features"="+cx16,+cx8,+fxsr,+mmx,+sahf,+sse,+sse2,+sse3,+sse4.1,+ssse3,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { nounwind readnone speculatable willreturn }
+attributes #2 = { nonlazybind }
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!5, !6, !7, !8, !9, !10, !11, !12, !13}
+!llvm.ident = !{!14}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_ObjC, file: !1, producer: "clang version 11.0.0", isOptimized: false, runtimeVersion: 2, emissionKind: FullDebug, enums: !2, retainedTypes: !3, nameTableKind: None, sysroot: "/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk", sdk: "MacOSX10.15.sdk")
+!1 = !DIFile(filename: "fibonacci.m", directory: "/path/to/file")
+!2 = !{}
+!3 = !{!4}
+!4 = !DICompositeType(tag: DW_TAG_structure_type, name: "Fibonacci", scope: !1, file: !1, line: 1, flags: DIFlagObjcClassComplete, elements: !2, runtimeLang: DW_LANG_ObjC)
+!5 = !{i32 1, !"Objective-C Version", i32 2}
+!6 = !{i32 1, !"Objective-C Image Info Version", i32 0}
+!7 = !{i32 1, !"Objective-C Image Info Section", !"__DATA,__objc_imageinfo,regular,no_dead_strip"}
+!8 = !{i32 1, !"Objective-C Garbage Collection", i8 0}
+!9 = !{i32 1, !"Objective-C Class Properties", i32 64}
+!10 = !{i32 7, !"Dwarf Version", i32 4}
+!11 = !{i32 2, !"Debug Info Version", i32 3}
+!12 = !{i32 1, !"wchar_size", i32 4}
+!13 = !{i32 7, !"PIC Level", i32 2}
+!14 = !{!"clang version 11.0.0"}
+!15 = distinct !DISubprogram(name: "+[Fibonacci compute:]", scope: !1, file: !1, line: 6, type: !16, scopeLine: 6, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !0, retainedNodes: !2)
+!16 = !DISubroutineType(types: !17)
+!17 = !{!18, !19, !22, !18}
+!18 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!19 = !DIDerivedType(tag: DW_TAG_typedef, name: "Class", file: !1, baseType: !20, flags: DIFlagArtificial | DIFlagObjectPointer)
+!20 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !21, size: 64)
+!21 = !DICompositeType(tag: DW_TAG_structure_type, name: "objc_class", file: !1, flags: DIFlagFwdDecl)
+!22 = !DIDerivedType(tag: DW_TAG_typedef, name: "SEL", file: !1, baseType: !23, flags: DIFlagArtificial)
+!23 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !24, size: 64)
+!24 = !DICompositeType(tag: DW_TAG_structure_type, name: "objc_selector", file: !1, flags: DIFlagFwdDecl)
+!25 = !DILocalVariable(name: "self", arg: 1, scope: !15, type: !26, flags: DIFlagArtificial | DIFlagObjectPointer)
+!26 = !DIDerivedType(tag: DW_TAG_typedef, name: "Class", file: !1, baseType: !20)
+!27 = !DILocation(line: 0, scope: !15)
+!28 = !DILocalVariable(name: "_cmd", arg: 2, scope: !15, type: !29, flags: DIFlagArtificial)
+!29 = !DIDerivedType(tag: DW_TAG_typedef, name: "SEL", file: !1, baseType: !23)
+!30 = !DILocalVariable(name: "n", arg: 3, scope: !15, file: !1, line: 6, type: !18)
+!31 = !DILocation(line: 6, column: 20, scope: !15)
+!32 = !DILocation(line: 7, column: 7, scope: !33)
+!33 = distinct !DILexicalBlock(scope: !15, file: !1, line: 7, column: 7)
+!34 = !DILocation(line: 7, column: 9, scope: !33)
+!35 = !DILocation(line: 7, column: 7, scope: !15)
+!36 = !DILocation(line: 7, column: 21, scope: !33)
+!37 = !DILocation(line: 7, column: 14, scope: !33)
+!38 = !DILocation(line: 8, column: 10, scope: !15)
+!39 = !DILocation(line: 8, column: 29, scope: !15)
+!40 = !DILocation(line: 8, column: 31, scope: !15)
+!41 = !DILocation(line: 8, column: 38, scope: !15)
+!42 = !DILocation(line: 8, column: 57, scope: !15)
+!43 = !DILocation(line: 8, column: 59, scope: !15)
+!44 = !DILocation(line: 8, column: 36, scope: !15)
+!45 = !DILocation(line: 8, column: 3, scope: !15)
+!46 = !DILocation(line: 9, column: 1, scope: !15)
+!47 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 12, type: !48, scopeLine: 12, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
+!48 = !DISubroutineType(types: !49)
+!49 = !{!18}
+!50 = !DILocation(line: 12, column: 21, scope: !47)
+!51 = !DILocation(line: 12, column: 14, scope: !47)

--- a/spoor/instrumentation/inject_runtime/test_data/fib_debug_swift.ll
+++ b/spoor/instrumentation/inject_runtime/test_data/fib_debug_swift.ll
@@ -1,0 +1,134 @@
+; Copyright (c) Microsoft Corporation.
+; Licensed under the MIT License.
+
+; Source program: fibonacci.swift
+; 1: func fibonacci(_ n: Int) -> Int {
+; 2:   if (n < 2) {
+; 3:     return n;
+; 4:   }
+; 5:   return fibonacci(n - 1) + fibonacci(n - 2)
+; 6: }
+; 7:
+; 8: fibonacci(7)
+
+; ModuleID = '<swift-imported-modules>'
+source_filename = "<swift-imported-modules>"
+target datalayout = "e-m:o-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-apple-macosx10.15.0"
+
+@"\01l_entry_point" = private constant { i32 } { i32 trunc (i64 sub (i64 ptrtoint (i32 (i32, i8**)* @main to i64), i64 ptrtoint ({ i32 }* @"\01l_entry_point" to i64)) to i32) }, section "__TEXT, __swift5_entry, regular, no_dead_strip", align 4
+@"_swift_FORCE_LOAD_$_swiftCompatibility51_$_fibonacci" = weak_odr hidden constant void ()* @"_swift_FORCE_LOAD_$_swiftCompatibility51"
+@__swift_reflection_version = linkonce_odr hidden constant i16 3
+@llvm.used = appending global [4 x i8*] [i8* bitcast ({ i32 }* @"\01l_entry_point" to i8*), i8* bitcast (i16* @__swift_reflection_version to i8*), i8* bitcast (void ()** @"_swift_FORCE_LOAD_$_swiftCompatibility51_$_fibonacci" to i8*), i8* bitcast (i32 (i32, i8**)* @main to i8*)], section "llvm.metadata"
+; Function Attrs: nounwind
+define i32 @main(i32 %0, i8** nocapture readnone %1) #0 !dbg !26 {
+entry:
+  %2 = tail call swiftcc i64 @"$s9fibonacciAAyS2iF"(i64 7), !dbg !38
+  ret i32 0, !dbg !38
+}
+; Function Attrs: nounwind
+define hidden swiftcc i64 @"$s9fibonacciAAyS2iF"(i64 %0) local_unnamed_addr #0 !dbg !40 {
+entry:
+  call void @llvm.dbg.value(metadata i64 %0, metadata !44, metadata !DIExpression()), !dbg !46
+  %1 = icmp slt i64 %0, 2, !dbg !47
+  br i1 %1, label %10, label %2, !dbg !47
+
+2:                                                ; preds = %entry
+  %3 = add nsw i64 %0, -1, !dbg !50
+  %4 = tail call swiftcc i64 @"$s9fibonacciAAyS2iF"(i64 %3), !dbg !51
+  %5 = add nsw i64 %0, -2, !dbg !52
+  %6 = tail call swiftcc i64 @"$s9fibonacciAAyS2iF"(i64 %5), !dbg !53
+  %7 = tail call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 %4, i64 %6), !dbg !54
+  %8 = extractvalue { i64, i1 } %7, 0, !dbg !54
+  %9 = extractvalue { i64, i1 } %7, 1, !dbg !54
+  br i1 %9, label %12, label %10, !dbg !54, !prof !55, !misexpect !56
+
+10:                                               ; preds = %2, %entry
+  %11 = phi i64 [ %0, %entry ], [ %8, %2 ], !dbg !57
+  ret i64 %11, !dbg !57
+
+12:                                               ; preds = %2
+  tail call void asm sideeffect "", "n"(i32 0) #3, !dbg !54
+  tail call void @llvm.trap(), !dbg !58
+  unreachable, !dbg !58
+}
+; Function Attrs: nounwind readnone speculatable willreturn
+declare void @llvm.dbg.value(metadata, metadata, metadata) #1
+; Function Attrs: nounwind readnone speculatable willreturn
+declare { i64, i1 } @llvm.sadd.with.overflow.i64(i64, i64) #1
+; Function Attrs: cold noreturn nounwind
+declare void @llvm.trap() #2
+declare extern_weak void @"_swift_FORCE_LOAD_$_swiftCompatibility51"()
+
+attributes #0 = { nounwind "frame-pointer"="all" "probe-stack"="__chkstk_darwin" "target-cpu"="penryn" "target-features"="+cx16,+cx8,+fxsr,+mmx,+sahf,+sse,+sse2,+sse3,+sse4.1,+ssse3,+x87" }
+attributes #1 = { nounwind readnone speculatable willreturn }
+attributes #2 = { cold noreturn nounwind }
+attributes #3 = { nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7, !8, !9, !10}
+!llvm.dbg.cu = !{!11, !19}
+!swift.module.flags = !{!21}
+!llvm.linker.options = !{!22, !23, !24}
+!llvm.asan.globals = !{!25}
+
+!0 = !{i32 2, !"SDK Version", [3 x i32] [i32 10, i32 15, i32 6]}
+!1 = !{i32 1, !"Objective-C Version", i32 2}
+!2 = !{i32 1, !"Objective-C Image Info Version", i32 0}
+!3 = !{i32 1, !"Objective-C Image Info Section", !"__DATA,__objc_imageinfo,regular,no_dead_strip"}
+!4 = !{i32 4, !"Objective-C Garbage Collection", i32 84084480}
+!5 = !{i32 1, !"Objective-C Class Properties", i32 64}
+!6 = !{i32 7, !"Dwarf Version", i32 4}
+!7 = !{i32 2, !"Debug Info Version", i32 3}
+!8 = !{i32 1, !"wchar_size", i32 4}
+!9 = !{i32 7, !"PIC Level", i32 2}
+!10 = !{i32 1, !"Swift Version", i32 7}
+!11 = distinct !DICompileUnit(language: DW_LANG_Swift, file: !12, producer: "Apple Swift version 5.3 (swiftlang-1200.0.29.2 clang-1200.0.30.1)", isOptimized: true, runtimeVersion: 5, emissionKind: FullDebug, enums: !13, imports: !14, sysroot: "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk", sdk: "MacOSX10.15.sdk")
+!12 = !DIFile(filename: "fibonacci.swift", directory: "/path/to/file")
+!13 = !{}
+!14 = !{!15, !17}
+!15 = !DIImportedEntity(tag: DW_TAG_imported_module, scope: !12, entity: !16, file: !12)
+!16 = !DIModule(scope: null, name: "fibonacci")
+!17 = !DIImportedEntity(tag: DW_TAG_imported_module, scope: !12, entity: !18, file: !12)
+!18 = !DIModule(scope: null, name: "Swift", includePath: "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk/usr/lib/swift/Swift.swiftmodule/x86_64.swiftinterface")
+!19 = distinct !DICompileUnit(language: DW_LANG_ObjC, file: !20, producer: "Apple clang version 12.0.0 (clang-1200.0.30.1)", isOptimized: true, runtimeVersion: 2, emissionKind: FullDebug, enums: !13, nameTableKind: None, sysroot: "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk", sdk: "MacOSX10.15.sdk")
+!20 = !DIFile(filename: "<swift-imported-modules>", directory: "/path/to/file")
+!21 = !{!"standard-library", i1 false}
+!22 = !{!"-lswiftCore"}
+!23 = !{!"-lobjc"}
+!24 = !{!"-lswiftCompatibility51"}
+!25 = distinct !{null, null, null, i1 false, i1 true}
+!26 = distinct !DISubprogram(name: "main", linkageName: "main", scope: !16, file: !12, line: 1, type: !27, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !11, retainedNodes: !13)
+!27 = !DISubroutineType(types: !28)
+!28 = !{!29, !29, !31}
+!29 = !DICompositeType(tag: DW_TAG_structure_type, name: "Int32", scope: !18, file: !30, size: 32, elements: !13, runtimeLang: DW_LANG_Swift, identifier: "$ss5Int32VD")
+!30 = !DIFile(filename: "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk/usr/lib/swift/Swift.swiftmodule/x86_64.swiftinterface", directory: "")
+!31 = !DICompositeType(tag: DW_TAG_structure_type, scope: !18, file: !12, size: 64, elements: !32, runtimeLang: DW_LANG_Swift)
+!32 = !{!33}
+!33 = !DIDerivedType(tag: DW_TAG_member, scope: !18, file: !12, baseType: !34, size: 64)
+!34 = !DICompositeType(tag: DW_TAG_structure_type, name: "UnsafeMutablePointer", scope: !18, file: !12, runtimeLang: DW_LANG_Swift, templateParams: !35, identifier: "$sSpySpys4Int8VGSgGD")
+!35 = !{!36}
+!36 = !DITemplateTypeParameter(type: !37)
+!37 = !DICompositeType(tag: DW_TAG_structure_type, name: "$sSpys4Int8VGSgD", scope: !18, flags: DIFlagFwdDecl, runtimeLang: DW_LANG_Swift, identifier: "$sSpys4Int8VGSgD")
+!38 = !DILocation(line: 8, column: 1, scope: !39)
+!39 = distinct !DILexicalBlock(scope: !26, file: !12, line: 8, column: 1)
+!40 = distinct !DISubprogram(name: "fibonacci", linkageName: "$s9fibonacciAAyS2iF", scope: !16, file: !12, line: 1, type: !41, scopeLine: 1, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !11, retainedNodes: !13)
+!41 = !DISubroutineType(types: !42)
+!42 = !{!43, !43}
+!43 = !DICompositeType(tag: DW_TAG_structure_type, name: "Int", scope: !18, file: !30, size: 64, elements: !13, runtimeLang: DW_LANG_Swift, identifier: "$sSiD")
+!44 = !DILocalVariable(name: "n", arg: 1, scope: !40, file: !12, line: 1, type: !45)
+!45 = !DIDerivedType(tag: DW_TAG_const_type, baseType: !43)
+!46 = !DILocation(line: 1, column: 16, scope: !40)
+!47 = !DILocation(line: 2, column: 9, scope: !48)
+!48 = distinct !DILexicalBlock(scope: !49, file: !12, line: 2, column: 3)
+!49 = distinct !DILexicalBlock(scope: !40, file: !12, line: 1, column: 33)
+!50 = !DILocation(line: 5, column: 22, scope: !49)
+!51 = !DILocation(line: 5, column: 10, scope: !49)
+!52 = !DILocation(line: 5, column: 41, scope: !49)
+!53 = !DILocation(line: 5, column: 29, scope: !49)
+!54 = !DILocation(line: 5, column: 27, scope: !49)
+!55 = !{!"branch_weights", i32 1, i32 2000}
+!56 = !{!"misexpect", i64 1, i64 2000, i64 1}
+!57 = !DILocation(line: 6, column: 1, scope: !49)
+!58 = !DILocation(line: 0, scope: !59, inlinedAt: !54)
+!59 = distinct !DISubprogram(name: "Swift runtime failure: arithmetic overflow", scope: !16, file: !12, type: !60, flags: DIFlagArtificial, spFlags: DISPFlagDefinition, unit: !11, retainedNodes: !13)
+!60 = !DISubroutineType(types: null)

--- a/spoor/instrumentation/inject_runtime/test_data/fib_instrumented.ll
+++ b/spoor/instrumentation/inject_runtime/test_data/fib_instrumented.ll
@@ -1,0 +1,33 @@
+; Copyright (c) Microsoft Corporation.
+; Licensed under the MIT License.
+
+define i32 @_Z9Fibonaccii(i32 %0) {
+  call void @_spoor_runtime_LogFunctionEntry(i64 0)
+  %2 = icmp slt i32 %0, 2
+  br i1 %2, label %9, label %3
+3:
+  %4 = add nsw i32 %0, -1
+  %5 = tail call i32 @_Z9Fibonaccii(i32 %4)
+  %6 = add nsw i32 %0, -2
+  %7 = tail call i32 @_Z9Fibonaccii(i32 %6)
+  %8 = add nsw i32 %7, %5
+  call void @_spoor_runtime_LogFunctionExit(i64 0)
+  ret i32 %8
+9:
+  call void @_spoor_runtime_LogFunctionExit(i64 0)
+  ret i32 %0
+}
+
+define i32 @main() {
+  call void @_spoor_runtime_LogFunctionEntry(i64 1)
+  %1 = tail call i32 @_Z9Fibonaccii(i32 7)
+  call void @_spoor_runtime_LogFunctionExit(i64 1)
+  call void @_spoor_runtime_DeinitializeRuntime()
+  ret i32 %1
+}
+
+declare void @_spoor_runtime_InitializeRuntime()
+declare void @_spoor_runtime_DeinitializeRuntime()
+declare void @_spoor_runtime_EnableRuntime()
+declare void @_spoor_runtime_LogFunctionEntry(i64)
+declare void @_spoor_runtime_LogFunctionExit(i64)

--- a/spoor/instrumentation/inject_runtime/test_data/fib_instrumented_initialized.ll
+++ b/spoor/instrumentation/inject_runtime/test_data/fib_instrumented_initialized.ll
@@ -1,0 +1,34 @@
+; Copyright (c) Microsoft Corporation.
+; Licensed under the MIT License.
+
+define i32 @_Z9Fibonaccii(i32 %0) {
+  call void @_spoor_runtime_LogFunctionEntry(i64 0)
+  %2 = icmp slt i32 %0, 2
+  br i1 %2, label %9, label %3
+3:
+  %4 = add nsw i32 %0, -1
+  %5 = tail call i32 @_Z9Fibonaccii(i32 %4)
+  %6 = add nsw i32 %0, -2
+  %7 = tail call i32 @_Z9Fibonaccii(i32 %6)
+  %8 = add nsw i32 %7, %5
+  call void @_spoor_runtime_LogFunctionExit(i64 0)
+  ret i32 %8
+9:
+  call void @_spoor_runtime_LogFunctionExit(i64 0)
+  ret i32 %0
+}
+
+define i32 @main() {
+  call void @_spoor_runtime_InitializeRuntime()
+  call void @_spoor_runtime_LogFunctionEntry(i64 1)
+  %1 = tail call i32 @_Z9Fibonaccii(i32 7)
+  call void @_spoor_runtime_LogFunctionExit(i64 1)
+  call void @_spoor_runtime_DeinitializeRuntime()
+  ret i32 %1
+}
+
+declare void @_spoor_runtime_InitializeRuntime()
+declare void @_spoor_runtime_DeinitializeRuntime()
+declare void @_spoor_runtime_EnableRuntime()
+declare void @_spoor_runtime_LogFunctionEntry(i64)
+declare void @_spoor_runtime_LogFunctionExit(i64)

--- a/spoor/instrumentation/inject_runtime/test_data/fib_instrumented_initialized_enabled.ll
+++ b/spoor/instrumentation/inject_runtime/test_data/fib_instrumented_initialized_enabled.ll
@@ -1,0 +1,35 @@
+; Copyright (c) Microsoft Corporation.
+; Licensed under the MIT License.
+
+define i32 @_Z9Fibonaccii(i32 %0) {
+  call void @_spoor_runtime_LogFunctionEntry(i64 0)
+  %2 = icmp slt i32 %0, 2
+  br i1 %2, label %9, label %3
+3:
+  %4 = add nsw i32 %0, -1
+  %5 = tail call i32 @_Z9Fibonaccii(i32 %4)
+  %6 = add nsw i32 %0, -2
+  %7 = tail call i32 @_Z9Fibonaccii(i32 %6)
+  %8 = add nsw i32 %7, %5
+  call void @_spoor_runtime_LogFunctionExit(i64 0)
+  ret i32 %8
+9:
+  call void @_spoor_runtime_LogFunctionExit(i64 0)
+  ret i32 %0
+}
+
+define i32 @main() {
+  call void @_spoor_runtime_InitializeRuntime()
+  call void @_spoor_runtime_EnableRuntime()
+  call void @_spoor_runtime_LogFunctionEntry(i64 1)
+  %1 = tail call i32 @_Z9Fibonaccii(i32 7)
+  call void @_spoor_runtime_LogFunctionExit(i64 1)
+  call void @_spoor_runtime_DeinitializeRuntime()
+  ret i32 %1
+}
+
+declare void @_spoor_runtime_InitializeRuntime()
+declare void @_spoor_runtime_DeinitializeRuntime()
+declare void @_spoor_runtime_EnableRuntime()
+declare void @_spoor_runtime_LogFunctionEntry(i64)
+declare void @_spoor_runtime_LogFunctionExit(i64)

--- a/spoor/instrumentation/inject_runtime/test_data/fib_only_main_instrumented.ll
+++ b/spoor/instrumentation/inject_runtime/test_data/fib_only_main_instrumented.ll
@@ -1,0 +1,30 @@
+; Copyright (c) Microsoft Corporation.
+; Licensed under the MIT License.
+
+define i32 @_Z9Fibonaccii(i32 %0) {
+  %2 = icmp slt i32 %0, 2
+  br i1 %2, label %9, label %3
+3:
+  %4 = add nsw i32 %0, -1
+  %5 = tail call i32 @_Z9Fibonaccii(i32 %4)
+  %6 = add nsw i32 %0, -2
+  %7 = tail call i32 @_Z9Fibonaccii(i32 %6)
+  %8 = add nsw i32 %7, %5
+  ret i32 %8
+9:
+  ret i32 %0
+}
+
+define i32 @main() {
+  call void @_spoor_runtime_LogFunctionEntry(i64 1)
+  %1 = tail call i32 @_Z9Fibonaccii(i32 7)
+  call void @_spoor_runtime_LogFunctionExit(i64 1)
+  call void @_spoor_runtime_DeinitializeRuntime()
+  ret i32 %1
+}
+
+declare void @_spoor_runtime_InitializeRuntime()
+declare void @_spoor_runtime_DeinitializeRuntime()
+declare void @_spoor_runtime_EnableRuntime()
+declare void @_spoor_runtime_LogFunctionEntry(i64)
+declare void @_spoor_runtime_LogFunctionExit(i64)

--- a/spoor/instrumentation/instrumentation.h
+++ b/spoor/instrumentation/instrumentation.h
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <string_view>
+
+namespace spoor::instrumentation {
+
+constexpr std::string_view kPluginName{"inject-spoor-runtime"};
+constexpr std::string_view kPluginVersion{"0.0.0"};
+
+}  // namespace spoor::instrumentation

--- a/spoor/instrumentation/instrumentation_map.proto
+++ b/spoor/instrumentation/instrumentation_map.proto
@@ -1,0 +1,17 @@
+syntax = "proto3";
+
+package spoor.instrumentation;
+
+message FunctionInfo {
+  string linkage_name = 1;
+  string demangled_name = 2;
+  string file_name = 3;
+  string directory = 4;
+  int32 line = 5;
+  bool instrumented = 6;
+};
+
+message InstrumentedFunctionMap {
+  string module_id = 1;
+  map<uint64, FunctionInfo> function_map = 2;
+}

--- a/spoor/instrumentation/register_pass.cc
+++ b/spoor/instrumentation/register_pass.cc
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Register `InjectRuntime` with LLVM's pass manager.
+
+#include "llvm/Passes/PassBuilder.h"
+#include "llvm/Passes/PassPlugin.h"
+#include "spoor/instrumentation/inject_runtime/inject_runtime.h"
+#include "spoor/instrumentation/instrumentation.h"
+
+namespace spoor::instrumentation {
+
+auto PluginInfo() -> llvm::PassPluginLibraryInfo {
+  const auto callback = [](llvm::PassBuilder& pass_builder) {
+    const auto pipeline_parsing_callback =
+        [](llvm::StringRef pass_name, llvm::ModulePassManager& pass_manager,
+           llvm::ArrayRef<llvm::PassBuilder::PipelineElement> /*unused*/) {
+          if (pass_name != kPluginName.data()) return false;
+          inject_runtime::InjectRuntime::Options options{};
+          pass_manager.addPass(inject_runtime::InjectRuntime(options));
+          return true;
+        };
+    pass_builder.registerPipelineParsingCallback(pipeline_parsing_callback);
+  };
+  return {.APIVersion = LLVM_PLUGIN_API_VERSION,
+          .PluginName = kPluginName.data(),
+          .PluginVersion = kPluginVersion.data(),
+          .RegisterPassBuilderCallbacks = callback};
+}
+
+}  // namespace spoor::instrumentation
+
+auto llvmGetPassPluginInfo() -> llvm::PassPluginLibraryInfo {
+  return spoor::instrumentation::PluginInfo();
+}

--- a/spoor/instrumentation/register_pass_test.cc
+++ b/spoor/instrumentation/register_pass_test.cc
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "gtest/gtest.h"
+#include "llvm/Passes/PassPlugin.h"
+#include "spoor/instrumentation/instrumentation.h"
+
+namespace {
+
+TEST(RegisterPass, PassPluginInfo) {  // NOLINT
+  const auto result = llvmGetPassPluginInfo();
+  ASSERT_EQ(result.APIVersion, LLVM_PLUGIN_API_VERSION);
+  ASSERT_EQ(result.PluginName, spoor::instrumentation::kPluginName);
+  ASSERT_EQ(result.PluginVersion, spoor::instrumentation::kPluginVersion);
+  ASSERT_NE(result.RegisterPassBuilderCallbacks, nullptr);
+}
+
+}  // namespace

--- a/toolchain/crosstool/cc_toolchain_config.bzl
+++ b/toolchain/crosstool/cc_toolchain_config.bzl
@@ -24,9 +24,11 @@ FEATURES = [
                 flag_groups = ([
                     flag_group(
                         flags = [
+                            "-lc++",
                             "-lstdc++",
-                            "-lm",
                             "-lpthread",
+                            "-lm",
+                            "-lz",
                         ],
                     ),
                 ]),
@@ -45,6 +47,7 @@ FEATURES = [
                     flag_group(
                         flags = [
                             "-std=c++20",
+                            "-stdlib=libc++",
                             "-pthread",
                             "-fno-exceptions",
                             "-fno-rtti",
@@ -102,7 +105,7 @@ def linux_llvm_toolchain_impl(ctx):
         features = FEATURES,
         cxx_builtin_include_directories = [
             "/usr/include",
-            "/usr/lib/llvm-11/include/llvm",
+            "/usr/lib/llvm-11/include/c++/v1/",
             "/usr/lib/llvm-11/lib/clang/11.0.1/include",
             "/usr/lib/llvm-11/lib/clang/11.0.1/share",
         ],

--- a/toolchain/swift.BUILD
+++ b/toolchain/swift.BUILD
@@ -1,0 +1,27 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+cc_library(
+    name = "demangle",
+    srcs = glob([
+        "swift/lib/Demangling/**/*.cpp",
+        "lib/Demangling/**/*.cpp",
+        "lib/Demangling/**/*.h",
+    ]),
+    hdrs = glob([
+        "include/swift/**/*.h",
+        "include/swift/**/*.def",
+    ]),
+    copts = [
+        "-Wno-dollar-in-identifier-extension",
+        "-Wno-unused-parameter",
+        "-Werror",
+    ],
+    strip_include_prefix = "include",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@llvm//11.0.0",
+    ],
+)


### PR DESCRIPTION
Implements an LLVM pass that injects Spoor's runtime library instrumentation at the beginning and end of functions. Environment configuration will be implemented in an upcoming PR.

Introduces #54.