### PR TITLE
(Temporarily) remove Linux support in CI

### DIFF
--- a/.build/azure-pipelines.yml
+++ b/.build/azure-pipelines.yml
@@ -5,8 +5,7 @@ jobs:
 - job: build_and_test
   strategy:
     matrix:
-      linux:
-        imageName: 'ubuntu-20.04'
+      # TODO(#58): Support Linux in CI.
       mac:
         imageName: 'macos-10.15'
   pool:


### PR DESCRIPTION
Temporarily remove Linux support in CI to unblock our MVP. We're encountering lots of compiler and linker errors in #55 on Linux when trying to take a dependency on LLVM. This is in-part because we're using a very recent version of C++ (20) and LLVM (11), but need to compile with libstdc++ (used by the prebuilt LLVM Ubuntu binaries) which doesn't seem to have full support for all the language/stdlib library features used.

Introduces #58.