### PR TITLE
Add copyright header to more files

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 ---
 BasedOnStyle: Google
 ---

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 # cppcoreguidelines-init-variables
 #   Appears not to support the {} default initializer.
 # fuchsia-default-arguments

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,4 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 dist/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 # Bazel
 .bazelrc
 bazel-*

--- a/toolchain/copyright_header/add_copyright_header.cc
+++ b/toolchain/copyright_header/add_copyright_header.cc
@@ -24,23 +24,12 @@ const std::string kCopyrightHeaderFile{
     "toolchain/copyright_header/copyright_header.txt"};
 // NOLINTNEXTLINE(fuchsia-statically-constructed-objects)
 const std::unordered_map<std::string, std::string> kFileExtensionComment{
-    {".clang-format", "#"},
-    {".clang-tidy", "#"},
-    {".gitignore", "#"},
-    {"BUILD", "#"},
-    {"WORKSPACE", "#"},
-    {"bazelrc", "#"},
-    {"bzl", "#"},
-    {"c", "//"},
-    {"cc", "//"},
-    {"h", "//"},
-    {"js", "//"},
-    {"jsx", "//"},
-    {"ll", ";"},
-    {"proto", "//"},
-    {"sh", "#"},
-    {"ts", "//"},
-    {"tsx", "//"},
+    {"BUILD", "#"},        {"WORKSPACE", "#"},  {"bazelrc", "#"},
+    {"bzl", "#"},          {"c", "//"},         {"cc", "//"},
+    {"clang-format", "#"}, {"clang-tidy", "#"}, {"eslintignore", "#"},
+    {"gitignore", "#"},    {"h", "//"},         {"js", "//"},
+    {"jsx", "//"},         {"ll", ";"},         {"proto", "//"},
+    {"sh", "#"},           {"ts", "//"},        {"tsx", "//"},
     {"yml", "#"}};
 // NOLINTNEXTLINE(fuchsia-statically-constructed-objects)
 const std::unordered_set<std::string> kPathBlocklist{
@@ -54,9 +43,6 @@ auto AddCopyrightHeaderToFile(const std::filesystem::path& path,
     const auto& file_name = path.filename();
     if (file_name.has_extension()) {
       return file_name.extension().string().substr(1);
-    }
-    if (!file_name.empty() && file_name.string().at(0) == '.') {
-      return file_name.string().substr(1);
     }
     return file_name.string();
   }();


### PR DESCRIPTION
* Fixes the copyright header logic for `.clang-format`, `.clang-tidy`, and `.gitignore`.
* Adds a copyright header to `.eslintignore` files.