### PR TITLE
Instrumentation: Configurable module ID

### DIFF
--- a/spoor/instrumentation/config/config.cc
+++ b/spoor/instrumentation/config/config.cc
@@ -10,32 +10,34 @@ namespace spoor::instrumentation::config {
 using util::env::GetEnvOrDefault;
 
 auto Config::FromEnv(const util::env::GetEnv& get_env) -> Config {
-  return {
-      .instrumentation_map_output_path =
-          GetEnvOrDefault(kInstrumentationMapOutputPathKey.data(),
-                          kInstrumentationMapOutputPathDefaultValue, get_env),
-      .initialize_runtime =
-          GetEnvOrDefault(kInitializeRuntimeKey.data(),
-                          kInitializeRuntimeDefaultValue, get_env),
-      .enable_runtime = GetEnvOrDefault(kEnableRuntimeKey.data(),
-                                        kEnableRuntimeDefaultValue, get_env),
-      .min_instruction_threshold =
-          GetEnvOrDefault(kMinInstructionThresholdKey.data(),
-                          kMinInstructionThresholdDefaultValue, get_env),
-      .function_allow_list_file =
-          GetEnvOrDefault(kFunctionAllowListFileKey.data(),
-                          kFunctionAllowListFileDefaultValue, true, get_env),
-      .function_blocklist_file =
-          GetEnvOrDefault(kFunctionBlocklistFileKey.data(),
-                          kFunctionBlocklistFileDefaultValue, true, get_env)};
+  return {.instrumented_function_map_output_path = GetEnvOrDefault(
+              kInstrumentedFunctionMapOutputPathKey.data(),
+              kInstrumentedFunctionMapOutputPathDefaultValue, get_env),
+          .initialize_runtime =
+              GetEnvOrDefault(kInitializeRuntimeKey.data(),
+                              kInitializeRuntimeDefaultValue, get_env),
+          .enable_runtime = GetEnvOrDefault(
+              kEnableRuntimeKey.data(), kEnableRuntimeDefaultValue, get_env),
+          .min_instruction_threshold =
+              GetEnvOrDefault(kMinInstructionThresholdKey.data(),
+                              kMinInstructionThresholdDefaultValue, get_env),
+          .module_id = GetEnvOrDefault(kModuleIdKey.data(),
+                                       kModuleIdDefaultValue, true, get_env),
+          .function_allow_list_file = GetEnvOrDefault(
+              kFunctionAllowListFileKey.data(),
+              kFunctionAllowListFileDefaultValue, true, get_env),
+          .function_blocklist_file = GetEnvOrDefault(
+              kFunctionBlocklistFileKey.data(),
+              kFunctionBlocklistFileDefaultValue, true, get_env)};
 }
 
 auto operator==(const Config& lhs, const Config& rhs) -> bool {
-  return lhs.instrumentation_map_output_path ==
-             rhs.instrumentation_map_output_path &&
+  return lhs.instrumented_function_map_output_path ==
+             rhs.instrumented_function_map_output_path &&
          lhs.initialize_runtime == rhs.initialize_runtime &&
          lhs.enable_runtime == rhs.enable_runtime &&
          lhs.min_instruction_threshold == rhs.min_instruction_threshold &&
+         lhs.module_id == rhs.module_id &&
          lhs.function_allow_list_file == rhs.function_allow_list_file &&
          lhs.function_blocklist_file == rhs.function_blocklist_file;
 }

--- a/spoor/instrumentation/config/config.h
+++ b/spoor/instrumentation/config/config.h
@@ -4,7 +4,6 @@
 #pragma once
 
 #include <cstdlib>
-#include <limits>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -14,10 +13,10 @@
 
 namespace spoor::instrumentation::config {
 
-constexpr std::string_view kInstrumentationMapOutputPathKey{
-    "SPOOR_INSTRUMENTATION_MAP_OUTPUT_PATH"};
+constexpr std::string_view kInstrumentedFunctionMapOutputPathKey{
+    "SPOOR_INSTRUMENTATION_INSTRUMENTED_FUNCTION_MAP_OUTPUT_PATH"};
 // NOLINTNEXTLINE(fuchsia-statically-constructed-objects)
-const std::string kInstrumentationMapOutputPathDefaultValue{"."};
+const std::string kInstrumentedFunctionMapOutputPathDefaultValue{"."};
 constexpr std::string_view kInitializeRuntimeKey{
     "SPOOR_INSTRUMENTATION_RUNTIME_INITIALIZE_RUNTIME"};
 constexpr bool kInitializeRuntimeDefaultValue{true};
@@ -27,6 +26,9 @@ constexpr bool kEnableRuntimeDefaultValue{true};
 constexpr std::string_view kMinInstructionThresholdKey{
     "SPOOR_INSTRUMENTATION_MIN_INSTRUCTION_THRESHOLD"};
 constexpr uint32 kMinInstructionThresholdDefaultValue{0};
+constexpr std::string_view kModuleIdKey{"SPOOR_INSTRUMENTATION_MODULE_ID"};
+// NOLINTNEXTLINE(fuchsia-statically-constructed-objects)
+const std::optional<std::string> kModuleIdDefaultValue{};
 constexpr std::string_view kFunctionAllowListFileKey{
     "SPOOR_INSTRUMENTATION_FUNCTION_ALLOW_LIST_FILE"};
 // NOLINTNEXTLINE(fuchsia-statically-constructed-objects)
@@ -41,10 +43,11 @@ struct Config {
     return std::getenv(key);
   }) -> Config;
 
-  std::string instrumentation_map_output_path;
+  std::string instrumented_function_map_output_path;
   bool initialize_runtime;
   bool enable_runtime;
   uint32 min_instruction_threshold;
+  std::optional<std::string> module_id;
   std::optional<std::string> function_allow_list_file;
   std::optional<std::string> function_blocklist_file;
 };

--- a/spoor/instrumentation/config/config_test.cc
+++ b/spoor/instrumentation/config/config_test.cc
@@ -16,25 +16,28 @@ using spoor::instrumentation::config::kEnableRuntimeKey;
 using spoor::instrumentation::config::kFunctionAllowListFileKey;
 using spoor::instrumentation::config::kFunctionBlocklistFileKey;
 using spoor::instrumentation::config::kInitializeRuntimeKey;
-using spoor::instrumentation::config::kInstrumentationMapOutputPathKey;
+using spoor::instrumentation::config::kInstrumentedFunctionMapOutputPathKey;
 using spoor::instrumentation::config::kMinInstructionThresholdKey;
+using spoor::instrumentation::config::kModuleIdKey;
 
 TEST(Config, GetsUserProvidedValue) {  // NOLINT
   const auto get_env = [](const char* key) {
     const std::unordered_map<std::string_view, std::string_view> environment{
-        {kInstrumentationMapOutputPathKey, "/path/to/output/"},
+        {kInstrumentedFunctionMapOutputPathKey, "/path/to/output/"},
         {kInitializeRuntimeKey, "false"},
         {kEnableRuntimeKey, "false"},
         {kMinInstructionThresholdKey, "42"},
+        {kModuleIdKey, "ModuleId"},
         {kFunctionAllowListFileKey, "/path/to/allow_list.txt"},
         {kFunctionBlocklistFileKey, "/path/to/blocklist.txt"}};
     return environment.at(key).data();
   };
   const Config expected_options{
-      .instrumentation_map_output_path = "/path/to/output/",
+      .instrumented_function_map_output_path = "/path/to/output/",
       .initialize_runtime = false,
       .enable_runtime = false,
       .min_instruction_threshold = 42,
+      .module_id = "ModuleId",
       .function_allow_list_file = "/path/to/allow_list.txt",
       .function_blocklist_file = "/path/to/blocklist.txt"};
   ASSERT_EQ(Config::FromEnv(get_env), expected_options);
@@ -44,10 +47,33 @@ TEST(Config, UsesDefaultValueWhenNotSpecified) {  // NOLINT
   const auto get_env = [](const char* /*unused*/) -> const char* {
     return nullptr;
   };
-  const Config expected_options{.instrumentation_map_output_path = ".",
+  const Config expected_options{.instrumented_function_map_output_path = ".",
                                 .initialize_runtime = true,
                                 .enable_runtime = true,
                                 .min_instruction_threshold = 0,
+                                .module_id = {},
+                                .function_allow_list_file = {},
+                                .function_blocklist_file = {}};
+  ASSERT_EQ(Config::FromEnv(get_env), expected_options);
+}
+
+TEST(Config, UsesDefaultValueForEmptyStringValues) {  // NOLINT
+  const auto get_env = [](const char* key) {
+    const std::unordered_map<std::string_view, std::string_view> environment{
+        {kInstrumentedFunctionMapOutputPathKey, ""},
+        {kInitializeRuntimeKey, ""},
+        {kEnableRuntimeKey, ""},
+        {kMinInstructionThresholdKey, ""},
+        {kModuleIdKey, ""},
+        {kFunctionAllowListFileKey, ""},
+        {kFunctionBlocklistFileKey, ""}};
+    return environment.at(key).data();
+  };
+  const Config expected_options{.instrumented_function_map_output_path = "",
+                                .initialize_runtime = true,
+                                .enable_runtime = true,
+                                .min_instruction_threshold = 0,
+                                .module_id = {},
                                 .function_allow_list_file = {},
                                 .function_blocklist_file = {}};
   ASSERT_EQ(Config::FromEnv(get_env), expected_options);

--- a/spoor/instrumentation/inject_runtime/inject_runtime.cc
+++ b/spoor/instrumentation/inject_runtime/inject_runtime.cc
@@ -67,11 +67,13 @@ auto InjectRuntime::run(llvm::Module& llvm_module, llvm::ModuleAnalysisManager&
 
   const auto file_name = [&] {
     std::string buffer{};
-    const auto module_id_hash =
-        std::hash<std::string>{}(llvm_module.getModuleIdentifier());
+    const auto module_id =
+        options_.module_id.value_or(llvm_module.getModuleIdentifier());
+    const auto module_id_hash = std::hash<std::string>{}(module_id);
     llvm::raw_string_ostream{buffer}
-        << llvm::format_hex_no_prefix(module_id_hash, 16) << '.'
-        << kInstrumentedFunctionMapFileExtension.data();
+        << llvm::format_hex_no_prefix(module_id_hash,
+                                      sizeof(module_id_hash) * 2)
+        << '.' << kInstrumentedFunctionMapFileExtension;
     return buffer;
   }();
   const auto path = options_.instrumented_function_map_output_path / file_name;

--- a/spoor/instrumentation/inject_runtime/inject_runtime.h
+++ b/spoor/instrumentation/inject_runtime/inject_runtime.h
@@ -40,6 +40,7 @@ class InjectRuntime : public llvm::PassInfoMixin<InjectRuntime> {
     gsl::not_null<util::time::SystemClock*> system_clock;
     std::unordered_set<std::string> function_allow_list;
     std::unordered_set<std::string> function_blocklist;
+    std::optional<std::string> module_id;
     uint32 min_instruction_count_to_instrument;
     bool initialize_runtime;
     bool enable_runtime;

--- a/spoor/instrumentation/register_pass.cc
+++ b/spoor/instrumentation/register_pass.cc
@@ -75,12 +75,13 @@ auto PluginInfo() -> llvm::PassPluginLibraryInfo {
           // llvm::errs() << n.count() << '\n';
           pass_manager.addPass(inject_runtime::InjectRuntime({
               .instrumented_function_map_output_path =
-                  config.instrumentation_map_output_path,
+                  config.instrumented_function_map_output_path,
               .instrumented_function_map_output_stream =
                   std::move(instrumented_function_map_output_stream),
               .system_clock = &system_clock,
               .function_allow_list = function_allow_list,
               .function_blocklist = function_blocklist,
+              .module_id = config.module_id,
               .min_instruction_count_to_instrument =
                   config.min_instruction_threshold,
               .initialize_runtime = config.initialize_runtime,


### PR DESCRIPTION
Allow the IR's module ID to be overridden by setting the `SPOOR_INSTRUMENTATION_MODULE_ID` environment variable. This is helpful because all IR emitted by Swift has a module ID of `<swift-imported-modules>`.

Also renames `SPOOR_INSTRUMENTATION_MAP_OUTPUT_PATH` to `SPOOR_INSTRUMENTATION_INSTRUMENTED_FUNCTION_MAP_OUTPUT_PATH` for naming consistency (at the expense of being verbose).