### PR TITLE
Change binary trace file extension to spoor_trace

### DIFF
--- a/spoor/runtime/flush_queue/disk_flush_queue.cc
+++ b/spoor/runtime/flush_queue/disk_flush_queue.cc
@@ -152,8 +152,8 @@ auto DiskFlushQueue::TraceFilePath(const FlushInfo& flush_info) const
                              flush_info.flush_timestamp.time_since_epoch())
                              .count();
   const auto file_name =
-      absl::StrFormat("%016x-%016x-%016x.spoor", options_.session_id,
-                      flush_info.thread_id, timestamp);
+      absl::StrFormat("%016x-%016x-%016x.%s", options_.session_id,
+                      flush_info.thread_id, timestamp, kTraceFileExtension);
   return options_.trace_file_path / file_name;
 }
 

--- a/spoor/runtime/flush_queue/disk_flush_queue.h
+++ b/spoor/runtime/flush_queue/disk_flush_queue.h
@@ -11,6 +11,7 @@
 #include <mutex>
 #include <optional>
 #include <shared_mutex>
+#include <string_view>
 #include <thread>
 #include <unordered_set>
 
@@ -23,6 +24,8 @@
 #include "util/time/clock.h"
 
 namespace spoor::runtime::flush_queue {
+
+constexpr std::string_view kTraceFileExtension{"spoor_trace"};
 
 class DiskFlushQueue final
     : public FlushQueue<buffer::CircularSliceBuffer<trace::Event>> {

--- a/spoor/runtime/flush_queue/disk_flush_queue_test.cc
+++ b/spoor/runtime/flush_queue/disk_flush_queue_test.cc
@@ -24,6 +24,7 @@
 namespace {
 
 using spoor::runtime::flush_queue::DiskFlushQueue;
+using spoor::runtime::flush_queue::kTraceFileExtension;
 using spoor::runtime::trace::Event;
 using spoor::runtime::trace::Footer;
 using spoor::runtime::trace::Header;
@@ -47,8 +48,9 @@ using Pool = spoor::runtime::buffer::ReservedBufferSlicePool<Event>;
 // NOLINTNEXTLINE(fuchsia-statically-constructed-objects)
 const std::filesystem::path kTraceFilePath{"trace/file/path"};
 // NOLINTNEXTLINE(fuchsia-statically-constructed-objects)
-const std::string kTraceFilePattern{
-    R"(trace\/file\/path\/[0-9a-f]{16}-[0-9a-f]{16}-[0-9a-f]{16}\.spoor)"};
+const std::string kTraceFilePattern = absl::StrFormat(
+    R"(trace\/file\/path\/[0-9a-f]{16}-[0-9a-f]{16}-[0-9a-f]{16}\.%s)",
+    kTraceFileExtension);
 constexpr spoor::runtime::trace::SessionId kSessionId{42};
 constexpr spoor::runtime::trace::ProcessId kProcessId{1729};
 constexpr Footer kExpectedFooter{};
@@ -123,8 +125,8 @@ TEST(DiskFlushQueue, WritesEvents) {  // NOLINT
           MakeTimePoint<std::chrono::steady_clock>(steady_clock_timestamp)));
 
   const std::string trace_file_pattern =
-      absl::StrFormat(R"(trace\/file\/path\/%016x-[0-9a-f]{16}-%016x\.spoor)",
-                      kSessionId, steady_clock_timestamp);
+      absl::StrFormat(R"(trace\/file\/path\/%016x-[0-9a-f]{16}-%016x\.%s)",
+                      kSessionId, steady_clock_timestamp, kTraceFileExtension);
   const auto matches_header = [&](const Header& header) {
     // Ignore the `thread_id` because it reflects the hash of the true value
     // which cannot be determined.


### PR DESCRIPTION
Change the binary trace file extension from `.spoor` to `.spoor_trace`. We'd like to use `.spoor` for the parsed trace file. Additionally, `_trace` makes the file content more clear.