### PR TITLE
`cc_static_library ` Bazel rule to create self-contained static libraries

### DIFF
--- a/spoor/runtime/BUILD
+++ b/spoor/runtime/BUILD
@@ -2,6 +2,7 @@
 # Licensed under the MIT License.
 
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+load("//toolchain:cc_static_library.bzl", "cc_static_library")
 
 cc_library(
     name = "runtime",
@@ -18,6 +19,11 @@ cc_library(
         "@com_google_absl//absl/strings",
         "@com_microsoft_gsl//:gsl",
     ],
+)
+
+cc_static_library(
+    name = "spoor_runtime",
+    deps = [":runtime"],
 )
 
 cc_test(

--- a/toolchain/cc_static_library.bzl
+++ b/toolchain/cc_static_library.bzl
@@ -1,0 +1,109 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""
+`cc_static_library` creates a self-contained static library from the rule's
+dependencies.
+"""
+
+load("@rules_cc//cc:action_names.bzl", "CPP_LINK_STATIC_LIBRARY_ACTION_NAME")
+load("@rules_cc//cc:toolchain_utils.bzl", "find_cpp_toolchain")
+
+def _cc_static_library_impl(ctx):
+    output_file_name = "lib%s.a" % ctx.label.name
+    output_file = ctx.actions.declare_file(output_file_name)
+
+    input_objects = []
+    for dep_target in ctx.attr.deps:
+        for dep in dep_target[CcInfo].linking_context.linker_inputs.to_list():
+            for library in dep.libraries:
+                input_objects += library.objects
+
+    cc_toolchain = find_cpp_toolchain(ctx)
+
+    feature_configuration = cc_common.configure_features(
+        ctx = ctx,
+        cc_toolchain = cc_toolchain,
+        requested_features = ctx.features,
+        unsupported_features = ctx.disabled_features,
+    )
+
+    library = cc_common.create_library_to_link(
+        actions = ctx.actions,
+        feature_configuration = feature_configuration,
+        cc_toolchain = cc_toolchain,
+        static_library = output_file,
+    )
+    linker_input = cc_common.create_linker_input(
+        owner = ctx.label,
+        libraries = depset(direct = [library]),
+    )
+
+    compilation_context = cc_common.create_compilation_context()
+    linking_context = cc_common.create_linking_context(
+        linker_inputs = depset(direct = [linker_input]),
+    )
+
+    archiver_path = cc_common.get_tool_for_action(
+        feature_configuration = feature_configuration,
+        action_name = CPP_LINK_STATIC_LIBRARY_ACTION_NAME,
+    )
+    archiver_variables = cc_common.create_link_variables(
+        cc_toolchain = cc_toolchain,
+        feature_configuration = feature_configuration,
+        output_file = output_file.path,
+        is_using_linker = False,
+    )
+    command_line = cc_common.get_memory_inefficient_command_line(
+        feature_configuration = feature_configuration,
+        action_name = CPP_LINK_STATIC_LIBRARY_ACTION_NAME,
+        variables = archiver_variables,
+    )
+
+    arguments = ctx.actions.args()
+    arguments.add_all(command_line)
+    arguments.add_all([obj.path for obj in input_objects])
+
+    env = cc_common.get_environment_variables(
+        feature_configuration = feature_configuration,
+        action_name = CPP_LINK_STATIC_LIBRARY_ACTION_NAME,
+        variables = archiver_variables,
+    )
+
+    ctx.actions.run(
+        outputs = [output_file],
+        inputs = depset(
+            direct = input_objects,
+            transitive = [cc_toolchain.all_files],
+        ),
+        executable = archiver_path,
+        arguments = [arguments],
+        mnemonic = "StaticArchive",
+        progress_message = "Creating static archive %s" % output_file_name,
+        env = env,
+    )
+
+    default_info = DefaultInfo(files = depset(direct = [output_file]))
+    this_cc_info = CcInfo(
+        compilation_context = compilation_context,
+        linking_context = linking_context,
+    )
+    deps_cc_infos = [dep[CcInfo] for dep in ctx.attr.deps]
+    cc_info = cc_common.merge_cc_infos(
+        cc_infos = [this_cc_info] + deps_cc_infos,
+    )
+    return [default_info, cc_info]
+
+cc_static_library = rule(
+    implementation = _cc_static_library_impl,
+    attrs = {
+        "deps": attr.label_list(providers = [CcInfo]),
+        "_cc_toolchain": attr.label(
+            default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
+        ),
+    },
+    fragments = ["cpp"],
+    toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],
+    incompatible_use_toolchain_transition = True,
+    doc = "Create a self-contained static library from the dependencies.",
+)


### PR DESCRIPTION
This PR implements `cc_static_library`, a Bazel rule to create self-contained static libraries for C++ targets.

A Bazel `cc_library` generates static library/archive (`.a` file) with just the object files for that rule, and lets the build system take care of linking the any transitive dependencies (i.e. other `.a` files) when constructing a binary. With this model, anyone who wants to link in Spoor's runtime library without using Bazel as a build system would need to link against over ten different static libraries (which we would need to supply) even though the runtime library's transitive dependencies are an implementation detail.

```
$ clang++ instrumented_module.ll -lruntime -lruntime_manager -lbuffer -lsome_internal_absl_strings_library ...
```

We want to give Spoor runtime library consumers a _single_ static library against which to link their instrumented binary. Surprisingly, unlike [shared/dynamic libraries](https://github.com/microsoft/spoor/blob/c2a3c38d56ac7246df9b0f1dbd71b9af04db621f/spoor/instrumentation/BUILD#L41), Bazel doesn't offer a built-in mechanism to achieve this and I couldn't find an existing open-source solution.

`cc_static_library` is a custom Bazel rule to create a static library/archive from the object files of each (transitive) dependency and combine them into a single static archive.

Now we can simply

```
$ clang++ instrumented_module.ll -lspoor_runtime
```

@aaroncrespo You might find this PR interesting.



Tip: To see how `cc_static_library` works under the hood:
```
$ bazel aquery //spoor/runtime:spoor_runtime

action 'Creating static archive libspoor_runtime.a'
  Mnemonic: StaticArchive
  Target: //spoor/runtime:spoor_runtime
  Configuration: darwin-fastbuild
  ActionKey: 722d60c2f39ee5a08ca64b8238f5b9f4cb78bd1a156a47c9b54518b88ec1c3c3
  Inputs: [bazel-out/darwin-fastbuild/bin/external/com_google_absl/absl/base/_objs/base/cycleclock.o, bazel-out/darwin-fastbuild/bin/external/com_google_absl/absl/base/_objs/base/spinloc
k.o, bazel-out/darwin-fastbuild/bin/external/com_google_absl/absl/base/_objs/base/sysinfo.o, bazel-out/darwin-fastbuild/bin/external/com_google_absl/absl/base/_objs/base/thread_identity.
o, bazel-out/darwin-fastbuild/bin/external/com_google_absl/absl/base/_objs/base/unscaledcycleclock.o, bazel-out/darwin-fastbuild/bin/external/com_google_absl/absl/base/_objs/dynamic_anno
tations/dynamic_annotations.o, bazel-out/darwin-fastbuild/bin/external/com_google_absl/absl/base/_objs/log_severity/log_severity.o, bazel-out/darwin-fastbuild/bin/external/com_google_abs
l/absl/base/_objs/raw_logging_internal/raw_logging.o, bazel-out/darwin-fastbuild/bin/external/com_google_absl/absl/base/_objs/spinlock_wait/spinlock_wait.o, bazel-out/darwin-fastbuild/bi
n/external/com_google_absl/absl/base/_objs/throw_delegate/throw_delegate.o, bazel-out/darwin-fastbuild/bin/external/com_google_absl/absl/numeric/_objs/int128/int128.o, bazel-out/darwin-f
astbuild/bin/external/com_google_absl/absl/strings/_objs/internal/escaping.o, bazel-out/darwin-fastbuild/bin/external/com_google_absl/absl/strings/_objs/internal/ostringstream.o, bazel-o
ut/darwin-fastbuild/bin/external/com_google_absl/absl/strings/_objs/internal/utf8.o, bazel-out/darwin-fastbuild/bin/external/com_google_absl/absl/strings/_objs/str_format_internal/arg.o,
 bazel-out/darwin-fastbuild/bin/external/com_google_absl/absl/strings/_objs/str_format_internal/bind.o, bazel-out/darwin-fastbuild/bin/external/com_google_absl/absl/strings/_objs/str_for
mat_internal/extension.o, bazel-out/darwin-fastbuild/bin/external/com_google_absl/absl/strings/_objs/str_format_internal/float_conversion.o, bazel-out/darwin-fastbuild/bin/external/com_g
oogle_absl/absl/strings/_objs/str_format_internal/output.o, bazel-out/darwin-fastbuild/bin/external/com_google_absl/absl/strings/_objs/str_format_internal/parser.o, bazel-out/darwin-fast
build/bin/external/com_google_absl/absl/strings/_objs/strings/ascii.o, bazel-out/darwin-fastbuild/bin/external/com_google_absl/absl/strings/_objs/strings/charconv.o, bazel-out/darwin-fas
tbuild/bin/external/com_google_absl/absl/strings/_objs/strings/charconv_bigint.o, bazel-out/darwin-fastbuild/bin/external/com_google_absl/absl/strings/_objs/strings/charconv_parse.o, baz
el-out/darwin-fastbuild/bin/external/com_google_absl/absl/strings/_objs/strings/escaping.o, bazel-out/darwin-fastbuild/bin/external/com_google_absl/absl/strings/_objs/strings/match.o, ba
zel-out/darwin-fastbuild/bin/external/com_google_absl/absl/strings/_objs/strings/memutil.o, bazel-out/darwin-fastbuild/bin/external/com_google_absl/absl/strings/_objs/strings/numbers.o,
bazel-out/darwin-fastbuild/bin/external/com_google_absl/absl/strings/_objs/strings/str_cat.o, bazel-out/darwin-fastbuild/bin/external/com_google_absl/absl/strings/_objs/strings/str_repla
ce.o, bazel-out/darwin-fastbuild/bin/external/com_google_absl/absl/strings/_objs/strings/str_split.o, bazel-out/darwin-fastbuild/bin/external/com_google_absl/absl/strings/_objs/strings/s
tring_view.o, bazel-out/darwin-fastbuild/bin/external/com_google_absl/absl/strings/_objs/strings/substitute.o, bazel-out/darwin-fastbuild/bin/spoor/runtime/_objs/runtime/runtime.o, bazel
-out/darwin-fastbuild/bin/spoor/runtime/config/_objs/config/config.o, bazel-out/darwin-fastbuild/bin/spoor/runtime/event_logger/_objs/event_logger/event_logger.o, bazel-out/darwin-fastbu
ild/bin/spoor/runtime/flush_queue/_objs/flush_queue/disk_flush_queue.o, bazel-out/darwin-fastbuild/bin/spoor/runtime/runtime_manager/_objs/runtime_manager/runtime_manager.o, bazel-out/da
rwin-fastbuild/bin/spoor/runtime/trace/_objs/trace/trace_file_reader.o, bazel-out/darwin-fastbuild/bin/spoor/runtime/trace/_objs/trace/trace_file_writer.o, bazel-out/darwin-fastbuild/bin
/util/env/_objs/env/env.o, bazel-out/darwin-fastbuild/bin/util/file_system/_objs/file_system/local_file_system.o]
  Outputs: [bazel-out/darwin-fastbuild/bin/spoor/runtime/libspoor_runtime.a]
  Command Line: (exec /usr/local/opt/llvm/bin/llvm-ar \
    rcsD \
    bazel-out/darwin-fastbuild/bin/spoor/runtime/libspoor_runtime.a \
    bazel-out/darwin-fastbuild/bin/spoor/runtime/_objs/runtime/runtime.o \
    bazel-out/darwin-fastbuild/bin/spoor/runtime/config/_objs/config/config.o \
    bazel-out/darwin-fastbuild/bin/util/env/_objs/env/env.o \
    bazel-out/darwin-fastbuild/bin/spoor/runtime/runtime_manager/_objs/runtime_manager/runtime_manager.o \
    bazel-out/darwin-fastbuild/bin/spoor/runtime/event_logger/_objs/event_logger/event_logger.o \
    bazel-out/darwin-fastbuild/bin/spoor/runtime/flush_queue/_objs/flush_queue/disk_flush_queue.o \
    bazel-out/darwin-fastbuild/bin/external/com_google_absl/absl/strings/_objs/str_format_internal/arg.o \
    bazel-out/darwin-fastbuild/bin/external/com_google_absl/absl/strings/_objs/str_format_internal/bind.o \
    bazel-out/darwin-fastbuild/bin/external/com_google_absl/absl/strings/_objs/str_format_internal/extension.o \
    bazel-out/darwin-fastbuild/bin/external/com_google_absl/absl/strings/_objs/str_format_internal/float_conversion.o \
    bazel-out/darwin-fastbuild/bin/external/com_google_absl/absl/strings/_objs/str_format_internal/output.o \
    bazel-out/darwin-fastbuild/bin/external/com_google_absl/absl/strings/_objs/str_format_internal/parser.o \
    bazel-out/darwin-fastbuild/bin/spoor/runtime/trace/_objs/trace/trace_file_reader.o \
    bazel-out/darwin-fastbuild/bin/spoor/runtime/trace/_objs/trace/trace_file_writer.o \
    bazel-out/darwin-fastbuild/bin/util/file_system/_objs/file_system/local_file_system.o \
    bazel-out/darwin-fastbuild/bin/external/com_google_absl/absl/strings/_objs/strings/ascii.o \
    bazel-out/darwin-fastbuild/bin/external/com_google_absl/absl/strings/_objs/strings/charconv.o \
    bazel-out/darwin-fastbuild/bin/external/com_google_absl/absl/strings/_objs/strings/escaping.o \
    bazel-out/darwin-fastbuild/bin/external/com_google_absl/absl/strings/_objs/strings/charconv_bigint.o \
    bazel-out/darwin-fastbuild/bin/external/com_google_absl/absl/strings/_objs/strings/charconv_parse.o \
    bazel-out/darwin-fastbuild/bin/external/com_google_absl/absl/strings/_objs/strings/memutil.o \
    bazel-out/darwin-fastbuild/bin/external/com_google_absl/absl/strings/_objs/strings/match.o \
    bazel-out/darwin-fastbuild/bin/external/com_google_absl/absl/strings/_objs/strings/numbers.o \
    bazel-out/darwin-fastbuild/bin/external/com_google_absl/absl/strings/_objs/strings/str_cat.o \
    bazel-out/darwin-fastbuild/bin/external/com_google_absl/absl/strings/_objs/strings/str_replace.o \
    bazel-out/darwin-fastbuild/bin/external/com_google_absl/absl/strings/_objs/strings/str_split.o \
    bazel-out/darwin-fastbuild/bin/external/com_google_absl/absl/strings/_objs/strings/string_view.o \
    bazel-out/darwin-fastbuild/bin/external/com_google_absl/absl/strings/_objs/strings/substitute.o \
    bazel-out/darwin-fastbuild/bin/external/com_google_absl/absl/strings/_objs/internal/escaping.o \
    bazel-out/darwin-fastbuild/bin/external/com_google_absl/absl/strings/_objs/internal/ostringstream.o \
    bazel-out/darwin-fastbuild/bin/external/com_google_absl/absl/strings/_objs/internal/utf8.o \
    bazel-out/darwin-fastbuild/bin/external/com_google_absl/absl/base/_objs/base/cycleclock.o \
    bazel-out/darwin-fastbuild/bin/external/com_google_absl/absl/base/_objs/base/spinlock.o \
    bazel-out/darwin-fastbuild/bin/external/com_google_absl/absl/base/_objs/base/sysinfo.o \
    bazel-out/darwin-fastbuild/bin/external/com_google_absl/absl/base/_objs/base/thread_identity.o \
    bazel-out/darwin-fastbuild/bin/external/com_google_absl/absl/base/_objs/base/unscaledcycleclock.o \
    bazel-out/darwin-fastbuild/bin/external/com_google_absl/absl/base/_objs/dynamic_annotations/dynamic_annotations.o \
    bazel-out/darwin-fastbuild/bin/external/com_google_absl/absl/base/_objs/spinlock_wait/spinlock_wait.o \
    bazel-out/darwin-fastbuild/bin/external/com_google_absl/absl/base/_objs/throw_delegate/throw_delegate.o \
    bazel-out/darwin-fastbuild/bin/external/com_google_absl/absl/base/_objs/raw_logging_internal/raw_logging.o \
    bazel-out/darwin-fastbuild/bin/external/com_google_absl/absl/base/_objs/log_severity/log_severity.o \
    bazel-out/darwin-fastbuild/bin/external/com_google_absl/absl/numeric/_objs/int128/int128.o)
```