### PR TITLE
Strict target visibility

### DIFF
--- a/spoor/runtime/buffer/BUILD
+++ b/spoor/runtime/buffer/BUILD
@@ -16,7 +16,7 @@ cc_library(
         "unowned_buffer_slice.h",
     ],
     copts = ["-Werror"],
-    visibility = ["//visibility:public"],
+    visibility = ["//spoor/runtime:__subpackages__"],
     deps = [
         "//util:numeric",
         "//util:result",

--- a/spoor/runtime/config/BUILD
+++ b/spoor/runtime/config/BUILD
@@ -8,7 +8,7 @@ cc_library(
     srcs = ["config.cc"],
     hdrs = ["config.h"],
     copts = ["-Werror"],
-    visibility = ["//visibility:public"],
+    visibility = ["//spoor/runtime:__subpackages__"],
     deps = [
         "//spoor/runtime/buffer",
         "//spoor/runtime/trace",

--- a/spoor/runtime/config/config.cc
+++ b/spoor/runtime/config/config.cc
@@ -3,6 +3,8 @@
 
 #include "spoor/runtime/config/config.h"
 
+#include "util/env/env.h"
+
 namespace spoor::runtime::config {
 
 using util::env::GetEnvOrDefault;

--- a/spoor/runtime/event_logger/BUILD
+++ b/spoor/runtime/event_logger/BUILD
@@ -11,7 +11,7 @@ cc_library(
         "event_logger_notifier.h",
     ],
     copts = ["-Werror"],
-    visibility = ["//visibility:public"],
+    visibility = ["//spoor/runtime:__subpackages__"],
     deps = [
         "//spoor/runtime/buffer",
         "//spoor/runtime/flush_queue",
@@ -23,9 +23,10 @@ cc_library(
 
 cc_library(
     name = "event_logger_notifier_mock",
+    testonly = True,
     hdrs = ["event_logger_notifier_mock.h"],
     copts = ["-Werror"],
-    visibility = ["//visibility:public"],
+    visibility = ["//spoor/runtime:__subpackages__"],
     deps = [
         ":event_logger",
         "@com_google_googletest//:gtest",

--- a/spoor/runtime/flush_queue/BUILD
+++ b/spoor/runtime/flush_queue/BUILD
@@ -11,7 +11,7 @@ cc_library(
         "flush_queue.h",
     ],
     copts = ["-Werror"],
-    visibility = ["//visibility:public"],
+    visibility = ["//spoor/runtime:__subpackages__"],
     deps = [
         "//spoor/runtime/buffer",
         "//spoor/runtime/trace",
@@ -43,9 +43,10 @@ cc_test(
 
 cc_library(
     name = "flush_queue_mock",
+    testonly = True,
     hdrs = ["flush_queue_mock.h"],
     copts = ["-Werror"],
-    visibility = ["//visibility:public"],
+    visibility = ["//spoor/runtime:__subpackages__"],
     deps = [
         ":flush_queue",
         "@com_google_googletest//:gtest",

--- a/spoor/runtime/runtime.cc
+++ b/spoor/runtime/runtime.cc
@@ -139,10 +139,9 @@ auto _spoor_runtime_FlushedTraceFiles(
             .size = gsl::narrow_cast<int32>(file_paths.size()),
             .file_paths = file_paths.data()});
       };  // NOLINT(clang-analyzer-unix.Malloc)
-  std::error_code error_code{};
+  std::error_code error{};
   const std::filesystem::directory_iterator directory{kConfig.trace_file_path,
-                                                      error_code};
-  const auto error = static_cast<bool>(error_code);
+                                                      error};
   if (error) {
     callback_adapter({});
     return;

--- a/spoor/runtime/runtime.h
+++ b/spoor/runtime/runtime.h
@@ -4,7 +4,7 @@
 #ifndef SPOOR_RUNTIME
 #define SPOOR_RUNTIME
 
-#ifdef cplusplus
+#ifdef __cplusplus
 #include <cstdint>
 extern "C" {
 #else
@@ -108,7 +108,7 @@ void _spoor_runtime_DeleteFlushedTraceFilesOlderThan(
 // Retrieve Spoor's configuration.
 _spoor_runtime_Config _spoor_runtime_GetConfig();
 
-#ifdef cplusplus
+#ifdef __cplusplus
 }
 #endif
 

--- a/spoor/runtime/runtime_manager/BUILD
+++ b/spoor/runtime/runtime_manager/BUILD
@@ -8,10 +8,9 @@ cc_library(
     srcs = ["runtime_manager.cc"],
     hdrs = ["runtime_manager.h"],
     copts = ["-Werror"],
-    visibility = ["//visibility:public"],
+    visibility = ["//spoor/runtime:__pkg__"],
     deps = [
         "//spoor/runtime/buffer",
-        "//spoor/runtime/config",
         "//spoor/runtime/event_logger",
         "//spoor/runtime/flush_queue",
         "//spoor/runtime/trace",

--- a/spoor/runtime/trace/BUILD
+++ b/spoor/runtime/trace/BUILD
@@ -17,7 +17,7 @@ cc_library(
         "trace_writer.h",
     ],
     copts = ["-Werror"],
-    visibility = ["//visibility:public"],
+    visibility = ["//spoor/runtime:__subpackages__"],
     deps = [
         "//spoor/runtime/buffer",
         "//util:numeric",
@@ -42,12 +42,13 @@ cc_test(
 
 cc_library(
     name = "trace_mock",
+    testonly = True,
     hdrs = [
         "trace_reader_mock.h",
         "trace_writer_mock.h",
     ],
     copts = ["-Werror"],
-    visibility = ["//visibility:public"],
+    visibility = ["//spoor/runtime:__subpackages__"],
     deps = [
         ":trace",
         "@com_google_googletest//:gtest",

--- a/toolchain/compilation_database/BUILD
+++ b/toolchain/compilation_database/BUILD
@@ -19,10 +19,12 @@ cc_proto_library(
 proto_library(
     name = "compile_commands_proto",
     srcs = ["compile_commands.proto"],
+    visibility = ["//visibility:private"],
 )
 
 cc_proto_library(
     name = "compile_commands_cc_proto",
+    visibility = ["//visibility:private"],
     deps = [":compile_commands_proto"],
 )
 
@@ -31,7 +33,7 @@ cc_library(
     srcs = ["compilation_database_util.cc"],
     hdrs = ["compilation_database_util.h"],
     copts = ["-Werror"],
-    visibility = ["//visibility:public"],
+    visibility = ["//visibility:private"],
     deps = [
         ":compile_commands_cc_proto",
         ":extra_actions_base_cc_proto",
@@ -61,6 +63,7 @@ cc_binary(
         "extract_compile_command.cc",
     ],
     copts = ["-Werror"],
+    visibility = ["//visibility:public"],
     deps = [
         ":compilation_database_util",
         "@com_google_absl//absl/flags:flag",
@@ -74,6 +77,7 @@ cc_binary(
     name = "concatenate_compile_commands",
     srcs = ["concatenate_compile_commands.cc"],
     copts = ["-Werror"],
+    visibility = ["//visibility:public"],
     deps = [
         ":compilation_database_util",
         "@com_google_absl//absl/flags:flag",
@@ -96,4 +100,5 @@ extra_action(
         --output_file=$(output $(ACTION_ID).compile_command.pb)",
     out_templates = ["$(ACTION_ID).compile_command.pb"],
     tools = [":extract_compile_command"],
+    visibility = ["//visibility:public"],
 )

--- a/toolchain/copyright_header/BUILD
+++ b/toolchain/copyright_header/BUILD
@@ -6,7 +6,7 @@ load("@rules_cc//cc:defs.bzl", "cc_binary")
 filegroup(
     name = "copyright_header",
     srcs = ["copyright_header.txt"],
-    visibility = ["//visibility:public"],
+    visibility = ["//visibility:private"],
 )
 
 cc_binary(
@@ -14,6 +14,7 @@ cc_binary(
     srcs = ["add_copyright_header.cc"],
     copts = ["-Werror"],
     data = [":copyright_header"],
+    visibility = ["//visibility:public"],
     deps = [
         "//util:numeric",
         "//util:result",

--- a/toolchain/crosstool/cc_toolchain_config.bzl
+++ b/toolchain/crosstool/cc_toolchain_config.bzl
@@ -24,7 +24,6 @@ FEATURES = [
                 flag_groups = ([
                     flag_group(
                         flags = [
-                            "-lc++",
                             "-lstdc++",
                             "-lpthread",
                             "-lm",
@@ -47,7 +46,6 @@ FEATURES = [
                     flag_group(
                         flags = [
                             "-std=c++20",
-                            "-stdlib=libc++",
                             "-pthread",
                             "-fno-exceptions",
                             "-fno-rtti",
@@ -129,7 +127,7 @@ def darwin_llvm_toolchain_impl(ctx):
         ),
         tool_path(
             name = "ld",
-            path = "/usr/local/opt/llvm/bin/lld",
+            path = "/usr/local/opt/llvm/bin/ld64.lld",
         ),
         tool_path(
             name = "ar",

--- a/toolchain/swift.BUILD
+++ b/toolchain/swift.BUILD
@@ -21,7 +21,5 @@ cc_library(
     ],
     strip_include_prefix = "include",
     visibility = ["//visibility:public"],
-    deps = [
-        "@llvm//11.0.0",
-    ],
+    deps = ["@llvm//11.0.0"],
 )


### PR DESCRIPTION
Use stricter Bazel target visibility constraints in favor of `public`. #60 addresses this for `//spoor/instrumentation/...`.