### PR TITLE
Add copyright header to protocol buffer files

### DIFF
--- a/spoor/instrumentation/instrumentation_map.proto
+++ b/spoor/instrumentation/instrumentation_map.proto
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 syntax = "proto3";
 
 package spoor.instrumentation;

--- a/toolchain/compilation_database/compile_commands.proto
+++ b/toolchain/compilation_database/compile_commands.proto
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 syntax = "proto3";
 
 package toolchain.compilation_database;

--- a/toolchain/copyright_header/add_copyright_header.cc
+++ b/toolchain/copyright_header/add_copyright_header.cc
@@ -37,6 +37,7 @@ const std::unordered_map<std::string, std::string> kFileExtensionComment{
     {"js", "//"},
     {"jsx", "//"},
     {"ll", ";"},
+    {"proto", "//"},
     {"sh", "#"},
     {"ts", "//"},
     {"tsx", "//"},


### PR DESCRIPTION
Enforce the copyright header in ".proto" (protocol buffer) files.