### PR TITLE
Fix C++ ifdef

### DIFF
--- a/spoor/runtime/runtime.h
+++ b/spoor/runtime/runtime.h
@@ -4,7 +4,7 @@
 #ifndef SPOOR_RUNTIME
 #define SPOOR_RUNTIME
 
-#ifdef cplusplus
+#ifdef __cplusplus
 #include <cstdint>
 extern "C" {
 #else
@@ -108,7 +108,7 @@ void _spoor_runtime_DeleteFlushedTraceFilesOlderThan(
 // Retrieve Spoor's configuration.
 _spoor_runtime_Config _spoor_runtime_GetConfig();
 
-#ifdef cplusplus
+#ifdef __cplusplus
 }
 #endif
 


### PR DESCRIPTION
Oops. The C++ preprocessor value should be `__cplusplus`, not `cplusplus`.