### PR TITLE
Remove config dependency from runtime manager

### DIFF
--- a/spoor/runtime/runtime_manager/BUILD
+++ b/spoor/runtime/runtime_manager/BUILD
@@ -30,7 +30,6 @@ cc_test(
     deps = [
         ":runtime_manager",
         "//spoor/runtime/buffer",
-        "//spoor/runtime/config",
         "//spoor/runtime/event_logger",
         "//spoor/runtime/flush_queue:flush_queue_mock",
         "//spoor/runtime/trace",

--- a/spoor/runtime/runtime_manager/runtime_manager_test.cc
+++ b/spoor/runtime/runtime_manager/runtime_manager_test.cc
@@ -15,7 +15,6 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "spoor/runtime/buffer/circular_slice_buffer.h"
-#include "spoor/runtime/config/config.h"
 #include "spoor/runtime/event_logger/event_logger.h"
 #include "spoor/runtime/flush_queue/flush_queue_mock.h"
 #include "spoor/runtime/trace/trace_reader_mock.h"


### PR DESCRIPTION
Remove the runtime config dependency from the runtime manager tests.