### PR TITLE
Update clang_tidy.sh TODO

### DIFF
--- a/toolchain/style/clang_tidy.sh
+++ b/toolchain/style/clang_tidy.sh
@@ -33,13 +33,10 @@ echo "Building C++ targets"
 bazel build $(bazel query 'kind(cc_.*, //...)')
 
 if [ $# -eq 0 ]; then
-  # TODO(#42): Do not exclude `event_logger_notifier_mock.h`.
-  # TODO(#37): Do not exclude `flush_queue_mock.h`.
   # `runtime.h` is excluded because the header uses a C-style API which emits
   # numerous warnings. Suppressing the warnings via NOLINT adds a considerable
   # amount of visual noise.
-  # TODO(#49): Do not exclude `trace_reader_mock.h`.
-  # TODO(#34): Do not exclude `trace_writer_mock.h`.
+  # TODO(#86): Compilation database support for header-only libraries.
   find "$WORKSPACE" \
     -type f \
     \( -iname "*.h" -o -iname "*.cc" \) \


### PR DESCRIPTION
Updates the TODO in `clang_tidy.sh` to reference the consolidated ticket for header-only library compilation database support (#86).