### PR TITLE
[WIP] Xcode toolchain

### DIFF
--- a/toolchain/Spoor.xctoolchain/ToolchainInfo.plist
+++ b/toolchain/Spoor.xctoolchain/ToolchainInfo.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!-- Copyright (c) Microsoft Corporation. -->
+<!-- Licensed under the MIT License. -->
+<plist version="1.0">
+  <dict>
+    <key>Aliases</key>
+    <array>
+      <string>Spoor</string>
+    </array>
+    <key>CFBundleIdentifier</key>
+    <string>com.microsoft.toolchain.Spoor</string>
+    <key>CompatibilityVersion</key>
+    <integer>2</integer>
+    <key>CompatibilityVersionDisplayString</key>
+    <string>Xcode 12.0+</string>
+    <key>DisplayName</key>
+    <string>Spoor</string>
+    <key>ReportProblemURL</key>
+    <string>https://github.com/microsoft/spoor</string>
+    <key>ShortDisplayName</key>
+    <string>Spoor</string>
+    <key>Version</key>
+    <string>0.0.0</string>
+  </dict>
+</plist>

--- a/toolchain/Spoor.xctoolchain/usr/bin/__init__.py
+++ b/toolchain/Spoor.xctoolchain/usr/bin/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.

--- a/toolchain/Spoor.xctoolchain/usr/bin/clang
+++ b/toolchain/Spoor.xctoolchain/usr/bin/clang
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+from shared import DEFAULT_CLANG, DEFAULT_CLANGXX, OBJECT_FILE_EXTENSION
+from shared import SPOOR_LIBRARY_PATH, LLVM_IR_LANGUAGE
+from shared import flatten, instrument_and_compile_ir
+import argparse
+import subprocess
+import sys
+
+CLANG_EMIT_LLVM_ARG = '-emit-llvm'
+CLANG_LANGUAGE_ARG = '-x'
+CLANG_LIBRARY_SEARCH_PATH_ARG = '-L'
+CLANG_LINK_LIBRARY_ARG = '-l'
+CLANG_ONLY_PREPROCESS_COMPILE_AND_ASSEMBLE_ARG = '-c'
+CLANG_OUTPUT_FILE_ARG = '-o'
+CLANG_OUTPUT_STDOUT_VALUE = '-'
+CLANG_TARGET_ARG = '-target'
+LIB_CXX_LIBRARY = 'c++'
+SUPPORTED_LANGUAGES = \
+        {'c', 'c++', LLVM_IR_LANGUAGE, 'objective-c', 'objective-c++'}
+
+def runtime_library_for_target(target):
+    if 'x86_64' in target:
+        if 'ios' in target:
+            return 'spoor_runtime_ios_x86_64'
+        elif 'mac' in target:
+            return 'spoor_runtime_macos_x86_64'
+    elif 'arm64' in target:
+        if 'ios' in target:
+            return 'spoor_runtime_ios_arm64'
+    raise ValueError(f'Unsupported target {target}')
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        CLANG_OUTPUT_FILE_ARG,
+        action='append',
+        dest='output_files',
+        nargs=1,
+    )
+    parser.add_argument(
+        CLANG_TARGET_ARG,
+        dest='target',
+        nargs=1,
+    )
+    parser.add_argument(
+        CLANG_LANGUAGE_ARG,
+        dest='language',
+        nargs=1,
+    )
+    args, other_args = parser.parse_known_args()
+
+    if not args.target:
+        raise ValueError('No target was supplied')
+    target = args.target[0]
+
+    output_files = flatten(args.output_files)
+    language = args.language[0] \
+            if (args.language and 0 < len(args.language)) else None
+    if not language in SUPPORTED_LANGUAGES or not output_files or \
+            not all(f.endswith(OBJECT_FILE_EXTENSION) for f in output_files):
+        clang_args = [DEFAULT_CLANG] + sys.argv[1:]
+        if CLANG_ONLY_PREPROCESS_COMPILE_AND_ASSEMBLE_ARG not in clang_args:
+            runtime_library = runtime_library_for_target(target)
+            clang_args += [
+                f'{CLANG_LIBRARY_SEARCH_PATH_ARG}{SPOOR_LIBRARY_PATH}',
+                f'{CLANG_LINK_LIBRARY_ARG}{runtime_library}',
+                f'{CLANG_LINK_LIBRARY_ARG}{LIB_CXX_LIBRARY}',
+            ]
+        clang_process = subprocess.Popen(clang_args)
+        clang_process.wait()
+        sys.exit(clang_process.returncode)
+
+    if len(output_files) != 1:
+        message = f'Expected exactly one output file, got {len(output_files)}'
+        raise ValueError(message)
+    output_file = output_files[0]
+
+    clang_args = [DEFAULT_CLANG]
+    clang_args += [CLANG_LANGUAGE_ARG, language]
+    clang_args += [CLANG_TARGET_ARG, target]
+    clang_args += other_args
+    clang_args += [CLANG_OUTPUT_FILE_ARG, CLANG_OUTPUT_STDOUT_VALUE]
+    clang_args += [CLANG_EMIT_LLVM_ARG]
+
+    clang_process = subprocess.Popen(clang_args, stdout=subprocess.PIPE)
+    return_code = instrument_and_compile_ir(clang_process, output_file, target)
+    sys.exit(return_code)
+
+
+if __name__ == '__main__':
+    main()

--- a/toolchain/Spoor.xctoolchain/usr/bin/shared.py
+++ b/toolchain/Spoor.xctoolchain/usr/bin/shared.py
@@ -1,0 +1,81 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+import functools
+import operator
+import os
+import pathlib
+import subprocess
+
+DEVELOPER_PATH = \
+        os.getenv('DEVELOPER_DIR', '/Applications/Xcode.app/Contents/Developer')
+DEFAULT_TOOLCHAIN_PATH = f'{DEVELOPER_PATH}/Toolchains/XcodeDefault.xctoolchain'
+
+CLANGXX_INPUT_STDIN_VALUE = '-'
+CLANGXX_LANGUAGE_ARG = '-x'
+CLANGXX_ONLY_PREPROCESS_COMPILE_AND_ASSEMBLE_ARG = '-c'
+CLANGXX_OUTPUT_FILE_ARG = '-o'
+CLANGXX_TARGET_ARG = '-target'
+CUSTOM_TOOLCHAIN_PATH = \
+        pathlib.Path(*pathlib.Path(__file__).parent.absolute().parts[:-2])
+DEFAULT_CLANG = f'{DEFAULT_TOOLCHAIN_PATH}/usr/bin/clang'
+DEFAULT_CLANGXX = f'{DEFAULT_TOOLCHAIN_PATH}/usr/bin/clang++'
+DEFAULT_OPT = subprocess.run(['which', 'opt'], capture_output=True, text=True) \
+        .stdout.strip() or '/usr/local/opt/llvm/bin/opt'
+DEFAULT_SWIFT = f'{DEFAULT_TOOLCHAIN_PATH}/usr/bin/swift'
+DEFAULT_SWIFTC = f'{DEFAULT_TOOLCHAIN_PATH}/usr/bin/swiftc'
+INSTRUMENTATION_PASS_LIBRARY_PATH = \
+        f'{CUSTOM_TOOLCHAIN_PATH}/spoor/libspoor_instrumentation.dylib'
+INSTRUMENTATION_PASS_NAMES = ['inject-spoor-runtime']
+LLVM_IR_LANGUAGE = 'ir'
+OBJECT_FILE_EXTENSION = '.o'
+OK_RETURN_CODE = 0
+OPT_INPUT_STDIN_VALUE = '-'
+OPT_LOAD_PASS_PLUGIN_ARG = '-load-pass-plugin'
+OPT_PASSES_ARG = '-passes'
+OPT_WRITE_OUTPUT_AS_LLVM_ASSEMBLY_ARG = '-S'
+SPOOR_INSTRUMENTATION_MODULE_ID_KEY = 'SPOOR_INSTRUMENTATION_MODULE_ID'
+SPOOR_LIBRARY_PATH = f'{CUSTOM_TOOLCHAIN_PATH}/spoor'
+WRAPPED_SWIFT = f'{CUSTOM_TOOLCHAIN_PATH}/usr/bin/swift'
+
+def flatten(list):
+    return functools.reduce(operator.iconcat, list or [], [])
+
+
+def instrument_and_compile_ir(frontend_process, output_file, target):
+    opt_args = [
+        DEFAULT_OPT,
+        OPT_INPUT_STDIN_VALUE,
+        OPT_WRITE_OUTPUT_AS_LLVM_ASSEMBLY_ARG,
+        f'{OPT_LOAD_PASS_PLUGIN_ARG}={INSTRUMENTATION_PASS_LIBRARY_PATH}',
+        f'{OPT_PASSES_ARG}={",".join(INSTRUMENTATION_PASS_NAMES)}',
+    ]
+    clangxx_args = [
+        DEFAULT_CLANGXX,
+        CLANGXX_TARGET_ARG, target,
+        CLANGXX_ONLY_PREPROCESS_COMPILE_AND_ASSEMBLE_ARG,
+        CLANGXX_LANGUAGE_ARG, LLVM_IR_LANGUAGE,
+        CLANGXX_INPUT_STDIN_VALUE,
+        CLANGXX_OUTPUT_FILE_ARG, output_file,
+    ]
+
+    env = os.environ.copy()
+    env[SPOOR_INSTRUMENTATION_MODULE_ID_KEY] = output_file
+
+    opt_process = subprocess.Popen(opt_args, stdin=frontend_process.stdout,
+            stdout=subprocess.PIPE, env=env)
+    frontend_process.stdout.close()
+    frontend_process.wait()
+    if frontend_process.returncode != OK_RETURN_CODE:
+        return frontend_process.returncode
+    clangxx_process = subprocess.Popen(clangxx_args, stdin=opt_process.stdout)
+    opt_process.stdout.close()
+    opt_process.wait()
+    if opt_process.returncode != OK_RETURN_CODE:
+        return opt_process.returncode
+    clangxx_process.wait()
+    opt_process.wait()
+    if opt_process.returncode != OK_RETURN_CODE:
+        return opt_process.returncode
+    clangxx_process.wait()
+    return clangxx_process.returncode

--- a/toolchain/Spoor.xctoolchain/usr/bin/swift
+++ b/toolchain/Spoor.xctoolchain/usr/bin/swift
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+from shared import DEFAULT_SWIFT, OBJECT_FILE_EXTENSION
+from shared import flatten, instrument_and_compile_ir
+import argparse
+import subprocess
+import sys
+
+SWIFT_EMIT_IR_ARG = '-emit-ir'
+SWIFT_OUTPUT_FILE_ARG = '-o'
+SWIFT_TARGET_ARG = '-target'
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        SWIFT_OUTPUT_FILE_ARG,
+        action='append',
+        dest='output_files',
+        nargs=1,
+    )
+    parser.add_argument(
+        SWIFT_TARGET_ARG,
+        dest='target',
+        nargs=1,
+    )
+    args, other_args = parser.parse_known_args()
+
+    output_files = flatten(args.output_files)
+    if not output_files or \
+            not all(f.endswith(OBJECT_FILE_EXTENSION) for f in output_files):
+        swift_args = [DEFAULT_SWIFT] + sys.argv[1:]
+        swift_process = subprocess.Popen(swift_args)
+        swift_process.wait()
+        sys.exit(swift_process.returncode)
+
+    if len(output_files) != 1:
+        message = f'Expected exactly one output file, got {len(output_files)}'
+        raise ValueError(message)
+    output_file = output_files[0]
+
+    if not args.target:
+        raise ValueError('No target was supplied')
+    target = args.target[0]
+
+    swift_args = [DEFAULT_SWIFT]
+    swift_args += other_args
+    swift_args += [SWIFT_TARGET_ARG, target]
+    swift_args += [SWIFT_EMIT_IR_ARG]
+
+    swift_process = subprocess.Popen(swift_args, stdout=subprocess.PIPE)
+    return_code = instrument_and_compile_ir(swift_process, output_file, target)
+    sys.exit(return_code)
+
+
+if __name__ == '__main__':
+    main()

--- a/toolchain/Spoor.xctoolchain/usr/bin/swiftc
+++ b/toolchain/Spoor.xctoolchain/usr/bin/swiftc
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+from shared import WRAPPED_SWIFT, DEFAULT_SWIFTC
+import subprocess
+import sys
+
+DISABLE_BATCH_MODE_ARG = '-disable-batch-mode'
+DRIVER_USE_FRONTEND_PATH_ARG = '-driver-use-frontend-path'
+ENABLE_BATCH_MODE_ARG = '-enable-batch-mode'
+WHOLE_MODULE_OPTIMIZATION_ARG = '-whole-module-optimization'
+
+def main():
+    args = sys.argv[1:]
+    # Swift compilation modes:
+    # https://github.com/apple/swift/blob/main/docs/CompilerPerformance.md
+    for mode in [ENABLE_BATCH_MODE_ARG, WHOLE_MODULE_OPTIMIZATION_ARG]:
+        args = [DISABLE_BATCH_MODE_ARG if arg == mode else arg for arg in args]
+    if DISABLE_BATCH_MODE_ARG not in args:
+        args.append(DISABLE_BATCH_MODE_ARG)
+
+    swiftc_args = [DEFAULT_SWIFTC]
+    swiftc_args += [DRIVER_USE_FRONTEND_PATH_ARG, WRAPPED_SWIFT]
+    swiftc_args += args
+
+    swiftc_process = subprocess.Popen(swiftc_args)
+    swiftc_process.wait()
+    sys.exit(swiftc_process.returncode)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
WORK IN PROGRESS

Implements wrapper scripts around `swift`, `swiftc`, and `clang` to seamlessly inject instrumentation. To achieve this, the wrapper scripts:
1. Run the compiler frontend and emit LLVM IR instead of compiling right down to an object file.
2. Run Spoor's instrumentation pass over the IR. As part of this process, the instrumentation emits a `.spoor_function_map` file mapping function IDs to debug information such as the demangled function name, file, and line number. This is used for symbolication when processing trace files offline.
3. Compile the IR down to an object file.

The intention is for these wrapper scripts to _behave_ like the actual `swift`, `swiftc`, and `clang` binaries. Note that these tools are very complex with an umpteen number of features and mechanisms to achieve the same result (for example, clang can be used as a C/C++/Objective-C/Objective-C++ (and more!) compiler, an assembler, and/or a linker). **The goal with these wrapper scripts (for now) is to provide the required functionality for use with Xcode, not to work in every possible use case.** Detecting how the tool is used is achieved using heuristics on the supplied flags.

Note: In Swift, the wrapper scripts disables batched and whole-module modes which unfortunately can double or triple the build time. We'll support other compilation modes in a future PR.

To use the toolchain in Xcode:
* Installation: Copy or symlink `Spoor.xctoolchain` into `~/Library/Developer/Toolchains`.
* Enable: Xcode menu > Toolchains > Spoor, then rebuild. That's it!

<img width="553" alt="Screen Shot 2021-02-09 at 9 29 24 PM" src="https://user-images.githubusercontent.com/11789857/107469043-e5e2c600-6b1d-11eb-8554-d31e447beac7.png">

#### TODO
- [ ] Integrate with the build system.
- [ ] Configuration to run optimizations before and/or after instrumentation.
- [ ] Configuration for the function map output file location.
- [ ] Configuration to strip debug information after running the instrumentation pass.
- [ ] Add required libraries to `Spoor.xctoolchain/spoor/`.
- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Python [style guide](https://google.github.io/styleguide/pyguide.html) (and update code to conform).
- [ ] Supporting tooling (pylint, copyright header, etc.).
- [ ] This logic probably warrants some inline documentation.
- [ ] Code cleanup.