### PR TITLE
Instrumentation: Allocate system_clock on the heap to prevent bad memory access

### DIFF
--- a/spoor/instrumentation/inject_runtime/inject_runtime.h
+++ b/spoor/instrumentation/inject_runtime/inject_runtime.h
@@ -37,7 +37,7 @@ class InjectRuntime : public llvm::PassInfoMixin<InjectRuntime> {
         llvm::StringRef /*file_path*/,
         gsl::not_null<std::error_code*> /*error*/)>
         instrumented_function_map_output_stream;
-    gsl::not_null<util::time::SystemClock*> system_clock;
+    std::unique_ptr<util::time::SystemClock> system_clock;
     std::unordered_set<std::string> function_allow_list;
     std::unordered_set<std::string> function_blocklist;
     std::optional<std::string> module_id;
@@ -47,10 +47,10 @@ class InjectRuntime : public llvm::PassInfoMixin<InjectRuntime> {
   };
 
   InjectRuntime() = delete;
-  explicit InjectRuntime(Options options);
-  InjectRuntime(const InjectRuntime&) = default;
+  explicit InjectRuntime(Options&& options);
+  InjectRuntime(const InjectRuntime&) = delete;
   InjectRuntime(InjectRuntime&&) noexcept = default;
-  auto operator=(const InjectRuntime&) -> InjectRuntime& = default;
+  auto operator=(const InjectRuntime&) -> InjectRuntime& = delete;
   auto operator=(InjectRuntime&&) noexcept -> InjectRuntime& = default;
   ~InjectRuntime() = default;
 

--- a/spoor/instrumentation/inject_runtime/inject_runtime_test.cc
+++ b/spoor/instrumentation/inject_runtime/inject_runtime_test.cc
@@ -126,13 +126,13 @@ TEST(InjectRuntime, InstrumentsModule) {  // NOLINT
                             gsl::not_null<std::error_code*> /*unused*/) {
       return std::make_unique<llvm::raw_null_ostream>();
     };
-    SystemClockMock system_clock{};
-    EXPECT_CALL(system_clock, Now())
+    auto system_clock = std::make_unique<SystemClockMock>();
+    EXPECT_CALL(*system_clock, Now())
         .WillOnce(Return(MakeTimePoint<std::chrono::system_clock>(0)));
     InjectRuntime inject_runtime{
         {.instrumented_function_map_output_path = "/",
          .instrumented_function_map_output_stream = ostream,
-         .system_clock = &system_clock,
+         .system_clock = std::move(system_clock),
          .function_allow_list = {},
          .function_blocklist = {},
          .module_id = {},
@@ -323,13 +323,13 @@ TEST(InjectRuntime, OutputsInstrumentedFunctionMap) {  // NOLINT
                                    gsl::not_null<std::error_code*> /*unused*/) {
       return std::make_unique<llvm::raw_string_ostream>(buffer);
     };
-    SystemClockMock system_clock{};
-    EXPECT_CALL(system_clock, Now())
+    auto system_clock = std::make_unique<SystemClockMock>();
+    EXPECT_CALL(*system_clock, Now())
         .WillOnce(Return(MakeTimePoint<std::chrono::system_clock>(0)));
     InjectRuntime inject_runtime{
         {.instrumented_function_map_output_path = "/",
          .instrumented_function_map_output_stream = ostream,
-         .system_clock = &system_clock,
+         .system_clock = std::move(system_clock),
          .function_allow_list = {},
          .function_blocklist = {},
          .module_id = {},
@@ -369,13 +369,13 @@ TEST(InjectRuntime, FunctionBlocklist) {  // NOLINT
                           gsl::not_null<std::error_code*> /*unused*/) {
     return std::make_unique<llvm::raw_null_ostream>();
   };
-  SystemClockMock system_clock{};
-  EXPECT_CALL(system_clock, Now())
+  auto system_clock = std::make_unique<SystemClockMock>();
+  EXPECT_CALL(*system_clock, Now())
       .WillOnce(Return(MakeTimePoint<std::chrono::system_clock>(0)));
   InjectRuntime inject_runtime{
       {.instrumented_function_map_output_path = "/",
        .instrumented_function_map_output_stream = ostream,
-       .system_clock = &system_clock,
+       .system_clock = std::move(system_clock),
        .function_allow_list = {},
        .function_blocklist = {"_Z9Fibonaccii"},
        .module_id = {},
@@ -409,13 +409,13 @@ TEST(InjectRuntime, FunctionAllowListOverridesBlocklist) {  // NOLINT
                     gsl::not_null<std::error_code*> /*unused*/) {
     return std::make_unique<llvm::raw_null_ostream>();
   };
-  SystemClockMock system_clock{};
-  EXPECT_CALL(system_clock, Now())
+  auto system_clock = std::make_unique<SystemClockMock>();
+  EXPECT_CALL(*system_clock, Now())
       .WillOnce(Return(MakeTimePoint<std::chrono::system_clock>(0)));
   InjectRuntime inject_runtime{
       {.instrumented_function_map_output_path = "/",
        .instrumented_function_map_output_stream = ostream,
-       .system_clock = &system_clock,
+       .system_clock = std::move(system_clock),
        .function_allow_list = {"_Z9Fibonaccii"},
        .function_blocklist = {"_Z9Fibonaccii"},
        .module_id = {},
@@ -460,13 +460,13 @@ TEST(InjectRuntime, InstructionThreshold) {  // NOLINT
                             gsl::not_null<std::error_code*> /*unused*/) {
       return std::make_unique<llvm::raw_null_ostream>();
     };
-    SystemClockMock system_clock{};
-    EXPECT_CALL(system_clock, Now())
+    auto system_clock = std::make_unique<SystemClockMock>();
+    EXPECT_CALL(*system_clock, Now())
         .WillOnce(Return(MakeTimePoint<std::chrono::system_clock>(0)));
     InjectRuntime inject_runtime{
         {.instrumented_function_map_output_path = "/",
          .instrumented_function_map_output_stream = ostream,
-         .system_clock = &system_clock,
+         .system_clock = std::move(system_clock),
          .function_allow_list = {},
          .function_blocklist = {},
          .module_id = {},
@@ -502,13 +502,13 @@ TEST(InjectRuntime, AlwaysInstrumentsMain) {  // NOLINT
                           gsl::not_null<std::error_code*> /*unused*/) {
     return std::make_unique<llvm::raw_null_ostream>();
   };
-  SystemClockMock system_clock{};
-  EXPECT_CALL(system_clock, Now())
+  auto system_clock = std::make_unique<SystemClockMock>();
+  EXPECT_CALL(*system_clock, Now())
       .WillOnce(Return(MakeTimePoint<std::chrono::system_clock>(0)));
   InjectRuntime inject_runtime{
       {.instrumented_function_map_output_path = "/",
        .instrumented_function_map_output_stream = ostream,
-       .system_clock = &system_clock,
+       .system_clock = std::move(system_clock),
        .function_allow_list = {},
        .function_blocklist = {"main", "_Z9Fibonaccii"},
        .module_id = {},
@@ -560,14 +560,14 @@ TEST(InjectRuntime, InstrumentedFunctionMapFileName) {  // NOLINT
           << '.' << kInstrumentedFunctionMapFileExtension;
       return buffer;
     }();
-    SystemClockMock system_clock{};
-    EXPECT_CALL(system_clock, Now())
+    auto system_clock = std::make_unique<SystemClockMock>();
+    EXPECT_CALL(*system_clock, Now())
         .WillOnce(Return(MakeTimePoint<std::chrono::system_clock>(0)));
     InjectRuntime inject_runtime{
         {.instrumented_function_map_output_path =
              instrumented_function_map_output_path,
          .instrumented_function_map_output_stream = ostream,
-         .system_clock = &system_clock,
+         .system_clock = std::move(system_clock),
          .function_allow_list = {},
          .function_blocklist = {},
          .module_id = module_id,
@@ -596,13 +596,13 @@ TEST(InjectRuntime, AddsTimestamp) {  // NOLINT
     return std::make_unique<llvm::raw_string_ostream>(buffer);
   };
   const auto nanoseconds = 1'607'590'800'000'000'000;
-  SystemClockMock system_clock{};
-  EXPECT_CALL(system_clock, Now())
+  auto system_clock = std::make_unique<SystemClockMock>();
+  EXPECT_CALL(*system_clock, Now())
       .WillOnce(Return(MakeTimePoint<std::chrono::system_clock>(nanoseconds)));
   InjectRuntime inject_runtime{
       {.instrumented_function_map_output_path = "/path/to/output",
        .instrumented_function_map_output_stream = ostream,
-       .system_clock = &system_clock,
+       .system_clock = std::move(system_clock),
        .function_allow_list = {},
        .function_blocklist = {},
        .min_instruction_count_to_instrument = 0,
@@ -639,13 +639,13 @@ TEST(InjectRuntime, ReturnValue) {  // NOLINT
                             gsl::not_null<std::error_code*> /*unused*/) {
       return std::make_unique<llvm::raw_null_ostream>();
     };
-    SystemClockMock system_clock{};
-    EXPECT_CALL(system_clock, Now())
+    auto system_clock = std::make_unique<SystemClockMock>();
+    EXPECT_CALL(*system_clock, Now())
         .WillOnce(Return(MakeTimePoint<std::chrono::system_clock>(0)));
     InjectRuntime inject_runtime{
         {.instrumented_function_map_output_path = "/",
          .instrumented_function_map_output_stream = ostream,
-         .system_clock = &system_clock,
+         .system_clock = std::move(system_clock),
          .function_allow_list = {},
          .function_blocklist = config.function_blocklist,
          .module_id = {},
@@ -681,11 +681,11 @@ TEST(InjectRuntime, ExitsOnOstreamError) {  // NOLINT
     *error_code = error;
     return std::make_unique<llvm::raw_null_ostream>();
   };
-  SystemClock system_clock{};
+  auto system_clock = std::make_unique<SystemClock>();
   InjectRuntime inject_runtime{
       {.instrumented_function_map_output_path = "/",
        .instrumented_function_map_output_stream = ostream,
-       .system_clock = &system_clock,
+       .system_clock = std::move(system_clock),
        .function_allow_list = {},
        .function_blocklist = {},
        .module_id = {},

--- a/spoor/instrumentation/register_pass.cc
+++ b/spoor/instrumentation/register_pass.cc
@@ -69,16 +69,13 @@ auto PluginInfo() -> llvm::PassPluginLibraryInfo {
                 return std::make_unique<llvm::raw_fd_ostream>(file_path,
                                                               *error);
               };
-          util::time::SystemClock system_clock{};
-          // auto* sc = &system_clock;
-          // auto n = sc->Now().time_since_epoch();
-          // llvm::errs() << n.count() << '\n';
-          pass_manager.addPass(inject_runtime::InjectRuntime({
+          auto system_clock = std::make_unique<util::time::SystemClock>();
+          pass_manager.addPass(inject_runtime::InjectRuntime{{
               .instrumented_function_map_output_path =
                   config.instrumented_function_map_output_path,
               .instrumented_function_map_output_stream =
                   std::move(instrumented_function_map_output_stream),
-              .system_clock = &system_clock,
+              .system_clock = std::move(system_clock),
               .function_allow_list = function_allow_list,
               .function_blocklist = function_blocklist,
               .module_id = config.module_id,
@@ -86,7 +83,7 @@ auto PluginInfo() -> llvm::PassPluginLibraryInfo {
                   config.min_instruction_threshold,
               .initialize_runtime = config.initialize_runtime,
               .enable_runtime = config.enable_runtime,
-          }));
+          }});
           return true;
         };
     pass_builder.registerPipelineParsingCallback(pipeline_parsing_callback);


### PR DESCRIPTION
`system_clock` was being allocated on the stack in a lambda and deallocated at the end of the scope before being used 🙈. Sometimes the memory was overwritten causing a crash when accessed. Good catch, @dawidk-msft!

To fix this, allocate `system_clock` on the heap and transfer its ownership to `InjectRuntime`. This requires converting `InjectRuntime` to a move-only type.

This PR also includes some gardening by cleaning up commented code and taking `function_name` by reference when demangling the name.