### PR TITLE
Runtime manager benchmark

### DIFF
--- a/spoor/runtime/flush_queue/BUILD
+++ b/spoor/runtime/flush_queue/BUILD
@@ -42,6 +42,33 @@ cc_test(
 )
 
 cc_library(
+    name = "black_hole_flush_queue",
+    srcs = ["black_hole_flush_queue.cc"],
+    hdrs = ["black_hole_flush_queue.h"],
+    copts = ["-Werror"],
+    visibility = ["//spoor/runtime:__subpackages__"],
+    deps = [
+        ":flush_queue",
+        "//spoor/runtime/buffer",
+        "//spoor/runtime/trace",
+    ],
+)
+
+cc_test(
+    name = "black_hole_flush_queue_test",
+    size = "small",
+    srcs = ["black_hole_flush_queue_test.cc"],
+    copts = ["-Werror"],
+    visibility = ["//visibility:private"],
+    deps = [
+        ":black_hole_flush_queue",
+        "//spoor/runtime/buffer",
+        "//spoor/runtime/trace",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
     name = "flush_queue_mock",
     testonly = True,
     hdrs = ["flush_queue_mock.h"],

--- a/spoor/runtime/flush_queue/black_hole_flush_queue.cc
+++ b/spoor/runtime/flush_queue/black_hole_flush_queue.cc
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "spoor/runtime/flush_queue/black_hole_flush_queue.h"
+
+#include <functional>
+
+namespace spoor::runtime::flush_queue {
+
+auto BlackHoleFlushQueue::Run() -> void {}
+
+auto BlackHoleFlushQueue::Enqueue(Buffer&& /*unused*/) -> void {}
+
+auto BlackHoleFlushQueue::DrainAndStop() -> void {}
+
+auto BlackHoleFlushQueue::Flush(std::function<void()> completion) -> void {
+  if (completion != nullptr) completion();
+}
+
+auto BlackHoleFlushQueue::Clear() -> void{};
+
+// A member function is required to conform to `FlushQueue`'s interface.
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
+auto BlackHoleFlushQueue::Size() const -> SizeType { return 0; }
+
+// A member function is required to conform to `FlushQueue`'s interface.
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
+auto BlackHoleFlushQueue::Empty() const -> bool { return true; }
+
+}  // namespace spoor::runtime::flush_queue

--- a/spoor/runtime/flush_queue/black_hole_flush_queue.h
+++ b/spoor/runtime/flush_queue/black_hole_flush_queue.h
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <functional>
+
+#include "spoor/runtime/buffer/circular_slice_buffer.h"
+#include "spoor/runtime/flush_queue/flush_queue.h"
+#include "spoor/runtime/trace/trace.h"
+
+namespace spoor::runtime::flush_queue {
+
+class BlackHoleFlushQueue final
+    : public FlushQueue<buffer::CircularSliceBuffer<trace::Event>> {
+ public:
+  using Buffer = buffer::CircularSliceBuffer<trace::Event>;
+  using SizeType = Buffer::SizeType;
+
+  auto Run() -> void override;
+  auto Enqueue(Buffer&& /*unused*/) -> void override;
+  auto DrainAndStop() -> void override;
+  auto Flush(std::function<void()> completion) -> void override;
+  auto Clear() -> void override;
+
+  [[nodiscard]] auto Size() const -> SizeType;
+  [[nodiscard]] auto Empty() const -> bool;
+};
+
+}  // namespace spoor::runtime::flush_queue

--- a/spoor/runtime/flush_queue/black_hole_flush_queue_test.cc
+++ b/spoor/runtime/flush_queue/black_hole_flush_queue_test.cc
@@ -1,0 +1,66 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "spoor/runtime/flush_queue/black_hole_flush_queue.h"
+
+#include <future>
+
+#include "gtest/gtest.h"
+#include "spoor/runtime/buffer/circular_slice_buffer.h"
+#include "spoor/runtime/buffer/reserved_buffer_slice_pool.h"
+#include "spoor/runtime/trace/trace.h"
+
+namespace {
+
+using spoor::runtime::flush_queue::BlackHoleFlushQueue;
+using spoor::runtime::trace::Event;
+using Buffer = spoor::runtime::buffer::CircularSliceBuffer<Event>;
+using Pool = spoor::runtime::buffer::ReservedBufferSlicePool<Event>;
+
+TEST(BlackHoleFlushQueue, Run) {  // NOLINT
+  BlackHoleFlushQueue flush_queue{};
+  flush_queue.Run();
+}
+
+TEST(BlackHoleFlushQueue, Enqueue) {  // NOLINT
+  constexpr auto capacity{0};
+  Pool pool{{.max_slice_capacity = capacity, .capacity = capacity}};
+  Buffer buffer{{.buffer_slice_pool = &pool, .capacity = capacity}};
+  BlackHoleFlushQueue flush_queue{};
+  flush_queue.Enqueue(std::move(buffer));
+}
+
+TEST(BlackHoleFlushQueue, DrainAndStop) {  // NOLINT
+  BlackHoleFlushQueue flush_queue{};
+  flush_queue.DrainAndStop();
+}
+
+TEST(BlackHoleFlushQueue, Flush) {  // NOLINT
+  BlackHoleFlushQueue flush_queue{};
+  std::promise<void> promise{};
+  flush_queue.Flush([&promise] { promise.set_value(); });
+  auto future = promise.get_future();
+  future.wait();
+}
+
+TEST(BlackHoleFlushQueue, FlushWithNullptr) {  // NOLINT
+  BlackHoleFlushQueue flush_queue{};
+  flush_queue.Flush({});
+}
+
+TEST(BlackHoleFlushQueue, Clear) {  // NOLINT
+  BlackHoleFlushQueue flush_queue{};
+  flush_queue.Clear();
+}
+
+TEST(BlackHoleFlushQueue, Size) {  // NOLINT
+  BlackHoleFlushQueue flush_queue{};
+  ASSERT_EQ(flush_queue.Size(), 0);
+}
+
+TEST(BlackHoleFlushQueue, Empty) {  // NOLINT
+  BlackHoleFlushQueue flush_queue{};
+  ASSERT_TRUE(flush_queue.Empty());
+}
+
+}  // namespace

--- a/spoor/runtime/flush_queue/disk_flush_queue.h
+++ b/spoor/runtime/flush_queue/disk_flush_queue.h
@@ -8,6 +8,7 @@
 #include <cstddef>
 #include <deque>
 #include <filesystem>
+#include <functional>
 #include <mutex>
 #include <optional>
 #include <shared_mutex>
@@ -54,9 +55,9 @@ class DiskFlushQueue final
   ~DiskFlushQueue() override;
 
   auto Run() -> void override;
+  auto Enqueue(Buffer&& buffer) -> void override;
   // Waits for the queue to empty synchronously. Buffers will be retained until
   // the deadline or until the queue is flushed or cleared.
-  auto Enqueue(Buffer&& buffer) -> void override;
   auto DrainAndStop() -> void override;
   auto Flush(std::function<void()> completion) -> void override;
   auto Clear() -> void override;

--- a/spoor/runtime/runtime_manager/BUILD
+++ b/spoor/runtime/runtime_manager/BUILD
@@ -39,3 +39,18 @@ cc_test(
         "@com_google_googletest//:gtest_main",
     ],
 )
+
+cc_binary(
+    name = "runtime_manager_benchmark",
+    srcs = ["runtime_manager_benchmark.cc"],
+    copts = ["-Werror"],
+    visibility = ["//visibility:private"],
+    deps = [
+        ":runtime_manager",
+        "//spoor/runtime/flush_queue:black_hole_flush_queue",
+        "//util:numeric",
+        "//util/time:clock",
+        "@com_google_benchmark//:benchmark",
+        "@com_microsoft_gsl//:gsl",
+    ],
+)

--- a/spoor/runtime/runtime_manager/runtime_manager_benchmark.cc
+++ b/spoor/runtime/runtime_manager/runtime_manager_benchmark.cc
@@ -1,0 +1,209 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include <functional>
+#include <thread>
+#include <vector>
+
+#include "benchmark/benchmark.h"
+#include "external/com_google_benchmark/_virtual_includes/benchmark/benchmark/benchmark.h"
+#include "gsl/gsl"
+#include "spoor/runtime/flush_queue/black_hole_flush_queue.h"
+#include "spoor/runtime/runtime_manager/runtime_manager.h"
+#include "spoor/runtime/trace/trace.h"
+#include "util/numeric.h"
+#include "util/time/clock.h"
+
+namespace {
+
+using spoor::runtime::flush_queue::BlackHoleFlushQueue;
+using spoor::runtime::runtime_manager::RuntimeManager;
+using spoor::runtime::trace::Event;
+
+constexpr bool kFlushAllEvents{true};
+// NOLINTNEXTLINE(fuchsia-statically-constructed-objects)
+const std::vector<int64> kFibonacciArguments{0, 10, 20, 30};
+// NOLINTNEXTLINE(fuchsia-statically-constructed-objects)
+const std::vector<int64> kThreadCounts{1, 2, 4, 16};
+// NOLINTNEXTLINE(fuchsia-statically-constructed-objects)
+const std::vector<std::vector<int64>> kNAndThreadCount{kFibonacciArguments,
+                                                       kThreadCounts};
+
+// NOLINTNEXTLINE(misc-no-recursion)
+auto FibonacciUninstrumented(const uint64 n,
+                             gsl::not_null<RuntimeManager*> runtime_manager)
+    -> uint64 {
+  if (n < 2) return n;
+  return FibonacciUninstrumented(n - 1, runtime_manager) +
+         FibonacciUninstrumented(n - 2, runtime_manager);
+}
+
+// NOLINTNEXTLINE(misc-no-recursion)
+auto FibonacciInstrumented(const uint64 n,
+                           gsl::not_null<RuntimeManager*> runtime_manager)
+    -> uint64 {
+  constexpr uint64 function_id{42};
+  runtime_manager->LogEvent(Event::Type::kFunctionEntry, function_id);
+  if (n < 2) {
+    runtime_manager->LogEvent(Event::Type::kFunctionExit, function_id);
+    return n;
+  }
+  const auto result = FibonacciInstrumented(n - 1, runtime_manager) +
+                      FibonacciInstrumented(n - 2, runtime_manager);
+  runtime_manager->LogEvent(Event::Type::kFunctionExit, function_id);
+  return result;
+}
+
+// This linear-time implementation is simple, exact, and performant enough for
+// our needs. A floating point closed-form solution also exists, as do
+// techniques to do the computation at compile-time.
+auto FibonacciEfficient(const uint64 n) -> uint64 {
+  uint64 a{1};
+  uint64 b{1};
+  for (uint64 i{1}; i < n; ++i) {
+    const auto c = a + b;
+    a = b;
+    b = c;
+  }
+  return b;
+}
+
+auto FibonacciRecursiveCallCount(const uint64 n) -> uint64 {
+  // The number of function calls needed to recursively compute the nth
+  // Fibonacci number is linearly proportional to the nth Fibonacci number.
+  //
+  // let f(n) == Fibonacci(n)
+  // let g(n) == FibonacciRecursiveCallCount(n)
+  //
+  // Proof that g(n) = 2 * f(n) - 1
+  //
+  // n == 0:    g(0) = 1
+  // n == 1:    g(1) = 1
+  // Otherwise: g(n) = 1 + g(n - 1) + g(n - 2)
+  //                 ^ This function call plus the number of function calls to
+  //                   compute f(n - 1) plus the number of function calls to
+  //                   compute f(n - 2).
+  //
+  // Base case (n == 0 and n == 1)
+  // g(n) = 1
+  //      = 2 * 1 - 1
+  //      = 2 * f(n) - 1
+  //
+  // Inductive step (n >= 2)
+  // g(n + 1) = 1 + g(n) + g(n - 1)
+  //          = 1 + (2 * f(n) - 1) + (2 * f(n - 1) - 1)
+  //          = 2 * f(n) + 2 * f(n - 1) - 1
+  //          = 2 * f(n + 1) - 1
+  return 2 * FibonacciEfficient(n) - 1;
+}
+
+// NOLINTNEXTLINE(google-runtime-references)
+auto BenchmarkThreadCreation(benchmark::State& state) -> void {
+  constexpr uint64 n{0};
+  const auto fibonacci_function_calls = FibonacciRecursiveCallCount(n);
+  const auto event_count_per_thread = 2 * fibonacci_function_calls;
+  const auto thread_count = state.range(0);
+  util::time::SteadyClock steady_clock{};
+  BlackHoleFlushQueue flush_queue{};
+  RuntimeManager runtime_manager{
+      {.steady_clock = &steady_clock,
+       .flush_queue = &flush_queue,
+       .thread_event_buffer_capacity = event_count_per_thread,
+       .reserved_pool_capacity = thread_count * event_count_per_thread,
+       .reserved_pool_max_slice_capacity = event_count_per_thread,
+       .dynamic_pool_capacity = 0,
+       .dynamic_pool_max_slice_capacity = 0,
+       .dynamic_pool_borrow_cas_attempts = 1,
+       .max_buffer_flush_attempts = 1,
+       .flush_all_events = kFlushAllEvents}};
+  std::vector<std::thread> threads{};
+  threads.reserve(thread_count);
+  for (auto _ : state) {  // NOLINT(clang-analyzer-deadcode.DeadStores)
+    for (auto thread{0}; thread < thread_count; ++thread) {
+      threads.emplace_back(FibonacciInstrumented, 0, &runtime_manager);
+    }
+    std::for_each(std::begin(threads), std::end(threads), [](auto& thread) {
+      if (thread.joinable()) thread.join();
+    });
+    threads.clear();
+  }
+}
+
+BENCHMARK(BenchmarkThreadCreation)  // NOLINT
+    ->ArgsProduct({kThreadCounts});
+
+// NOLINTNEXTLINE(google-runtime-references)
+auto BenchmarkFibonacciUninstrumented(benchmark::State& state) -> void {
+  const auto n = state.range(0);
+  const auto fibonacci_function_calls = FibonacciRecursiveCallCount(n);
+  const auto event_count_per_thread = 2 * fibonacci_function_calls;
+  const auto thread_count = state.range(1);
+  util::time::SteadyClock steady_clock{};
+  BlackHoleFlushQueue flush_queue{};
+  RuntimeManager runtime_manager{
+      {.steady_clock = &steady_clock,
+       .flush_queue = &flush_queue,
+       .thread_event_buffer_capacity = event_count_per_thread,
+       .reserved_pool_capacity = thread_count * event_count_per_thread,
+       .reserved_pool_max_slice_capacity = event_count_per_thread,
+       .dynamic_pool_capacity = 0,
+       .dynamic_pool_max_slice_capacity = 0,
+       .dynamic_pool_borrow_cas_attempts = 1,
+       .max_buffer_flush_attempts = 1,
+       .flush_all_events = kFlushAllEvents}};
+  std::vector<std::thread> threads{};
+  threads.reserve(thread_count);
+  for (auto _ : state) {  // NOLINT(clang-analyzer-deadcode.DeadStores)
+    for (auto thread{0}; thread < thread_count; ++thread) {
+      threads.emplace_back(FibonacciUninstrumented, n, &runtime_manager);
+    }
+    std::for_each(std::begin(threads), std::end(threads), [](auto& thread) {
+      if (thread.joinable()) thread.join();
+    });
+  }
+}
+
+BENCHMARK(BenchmarkFibonacciUninstrumented)  // NOLINT
+    ->ArgsProduct(kNAndThreadCount);
+
+// NOLINTNEXTLINE(google-runtime-references)
+auto BenchmarkFibonacciInstrumented(benchmark::State& state) -> void {
+  const auto n = state.range(0);
+  const auto fibonacci_function_calls = FibonacciRecursiveCallCount(n);
+  const auto event_count_per_thread = 2 * fibonacci_function_calls;
+  const auto thread_count = state.range(1);
+  util::time::SteadyClock steady_clock{};
+  BlackHoleFlushQueue flush_queue{};
+  RuntimeManager runtime_manager{
+      {.steady_clock = &steady_clock,
+       .flush_queue = &flush_queue,
+       .thread_event_buffer_capacity = event_count_per_thread,
+       .reserved_pool_capacity = thread_count * event_count_per_thread,
+       .reserved_pool_max_slice_capacity = event_count_per_thread,
+       .dynamic_pool_capacity = 0,
+       .dynamic_pool_max_slice_capacity = 0,
+       .dynamic_pool_borrow_cas_attempts = 1,
+       .max_buffer_flush_attempts = 1,
+       .flush_all_events = kFlushAllEvents}};
+  runtime_manager.Initialize();
+  runtime_manager.Enable();
+  std::vector<std::thread> threads{};
+  threads.reserve(thread_count);
+  for (auto _ : state) {  // NOLINT(clang-analyzer-deadcode.DeadStores)
+    for (auto thread{0}; thread < thread_count; ++thread) {
+      threads.emplace_back(FibonacciInstrumented, n, &runtime_manager);
+    }
+    std::for_each(std::begin(threads), std::end(threads), [](auto& thread) {
+      if (thread.joinable()) thread.join();
+    });
+    threads.clear();
+  }
+  runtime_manager.Deinitialize();
+}
+
+BENCHMARK(BenchmarkFibonacciInstrumented)  // NOLINT
+    ->ArgsProduct(kNAndThreadCount);
+
+}  // namespace
+
+BENCHMARK_MAIN();  // NOLINT

--- a/toolchain/benchmark/run_benchmarks.sh
+++ b/toolchain/benchmark/run_benchmarks.sh
@@ -5,4 +5,4 @@
 set -eu
 
 bazel query 'kind(cc_binary, //...) intersect attr(name, ".*_benchmark", //...)' |
-  xargs bazel run --config=benchmark
+  xargs -L 1 bazel run --config=benchmark


### PR DESCRIPTION
* Benchmarks for the runtime manager. This certainly isn't an exhaustive benchmark suite but is a step in the right direction and should get us started.
* Implements a "black hole" flush queue that discards events as soon as they're enqueued (as close to a no-op as we can get for flush queue operations).

@a2 you might find these helpful :)

#### BenchmarkThreadCreation
`BenchmarkThreadCreation/t` where `t` is the number of threads being created.

Measures the cost of spinning up and tearing down the threads that is inevitably present in the benchmarks below.

####  BenchmarkFibonacciUninstrumented
`BenchmarkThreadCreation/n/t` where `n` is the nth Fibonacci number to compute recursively and `t` is the number of threads.

Measures the cost of of recursively computing the nth Fibonacci number without Spoor instrumentation + the cost of spinning up and tearing down t threads.

#### BenchmarkFibonacciInstrumented
`BenchmarkFibonacciInstrumented/n/t` where `n` is the nth Fibonacci number to compute recursively and `t` is the number of threads.

Measures the cost of Spoor's `LogEvent` + the cost of computing the nth fibonacci number + the cost of spinning up and tearing down t threads.


#### Sample run on my machine

```
$ bazel run --config=benchmark //spoor/runtime/runtime_manager:runtime_manager_benchmark
Run on (12 X 2600 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x6)
  L1 Instruction 32 KiB (x6)
  L2 Unified 256 KiB (x6)
  L3 Unified 9216 KiB (x1)
Load Average: 1.51, 2.35, 3.26
---------------------------------------------------------------------------------
Benchmark                                       Time             CPU   Iterations
---------------------------------------------------------------------------------
BenchmarkThreadCreation/1                   21628 ns        12795 ns        48086
BenchmarkThreadCreation/2                   27955 ns        23898 ns        29371
BenchmarkThreadCreation/4                   47173 ns        44759 ns        15684
BenchmarkThreadCreation/16                 186136 ns       184640 ns         3719
BenchmarkFibonacciUninstrumented/0/1        73437 ns        73271 ns        10000
BenchmarkFibonacciUninstrumented/10/1       73605 ns        73332 ns        10000
BenchmarkFibonacciUninstrumented/20/1      280607 ns        77555 ns        10000
BenchmarkFibonacciUninstrumented/30/1    29094648 ns        14390 ns          100
BenchmarkFibonacciUninstrumented/0/2       144150 ns       144107 ns        10000
BenchmarkFibonacciUninstrumented/10/2      143913 ns       143840 ns        10000
BenchmarkFibonacciUninstrumented/20/2      290839 ns       150783 ns        10000
BenchmarkFibonacciUninstrumented/30/2    29012491 ns        35140 ns          100
BenchmarkFibonacciUninstrumented/0/4       300754 ns       300593 ns        10189
BenchmarkFibonacciUninstrumented/10/4      304642 ns       304541 ns        10483
BenchmarkFibonacciUninstrumented/20/4      343458 ns       263000 ns         8579
BenchmarkFibonacciUninstrumented/30/4    30174365 ns        59030 ns          100
BenchmarkFibonacciUninstrumented/0/16      422576 ns       422042 ns         2351
BenchmarkFibonacciUninstrumented/10/16     394201 ns       393451 ns         2025
BenchmarkFibonacciUninstrumented/20/16     953337 ns       521683 ns         1627
BenchmarkFibonacciUninstrumented/30/16   92839579 ns       291200 ns          100
BenchmarkFibonacciInstrumented/0/1          27459 ns        14054 ns        43593
BenchmarkFibonacciInstrumented/10/1        134945 ns        13892 ns        50824
BenchmarkFibonacciInstrumented/20/1      13382641 ns        17365 ns         1000
BenchmarkFibonacciInstrumented/30/1    1590542215 ns        25500 ns           10
BenchmarkFibonacciInstrumented/0/2          36489 ns        25027 ns        27731
BenchmarkFibonacciInstrumented/10/2        236786 ns        23682 ns        28702
BenchmarkFibonacciInstrumented/20/2      21658672 ns        28600 ns         1000
BenchmarkFibonacciInstrumented/30/2    2695717704 ns        60000 ns            1
BenchmarkFibonacciInstrumented/0/4          55258 ns        47417 ns        14892
BenchmarkFibonacciInstrumented/10/4        677911 ns        47814 ns        10000
BenchmarkFibonacciInstrumented/20/4      80711108 ns        70570 ns          100
BenchmarkFibonacciInstrumented/30/4   10098843072 ns        95000 ns            1
BenchmarkFibonacciInstrumented/0/16        251136 ns       204501 ns         3405
BenchmarkFibonacciInstrumented/10/16      3992110 ns       320153 ns         1000
BenchmarkFibonacciInstrumented/20/16    372308188 ns       260400 ns           10
BenchmarkFibonacciInstrumented/30/16  44007208028 ns       262000 ns            1
```

Note that we can't nicely benchmark the runtime library (which essentially wraps the runtime manager) because it relies on environment variables for configuration and only uses the disk flush queue. I expect the performance difference between benchmarking the runtime manager and runtime API to be minimal, if at all.