### PR TITLE
Gardening and runtime interface refactoring

### DIFF
--- a/spoor/instrumentation/BUILD
+++ b/spoor/instrumentation/BUILD
@@ -44,6 +44,7 @@ cc_binary(
 
 sh_test(
     name = "register_pass_test",
+    size = "small",
     srcs = ["register_pass_test.sh"],
     data = [
         ":libspoor_instrumentation.dylib",

--- a/spoor/instrumentation/inject_runtime/inject_runtime_test.cc
+++ b/spoor/instrumentation/inject_runtime/inject_runtime_test.cc
@@ -342,9 +342,6 @@ TEST(InjectRuntime, OutputsInstrumentedFunctionMap) {  // NOLINT
     InstrumentedFunctionMap instrumented_function_map{};
     instrumented_function_map.ParseFromString(buffer);
 
-    std::cerr << instrumented_function_map.DebugString() << "\n\n";
-    std::cerr << expected_instrumented_function_map.DebugString() << '\n';
-
     ASSERT_TRUE(MessageDifferencer::Equals(instrumented_function_map,
                                            expected_instrumented_function_map));
   }

--- a/spoor/runtime/BUILD
+++ b/spoor/runtime/BUILD
@@ -6,7 +6,10 @@ load("//toolchain:cc_static_library.bzl", "cc_static_library")
 
 cc_library(
     name = "runtime",
-    srcs = ["runtime.cc"],
+    srcs = [
+        "runtime.cc",
+        "runtime_common.cc",
+    ],
     hdrs = ["runtime.h"],
     copts = ["-Werror"],
     visibility = ["//visibility:public"],
@@ -28,10 +31,14 @@ cc_static_library(
 
 cc_library(
     name = "runtime_stub",
-    srcs = ["runtime_stub.cc"],
+    srcs = [
+        "runtime_common.cc",
+        "runtime_stub.cc",
+    ],
     hdrs = ["runtime.h"],
     copts = ["-Werror"],
     visibility = ["//visibility:public"],
+    deps = ["@com_microsoft_gsl//:gsl"],
 )
 
 cc_static_library(
@@ -42,11 +49,16 @@ cc_static_library(
 cc_test(
     name = "runtime_test",
     size = "small",
-    srcs = ["runtime_test.cc"],
+    srcs = [
+        "runtime_common_test.cc",
+        "runtime_test.cc",
+    ],
     copts = ["-Werror"],
     visibility = ["//visibility:private"],
     deps = [
         ":runtime",
+        "@com_google_absl//absl/synchronization",
+        "@com_google_absl//absl/time",
         "@com_google_googletest//:gtest_main",
         "@com_microsoft_gsl//:gsl",
     ],

--- a/spoor/runtime/buffer/buffer_slice_test.cc
+++ b/spoor/runtime/buffer/buffer_slice_test.cc
@@ -25,8 +25,8 @@ auto Slices(gsl::span<ValueType> buffer)
     -> std::vector<std::unique_ptr<BufferSlice>> {
   std::vector<std::unique_ptr<BufferSlice>> slices{};
   slices.reserve(2);
-  slices.push_back(std::make_unique<OwnedBufferSlice>(buffer.size()));
-  slices.push_back(std::make_unique<UnownedBufferSlice>(buffer));
+  slices.emplace_back(std::make_unique<OwnedBufferSlice>(buffer.size()));
+  slices.emplace_back(std::make_unique<UnownedBufferSlice>(buffer));
   return slices;
 }
 
@@ -38,7 +38,7 @@ TEST(BufferSlice, ContiguousMemoryChunksOneChunk) {  // NOLINT
     std::vector<ValueType> expected{};
     for (SizeType i{0}; i < capacity; ++i) {
       slice->Push(i);
-      expected.push_back(i);
+      expected.emplace_back(i);
       const auto chunks = slice->ContiguousMemoryChunks();
       ASSERT_EQ(chunks.size(), 1);
       auto chunk = chunks.front();

--- a/spoor/runtime/buffer/circular_buffer_test.cc
+++ b/spoor/runtime/buffer/circular_buffer_test.cc
@@ -44,11 +44,12 @@ auto MakeBuffers(
   using CircularSliceBuffer = spoor::runtime::buffer::CircularSliceBuffer<T>;
   std::vector<std::unique_ptr<CircularBuffer>> circular_buffers{};
   circular_buffers.reserve(3);
-  circular_buffers.push_back(std::make_unique<UnownedBufferSlice>(buffer));
-  circular_buffers.push_back(std::make_unique<OwnedBufferSlice>(buffer.size()));
+  circular_buffers.emplace_back(std::make_unique<UnownedBufferSlice>(buffer));
+  circular_buffers.emplace_back(
+      std::make_unique<OwnedBufferSlice>(buffer.size()));
   const typename CircularSliceBuffer::Options circular_slice_buffer_options{
       .buffer_slice_pool = pool, .capacity = pool->Capacity()};
-  circular_buffers.push_back(
+  circular_buffers.emplace_back(
       std::make_unique<CircularSliceBuffer>(circular_slice_buffer_options));
   return circular_buffers;
 }

--- a/spoor/runtime/buffer/circular_slice_buffer.h
+++ b/spoor/runtime/buffer/circular_slice_buffer.h
@@ -147,7 +147,7 @@ constexpr auto CircularSliceBuffer<T>::ContiguousMemoryChunks()
   const auto insertion_iterator_chunks =
       (*insertion_iterator_)->ContiguousMemoryChunks();
   if (1 < insertion_iterator_chunks.size()) {
-    chunks.push_back(insertion_iterator_chunks.front());
+    chunks.emplace_back(insertion_iterator_chunks.front());
   }
   for (auto iterator = std::next(insertion_iterator_);
        iterator != std::cend(slices_); ++iterator) {
@@ -161,7 +161,7 @@ constexpr auto CircularSliceBuffer<T>::ContiguousMemoryChunks()
     chunks.insert(std::cend(chunks), std::cbegin(slice_chunks),
                   std::cend(slice_chunks));
   }
-  chunks.push_back(insertion_iterator_chunks.back());
+  chunks.emplace_back(insertion_iterator_chunks.back());
   return chunks;
 }
 
@@ -179,7 +179,7 @@ constexpr auto CircularSliceBuffer<T>::PrepareToPush() -> void {
       if (result.IsOk()) {
         auto buffer_slice = std::move(result.Ok());
         acquired_slices_capacity_ += buffer_slice->Capacity();
-        slices_.push_back(std::move(buffer_slice));
+        slices_.emplace_back(std::move(buffer_slice));
         insertion_iterator_ = std::prev(std::end(slices_));
       } else {
         insertion_iterator_ = std::begin(slices_);

--- a/spoor/runtime/buffer/combined_buffer_slice_pool.h
+++ b/spoor/runtime/buffer/combined_buffer_slice_pool.h
@@ -116,7 +116,7 @@ constexpr auto CombinedBufferSlicePool<T>::Return(Collection&& slices)
   for (auto& slice : slices) {
     auto result = Return(std::move(slice));
     if (result.IsErr()) {
-      slices_owned_by_other_pools.push_back(std::move(result.Err()));
+      slices_owned_by_other_pools.emplace_back(std::move(result.Err()));
     }
   }
   return slices_owned_by_other_pools;

--- a/spoor/runtime/buffer/dynamic_buffer_slice_pool_test.cc
+++ b/spoor/runtime/buffer/dynamic_buffer_slice_pool_test.cc
@@ -3,7 +3,6 @@
 
 #include "spoor/runtime/buffer/dynamic_buffer_slice_pool.h"
 
-#include <future>
 #include <limits>
 #include <thread>
 #include <vector>
@@ -40,7 +39,7 @@ TEST(DynamicBufferSlicePool, BorrowsPreferredSliceCapacity) {  // NOLINT
     ASSERT_TRUE(result.IsOk());
     auto slice = std::move(result.Ok());
     ASSERT_EQ(slice->Capacity(), size);
-    retained_slices.push_back(std::move(slice));
+    retained_slices.emplace_back(std::move(slice));
   }
 }
 

--- a/spoor/runtime/buffer/reserved_buffer_slice_pool.h
+++ b/spoor/runtime/buffer/reserved_buffer_slice_pool.h
@@ -99,14 +99,14 @@ constexpr ReservedBufferSlicePool<T>::ReservedBufferSlicePool(
           auto* buffer =
               std::next(buffer_.data(), options.max_slice_capacity * index);
           const gsl::span<T> unowned_buffer{buffer, options.max_slice_capacity};
-          pool.push_back(UnownedSlice{unowned_buffer});
+          pool.emplace_back(UnownedSlice{unowned_buffer});
         }
         if (remainder_slice_buffer_size != 0) {
           auto* buffer = std::next(
               buffer_.data(), options.max_slice_capacity * (slices_size - 1));
           const gsl::span<T> unowned_buffer{buffer,
                                             remainder_slice_buffer_size};
-          pool.push_back(UnownedSlice{unowned_buffer});
+          pool.emplace_back(UnownedSlice{unowned_buffer});
         }
         return pool;
       }()},

--- a/spoor/runtime/buffer/reserved_buffer_slice_pool_test.cc
+++ b/spoor/runtime/buffer/reserved_buffer_slice_pool_test.cc
@@ -38,7 +38,7 @@ TEST(ReservedBufferSlicePool, BorrowsMaxSliceCapacity) {  // NOLINT
       ASSERT_TRUE(result.IsOk());
       auto slice = std::move(result.Ok());
       ASSERT_EQ(slice->Capacity(), capacity);
-      retained_slices.push_back(std::move(slice));
+      retained_slices.emplace_back(std::move(slice));
     }
   }
 }

--- a/spoor/runtime/flush_queue/BUILD
+++ b/spoor/runtime/flush_queue/BUILD
@@ -36,6 +36,8 @@ cc_test(
         "//util:numeric",
         "//util/time:clock_mock",
         "@com_google_absl//absl/strings:str_format",
+        "@com_google_absl//absl/synchronization",
+        "@com_google_absl//absl/time",
         "@com_google_googletest//:gtest_main",
         "@com_microsoft_gsl//:gsl",
     ],
@@ -64,6 +66,8 @@ cc_test(
         ":black_hole_flush_queue",
         "//spoor/runtime/buffer",
         "//spoor/runtime/trace",
+        "@com_google_absl//absl/synchronization",
+        "@com_google_absl//absl/time",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/spoor/runtime/flush_queue/disk_flush_queue.cc
+++ b/spoor/runtime/flush_queue/disk_flush_queue.cc
@@ -122,12 +122,10 @@ auto DiskFlushQueue::Flush(std::function<void()> completion) -> void {
   const auto now = options_.steady_clock->Now();
   std::unique_lock lock{lock_};
   flush_timestamp_ = now;
-  if (completion != nullptr) {
-    flush_completion_ = completion;
-    for (const auto& record : queue_) {
-      if (record.flush_timestamp <= now) {
-        manual_flush_record_ids_.emplace(record.id);
-      }
+  if (completion != nullptr) flush_completion_ = completion;
+  for (const auto& record : queue_) {
+    if (record.flush_timestamp <= now) {
+      manual_flush_record_ids_.emplace(record.id);
     }
   }
 }

--- a/spoor/runtime/runtime.h
+++ b/spoor/runtime/runtime.h
@@ -18,10 +18,11 @@ typedef int64_t _spoor_runtime_DurationNanoseconds;
 typedef int64_t _spoor_runtime_SystemTimestampSeconds;
 
 typedef struct _spoor_runtime_TraceFiles {
-  int32_t size;
-  // NOTE: The caller takes ownership of the file_paths array and is responsible
-  // for releasing the memory, e.g. by calling
+  _spoor_runtime_SizeType file_paths_size;
+  // NOTE: The caller takes ownership of `file_path_sizes` and `file_paths`, and
+  // is responsible for releasing the memory, e.g., by calling
   // `_spoor_runtime_ReleaseTraceFilePaths`.
+  _spoor_runtime_SizeType* file_path_sizes;
   char** file_paths;
 } _spoor_runtime_TraceFiles;
 
@@ -31,7 +32,8 @@ typedef struct _spoor_runtime_DeletedFilesInfo {
 } _spoor_runtime_DeletedFilesInfo;
 
 typedef struct _spoor_runtime_Config {
-  const char* trace_file_path;
+  _spoor_runtime_SizeType trace_file_path_size;
+  const char* trace_file_path;  // Non-owning
   _spoor_runtime_SessionId session_id;
   _spoor_runtime_SizeType thread_event_buffer_capacity;
   _spoor_runtime_SizeType max_reserved_event_buffer_slice_capacity;
@@ -95,11 +97,6 @@ void _spoor_runtime_ClearTraceEvents();
 void _spoor_runtime_FlushedTraceFiles(
     _spoor_runtime_FlushedTraceFilesCallback callback);
 
-// Release the memory owned by a `_spoor_runtime_TraceFiles` object (but not
-// the object itself).
-void _spoor_runtime_ReleaseTraceFilePaths(
-    _spoor_runtime_TraceFiles* trace_files);
-
 // Delete all trace files older than a given timestamp.
 void _spoor_runtime_DeleteFlushedTraceFilesOlderThan(
     _spoor_runtime_SystemTimestampSeconds system_timestamp,
@@ -111,8 +108,34 @@ _spoor_runtime_Config _spoor_runtime_GetConfig();
 // Check if the runtime contains stub implementations.
 bool _spoor_runtime_StubImplementation();
 
+// Release the memory owned by a `_spoor_runtime_TraceFiles` object (but not
+// the object itself).
+// Implemented in the stub.
+void _spoor_runtime_ReleaseTraceFilePaths(
+    _spoor_runtime_TraceFiles* trace_files);
+
+// Struct equality.
+// Implemented in the stub.
+bool _spoor_runtime_DeletedFilesInfoEqual(
+    const _spoor_runtime_DeletedFilesInfo* lhs,
+    const _spoor_runtime_DeletedFilesInfo* rhs);
+bool _spoor_runtime_TraceFilesEqual(const _spoor_runtime_TraceFiles* lhs,
+                                    const _spoor_runtime_TraceFiles* rhs);
+bool _spoor_runtime_ConfigEqual(const _spoor_runtime_Config* lhs,
+                                const _spoor_runtime_Config* rhs);
+
 #ifdef __cplusplus
 }
+#endif
+
+#ifdef __cplusplus
+// Implemented in the stub.
+auto operator==(const _spoor_runtime_DeletedFilesInfo& lhs,
+                const _spoor_runtime_DeletedFilesInfo& rhs) -> bool;
+auto operator==(const _spoor_runtime_TraceFiles& lhs,
+                const _spoor_runtime_TraceFiles& rhs) -> bool;
+auto operator==(const _spoor_runtime_Config& lhs,
+                const _spoor_runtime_Config& rhs) -> bool;
 #endif
 
 #endif

--- a/spoor/runtime/runtime_common.cc
+++ b/spoor/runtime/runtime_common.cc
@@ -1,0 +1,105 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include <cstring>
+
+#include "gsl/gsl"
+#include "spoor/runtime/runtime.h"
+
+auto _spoor_runtime_ReleaseTraceFilePaths(
+    _spoor_runtime_TraceFiles* trace_files) -> void {
+  gsl::span file_paths{trace_files->file_paths,
+                       static_cast<std::size_t>(trace_files->file_paths_size)};
+  for (auto* path : file_paths) {
+    // clang-format off NOLINTNEXTLINE(cppcoreguidelines-no-malloc, cppcoreguidelines-owning-memory) clang-format on
+    free(path);
+  }
+  // clang-format off NOLINTNEXTLINE(cppcoreguidelines-no-malloc, cppcoreguidelines-owning-memory) clang-format on
+  free(trace_files->file_paths);
+  trace_files->file_paths = nullptr;
+  // clang-format off NOLINTNEXTLINE(cppcoreguidelines-no-malloc, cppcoreguidelines-owning-memory) clang-format on
+  free(trace_files->file_path_sizes);
+  trace_files->file_path_sizes = nullptr;
+  trace_files->file_paths_size = 0;
+}
+
+auto _spoor_runtime_DeletedFilesInfoEqual(
+    const _spoor_runtime_DeletedFilesInfo* lhs,
+    const _spoor_runtime_DeletedFilesInfo* rhs) -> bool {
+  if (lhs == rhs) return true;
+  if (lhs == nullptr || rhs == nullptr) return false;
+  return lhs->deleted_files == rhs->deleted_files &&
+         lhs->deleted_bytes == rhs->deleted_bytes;
+}
+
+auto _spoor_runtime_TraceFilesEqual(const _spoor_runtime_TraceFiles* lhs,
+                                    const _spoor_runtime_TraceFiles* rhs)
+    -> bool {
+  if (lhs == rhs) return true;
+  if (lhs == nullptr || rhs == nullptr) return false;
+  if (lhs->file_paths_size != rhs->file_paths_size) return false;
+  if (lhs->file_paths_size == 0) return true;
+  if (lhs->file_path_sizes == nullptr || lhs->file_paths == nullptr ||
+      rhs->file_path_sizes == nullptr || rhs->file_paths == nullptr) {
+    return false;
+  }
+  const gsl::span<_spoor_runtime_SizeType> lhs_file_path_sizes{
+      lhs->file_path_sizes, lhs->file_paths_size};
+  const gsl::span<_spoor_runtime_SizeType> rhs_file_path_sizes{
+      rhs->file_path_sizes, rhs->file_paths_size};
+  const gsl::span<char*> lhs_file_paths{lhs->file_paths, lhs->file_paths_size};
+  const gsl::span<char*> rhs_file_paths{rhs->file_paths, rhs->file_paths_size};
+  for (_spoor_runtime_SizeType file_path{0}; file_path < lhs_file_paths.size();
+       ++file_path) {
+    if (lhs_file_path_sizes[file_path] != rhs_file_path_sizes[file_path]) {
+      return false;
+    }
+    const auto result =
+        std::strncmp(lhs_file_paths[file_path], rhs_file_paths[file_path],
+                     lhs_file_path_sizes[file_path]);
+    if (result != 0) return false;
+  }
+  return true;
+}
+
+auto _spoor_runtime_ConfigEqual(const _spoor_runtime_Config* lhs,
+                                const _spoor_runtime_Config* rhs) -> bool {
+  if (lhs == rhs) return true;
+  if (lhs == nullptr || rhs == nullptr) return false;
+  if (lhs->trace_file_path_size != rhs->trace_file_path_size) return false;
+  const auto result = std::strncmp(lhs->trace_file_path, rhs->trace_file_path,
+                                   lhs->trace_file_path_size);
+  if (result != 0) return false;
+  return lhs->session_id == rhs->session_id &&
+         lhs->thread_event_buffer_capacity ==
+             rhs->thread_event_buffer_capacity &&
+         lhs->max_reserved_event_buffer_slice_capacity ==
+             rhs->max_reserved_event_buffer_slice_capacity &&
+         lhs->max_dynamic_event_buffer_slice_capacity ==
+             rhs->max_dynamic_event_buffer_slice_capacity &&
+         lhs->reserved_event_pool_capacity ==
+             rhs->reserved_event_pool_capacity &&
+         lhs->dynamic_event_pool_capacity == rhs->dynamic_event_pool_capacity &&
+         lhs->dynamic_event_slice_borrow_cas_attempts ==
+             rhs->dynamic_event_slice_borrow_cas_attempts &&
+         lhs->event_buffer_retention_duration_nanoseconds ==
+             rhs->event_buffer_retention_duration_nanoseconds &&
+         lhs->max_flush_buffer_to_file_attempts ==
+             rhs->max_flush_buffer_to_file_attempts &&
+         lhs->flush_all_events == rhs->flush_all_events;
+}
+
+auto operator==(const _spoor_runtime_DeletedFilesInfo& lhs,
+                const _spoor_runtime_DeletedFilesInfo& rhs) -> bool {
+  return _spoor_runtime_DeletedFilesInfoEqual(&lhs, &rhs);
+}
+
+auto operator==(const _spoor_runtime_TraceFiles& lhs,
+                const _spoor_runtime_TraceFiles& rhs) -> bool {
+  return _spoor_runtime_TraceFilesEqual(&lhs, &rhs);
+}
+
+auto operator==(const _spoor_runtime_Config& lhs,
+                const _spoor_runtime_Config& rhs) -> bool {
+  return _spoor_runtime_ConfigEqual(&lhs, &rhs);
+}

--- a/spoor/runtime/runtime_common_test.cc
+++ b/spoor/runtime/runtime_common_test.cc
@@ -1,0 +1,224 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include <array>
+#include <string>
+
+#include "gsl/gsl"
+#include "gtest/gtest.h"
+#include "spoor/runtime/runtime.h"
+
+namespace {
+
+TEST(Runtime, ReleaseTraceFilePaths) {  // NOLINT
+  constexpr _spoor_runtime_TraceFiles empty_trace_files{
+      .file_paths_size = 0, .file_path_sizes = nullptr, .file_paths = nullptr};
+  constexpr auto path_a_size{5};
+  constexpr auto path_b_size{10};
+  constexpr auto paths_size{2};
+  // NOLINTNEXTLINE(cppcoreguidelines-no-malloc)
+  gsl::span<char> path_a{static_cast<char*>(malloc(sizeof(char) * path_a_size)),
+                         path_a_size};
+  // NOLINTNEXTLINE(cppcoreguidelines-no-malloc)
+  gsl::span<char> path_b{static_cast<char*>(malloc(sizeof(char) * path_b_size)),
+                         path_b_size};
+  gsl::span<_spoor_runtime_SizeType> path_sizes{
+      static_cast<_spoor_runtime_SizeType*>(
+          // NOLINTNEXTLINE(cppcoreguidelines-no-malloc)
+          malloc(sizeof(_spoor_runtime_SizeType) * paths_size)),
+      paths_size};
+  gsl::span<char*> paths{
+      // NOLINTNEXTLINE(cppcoreguidelines-no-malloc)
+      static_cast<char**>(malloc(sizeof(char*) * paths_size)), paths_size};
+  paths[0] = path_a.data();
+  paths[1] = path_b.data();
+  _spoor_runtime_TraceFiles trace_files{.file_paths_size = 2,
+                                        .file_path_sizes = path_sizes.data(),
+                                        .file_paths = paths.data()};
+  ASSERT_NE(trace_files, empty_trace_files);
+  _spoor_runtime_ReleaseTraceFilePaths(&trace_files);
+  ASSERT_EQ(trace_files, empty_trace_files);
+  _spoor_runtime_ReleaseTraceFilePaths(&trace_files);
+  ASSERT_EQ(trace_files, empty_trace_files);
+}
+
+TEST(Runtime, TraceFilesEquality) {  // NOLINT
+  std::string path_a{"/path/a"};
+  std::string path_b{"/path/b"};
+  std::string path_c{"/path/to/c"};
+  std::string path_d{};
+  std::string path_e{"/path/a"};
+  ASSERT_EQ(path_a, path_e);
+  std::array<_spoor_runtime_SizeType, 4> file_path_sizes_a{
+      {path_a.size(), path_b.size(), path_c.size(), path_d.size()}};
+  std::array<char*, 4> file_paths_a{
+      {path_a.data(), path_b.data(), path_c.data(), path_d.data()}};
+  ASSERT_NE(file_paths_a.size(), 0);
+  ASSERT_EQ(file_path_sizes_a.size(), file_paths_a.size());
+  std::array<_spoor_runtime_SizeType, 1> file_path_sizes_b{{path_e.size()}};
+  std::array<char*, 1> file_paths_b{{path_e.data()}};
+  _spoor_runtime_TraceFiles trace_files_a{
+      .file_paths_size = file_paths_a.size(),
+      .file_path_sizes = file_path_sizes_a.data(),
+      .file_paths = file_paths_a.data()};
+  _spoor_runtime_TraceFiles trace_files_b{
+      .file_paths_size = file_paths_a.size(),
+      .file_path_sizes = file_path_sizes_a.data(),
+      .file_paths = file_paths_a.data()};
+  _spoor_runtime_TraceFiles trace_files_c{
+      .file_paths_size = 1,
+      .file_path_sizes = file_path_sizes_a.data(),
+      .file_paths = file_paths_a.data()};
+  _spoor_runtime_TraceFiles trace_files_d{
+      .file_paths_size = file_paths_b.size(),
+      .file_path_sizes = file_path_sizes_b.data(),
+      .file_paths = file_paths_b.data()};
+  _spoor_runtime_TraceFiles malformed_trace_files_e{
+      .file_paths_size = file_paths_a.size(),
+      .file_path_sizes = nullptr,
+      .file_paths = nullptr};
+  _spoor_runtime_TraceFiles malformed_trace_files_f{
+      .file_paths_size = file_paths_a.size(),
+      .file_path_sizes = nullptr,
+      .file_paths = file_paths_a.data()};
+  // Note: ASAN will fail when testing a struct whose `file_paths_size` is
+  // greater than the size of `file_paths_size` or `file_paths`.
+  ASSERT_TRUE(_spoor_runtime_TraceFilesEqual(nullptr, nullptr));
+  ASSERT_FALSE(_spoor_runtime_TraceFilesEqual(&trace_files_a, nullptr));
+  ASSERT_FALSE(_spoor_runtime_TraceFilesEqual(nullptr, &trace_files_a));
+  ASSERT_EQ(trace_files_a, trace_files_a);
+  ASSERT_EQ(trace_files_a, trace_files_b);
+  ASSERT_NE(trace_files_a, trace_files_c);
+  ASSERT_NE(trace_files_a, trace_files_d);
+  ASSERT_EQ(trace_files_c, trace_files_d);
+  ASSERT_EQ(malformed_trace_files_e, malformed_trace_files_e);
+  ASSERT_NE(trace_files_a, malformed_trace_files_e);
+  ASSERT_NE(trace_files_a, malformed_trace_files_f);
+  ASSERT_NE(malformed_trace_files_e, malformed_trace_files_f);
+}
+
+TEST(Runtime, DeletedFilesInfoEquality) {  // NOLINT
+  constexpr _spoor_runtime_DeletedFilesInfo info_a{.deleted_files = 1,
+                                                   .deleted_bytes = 2};
+  constexpr _spoor_runtime_DeletedFilesInfo info_b{.deleted_files = 1,
+                                                   .deleted_bytes = 2};
+  constexpr _spoor_runtime_DeletedFilesInfo info_c{.deleted_files = 0,
+                                                   .deleted_bytes = 0};
+  ASSERT_TRUE(_spoor_runtime_DeletedFilesInfoEqual(nullptr, nullptr));
+  ASSERT_FALSE(_spoor_runtime_DeletedFilesInfoEqual(&info_a, nullptr));
+  ASSERT_FALSE(_spoor_runtime_DeletedFilesInfoEqual(nullptr, &info_a));
+  ASSERT_EQ(info_a, info_a);
+  ASSERT_EQ(info_a, info_b);
+  ASSERT_NE(info_a, info_c);
+}
+
+TEST(Runtime, ConfigEquality) {  // NOLINT
+  constexpr std::string_view path_a{"/path/to/file"};
+  constexpr _spoor_runtime_Config config_a{
+      .trace_file_path_size = path_a.size(),
+      .trace_file_path = path_a.data(),
+      .session_id = 1,
+      .thread_event_buffer_capacity = 2,
+      .max_reserved_event_buffer_slice_capacity = 3,
+      .max_dynamic_event_buffer_slice_capacity = 4,
+      .reserved_event_pool_capacity = 5,
+      .dynamic_event_pool_capacity = 6,
+      .dynamic_event_slice_borrow_cas_attempts = 7,
+      .event_buffer_retention_duration_nanoseconds = 8,
+      .max_flush_buffer_to_file_attempts = 9,
+      .flush_all_events = true};
+  constexpr _spoor_runtime_Config config_b{
+      .trace_file_path_size = path_a.size(),
+      .trace_file_path = path_a.data(),
+      .session_id = 1,
+      .thread_event_buffer_capacity = 2,
+      .max_reserved_event_buffer_slice_capacity = 3,
+      .max_dynamic_event_buffer_slice_capacity = 4,
+      .reserved_event_pool_capacity = 5,
+      .dynamic_event_pool_capacity = 6,
+      .dynamic_event_slice_borrow_cas_attempts = 7,
+      .event_buffer_retention_duration_nanoseconds = 8,
+      .max_flush_buffer_to_file_attempts = 9,
+      .flush_all_events = true};
+  constexpr std::string_view path_c{"/path/to/file"};
+  ASSERT_EQ(path_a, path_c);
+  constexpr _spoor_runtime_Config config_c{
+      .trace_file_path_size = path_c.size(),
+      .trace_file_path = path_c.data(),
+      .session_id = 1,
+      .thread_event_buffer_capacity = 2,
+      .max_reserved_event_buffer_slice_capacity = 3,
+      .max_dynamic_event_buffer_slice_capacity = 4,
+      .reserved_event_pool_capacity = 5,
+      .dynamic_event_pool_capacity = 6,
+      .dynamic_event_slice_borrow_cas_attempts = 7,
+      .event_buffer_retention_duration_nanoseconds = 8,
+      .max_flush_buffer_to_file_attempts = 9,
+      .flush_all_events = true};
+  constexpr std::string_view path_d{"xxxxxxxxxxxxx"};
+  ASSERT_EQ(path_a.size(), path_d.size());
+  constexpr _spoor_runtime_Config config_d{
+      .trace_file_path_size = path_d.size(),
+      .trace_file_path = path_d.data(),
+      .session_id = 1,
+      .thread_event_buffer_capacity = 2,
+      .max_reserved_event_buffer_slice_capacity = 3,
+      .max_dynamic_event_buffer_slice_capacity = 4,
+      .reserved_event_pool_capacity = 5,
+      .dynamic_event_pool_capacity = 6,
+      .dynamic_event_slice_borrow_cas_attempts = 7,
+      .event_buffer_retention_duration_nanoseconds = 8,
+      .max_flush_buffer_to_file_attempts = 9,
+      .flush_all_events = true};
+  constexpr _spoor_runtime_Config config_e{
+      .trace_file_path_size = path_a.size(),
+      .trace_file_path = path_a.data(),
+      .session_id = 0,
+      .thread_event_buffer_capacity = 0,
+      .max_reserved_event_buffer_slice_capacity = 0,
+      .max_dynamic_event_buffer_slice_capacity = 0,
+      .reserved_event_pool_capacity = 0,
+      .dynamic_event_pool_capacity = 0,
+      .dynamic_event_slice_borrow_cas_attempts = 0,
+      .event_buffer_retention_duration_nanoseconds = 0,
+      .max_flush_buffer_to_file_attempts = 0,
+      .flush_all_events = false};
+  constexpr _spoor_runtime_Config malformed_config_f{
+      .trace_file_path_size = 1,
+      .trace_file_path = nullptr,
+      .session_id = 1,
+      .thread_event_buffer_capacity = 2,
+      .max_reserved_event_buffer_slice_capacity = 3,
+      .max_dynamic_event_buffer_slice_capacity = 4,
+      .reserved_event_pool_capacity = 5,
+      .dynamic_event_pool_capacity = 6,
+      .dynamic_event_slice_borrow_cas_attempts = 7,
+      .event_buffer_retention_duration_nanoseconds = 8,
+      .max_flush_buffer_to_file_attempts = 9,
+      .flush_all_events = true};
+  constexpr _spoor_runtime_Config malformed_config_g{
+      .trace_file_path_size = 1,
+      .trace_file_path = path_a.data(),
+      .session_id = 1,
+      .thread_event_buffer_capacity = 2,
+      .max_reserved_event_buffer_slice_capacity = 3,
+      .max_dynamic_event_buffer_slice_capacity = 4,
+      .reserved_event_pool_capacity = 5,
+      .dynamic_event_pool_capacity = 6,
+      .dynamic_event_slice_borrow_cas_attempts = 7,
+      .event_buffer_retention_duration_nanoseconds = 8,
+      .max_flush_buffer_to_file_attempts = 9,
+      .flush_all_events = true};
+  ASSERT_TRUE(_spoor_runtime_ConfigEqual(nullptr, nullptr));
+  ASSERT_FALSE(_spoor_runtime_ConfigEqual(&config_a, nullptr));
+  ASSERT_FALSE(_spoor_runtime_ConfigEqual(nullptr, &config_a));
+  ASSERT_EQ(config_a, config_a);
+  ASSERT_EQ(config_a, config_b);
+  ASSERT_EQ(config_a, config_c);
+  ASSERT_NE(config_a, config_d);
+  ASSERT_NE(config_a, config_e);
+  ASSERT_NE(config_a, malformed_config_f);
+  ASSERT_NE(config_a, malformed_config_g);
+}
+
+}  // namespace

--- a/spoor/runtime/runtime_manager/BUILD
+++ b/spoor/runtime/runtime_manager/BUILD
@@ -36,6 +36,9 @@ cc_test(
         "//spoor/runtime/trace:trace_mock",
         "//util/file_system:file_system_mock",
         "//util/time:clock_mock",
+        "@com_google_absl//absl/strings:str_format",
+        "@com_google_absl//absl/synchronization",
+        "@com_google_absl//absl/time",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/spoor/runtime/runtime_manager/runtime_manager.cc
+++ b/spoor/runtime/runtime_manager/runtime_manager.cc
@@ -131,4 +131,10 @@ auto RuntimeManager::Enabled() const -> bool {
   return enabled_;
 }
 
+auto operator==(const RuntimeManager::DeletedFilesInfo& lhs,
+                const RuntimeManager::DeletedFilesInfo& rhs) -> bool {
+  return lhs.deleted_files == rhs.deleted_files &&
+         lhs.deleted_bytes == rhs.deleted_bytes;
+}
+
 }  // namespace spoor::runtime::runtime_manager

--- a/spoor/runtime/runtime_manager/runtime_manager.h
+++ b/spoor/runtime/runtime_manager/runtime_manager.h
@@ -146,4 +146,7 @@ auto RuntimeManager::DeleteFlushedTraceFilesOlderThan(
   }}.detach();
 }
 
+auto operator==(const RuntimeManager::DeletedFilesInfo& lhs,
+                const RuntimeManager::DeletedFilesInfo& rhs) -> bool;
+
 }  // namespace spoor::runtime::runtime_manager

--- a/spoor/runtime/runtime_stub.cc
+++ b/spoor/runtime/runtime_stub.cc
@@ -32,11 +32,10 @@ auto _spoor_runtime_ClearTraceEvents() -> void {}
 auto _spoor_runtime_FlushedTraceFiles(
     const _spoor_runtime_FlushedTraceFilesCallback callback) -> void {
   if (callback == nullptr) return;
-  callback({.file_paths = nullptr});
+  callback({.file_paths_size = 0,
+            .file_path_sizes = nullptr,
+            .file_paths = nullptr});
 }
-
-auto _spoor_runtime_ReleaseTraceFilePaths(_spoor_runtime_TraceFiles*
-                                          /*unused*/) -> void {}
 
 auto _spoor_runtime_DeleteFlushedTraceFilesOlderThan(
     const _spoor_runtime_SystemTimestampSeconds /*unused*/,

--- a/spoor/runtime/runtime_stub_test.cc
+++ b/spoor/runtime/runtime_stub_test.cc
@@ -1,14 +1,16 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#include <future>
 #include <limits>
 
+#include "gmock/gmock.h"
 #include "gsl/gsl"
 #include "gtest/gtest.h"
 #include "spoor/runtime/runtime.h"
 
 namespace {
+
+using testing::MockFunction;
 
 TEST(Runtime, Initialize) {  // NOLINT
   ASSERT_FALSE(_spoor_runtime_RuntimeInitialized());
@@ -29,12 +31,15 @@ TEST(Runtime, Enable) {  // NOLINT
 namespace flush_trace_events_test {
 
 // clang-format off NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables, fuchsia-statically-constructed-objects) clang-format on
-std::promise<void> promise_{};
+std::function<void()> callback_{};
 
 TEST(Runtime, FlushTraceEvents) {  // NOLINT
   _spoor_runtime_FlushTraceEvents({});
-  _spoor_runtime_FlushTraceEvents([] { promise_.set_value(); });
-  promise_.get_future();
+
+  MockFunction<void()> callback{};
+  callback_ = callback.AsStdFunction();
+  EXPECT_CALL(callback, Call());
+  _spoor_runtime_FlushTraceEvents([] { callback_(); });
 }
 
 }  // namespace flush_trace_events_test
@@ -43,56 +48,61 @@ TEST(Runtime, ClearTraceEvents) {  // NOLINT
   _spoor_runtime_ClearTraceEvents();
 }
 
-namespace flused_trace_files_test {
+namespace flushed_trace_files_test {
 
 // clang-format off NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables, fuchsia-statically-constructed-objects) clang-format on
-std::promise<_spoor_runtime_TraceFiles> promise_{};
+std::function<void(_spoor_runtime_TraceFiles)> callback_{};
 
 TEST(Runtime, FlushedTraceFiles) {  // NOLINT
   _spoor_runtime_FlushedTraceFiles({});
+
+  constexpr _spoor_runtime_TraceFiles expected_trace_files{
+      .file_paths_size = 0, .file_path_sizes = nullptr, .file_paths = nullptr};
+  MockFunction<void(_spoor_runtime_TraceFiles)> callback{};
+  callback_ = callback.AsStdFunction();
+  EXPECT_CALL(callback, Call(expected_trace_files));
   _spoor_runtime_FlushedTraceFiles(
-      [](auto trace_files) { promise_.set_value(trace_files); });
-  auto future = promise_.get_future();
-  auto trace_files = future.get();
-  auto _ =
-      gsl::finally([&] { _spoor_runtime_ReleaseTraceFilePaths(&trace_files); });
-  ASSERT_EQ(trace_files.size, 0);
+      [](auto trace_files) { callback_(trace_files); });
 }
 
-}  // namespace flused_trace_files_test
+}  // namespace flushed_trace_files_test
 
 namespace delete_flushed_trace_files_older_than_test {
 
 // clang-format off NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables, fuchsia-statically-constructed-objects) clang-format on
-std::promise<_spoor_runtime_DeletedFilesInfo> promise_{};
+std::function<void(_spoor_runtime_DeletedFilesInfo)> callback_{};
 
 TEST(Runtime, DeleteFlushedTraceFilesOlderThan) {  // NOLINT
   _spoor_runtime_DeleteFlushedTraceFilesOlderThan(
       std::numeric_limits<_spoor_runtime_SystemTimestampSeconds>::min(), {});
+
+  constexpr _spoor_runtime_DeletedFilesInfo expected_deleted_files_info{
+      .deleted_files = 0, .deleted_bytes = 0};
+  MockFunction<void(_spoor_runtime_DeletedFilesInfo)> callback{};
+  callback_ = callback.AsStdFunction();
+  EXPECT_CALL(callback, Call(expected_deleted_files_info));
   _spoor_runtime_DeleteFlushedTraceFilesOlderThan(
       std::numeric_limits<_spoor_runtime_SystemTimestampSeconds>::min(),
-      [](auto deleted_files_info) { promise_.set_value(deleted_files_info); });
-  auto future = promise_.get_future();
-  const auto deletes_files_info = future.get();
-  ASSERT_EQ(deletes_files_info.deleted_files, 0);
-  ASSERT_EQ(deletes_files_info.deleted_bytes, 0);
+      [](auto deleted_files_info) { callback_(deleted_files_info); });
 }
 
 }  // namespace delete_flushed_trace_files_older_than_test
 
 TEST(Runtime, GetConfig) {  // NOLINT
+  constexpr _spoor_runtime_Config expected_config{
+      .trace_file_path = nullptr,
+      .session_id = 0,
+      .thread_event_buffer_capacity = 0,
+      .max_reserved_event_buffer_slice_capacity = 0,
+      .max_dynamic_event_buffer_slice_capacity = 0,
+      .reserved_event_pool_capacity = 0,
+      .dynamic_event_pool_capacity = 0,
+      .dynamic_event_slice_borrow_cas_attempts = 0,
+      .event_buffer_retention_duration_nanoseconds = 0,
+      .max_flush_buffer_to_file_attempts = 0,
+      .flush_all_events = false};
   const auto config = _spoor_runtime_GetConfig();
-  ASSERT_EQ(config.trace_file_path, nullptr);
-  ASSERT_EQ(config.session_id, 0);
-  ASSERT_EQ(config.thread_event_buffer_capacity, 0);
-  ASSERT_EQ(config.max_reserved_event_buffer_slice_capacity, 0);
-  ASSERT_EQ(config.max_dynamic_event_buffer_slice_capacity, 0);
-  ASSERT_EQ(config.reserved_event_pool_capacity, 0);
-  ASSERT_EQ(config.dynamic_event_pool_capacity, 0);
-  ASSERT_EQ(config.dynamic_event_slice_borrow_cas_attempts, 0);
-  ASSERT_EQ(config.event_buffer_retention_duration_nanoseconds, 0);
-  ASSERT_EQ(config.max_flush_buffer_to_file_attempts, 0);
-  ASSERT_FALSE(config.flush_all_events);
+  ASSERT_EQ(config, expected_config);
 }
 
 TEST(Runtime, StubImplementation) {  // NOLINT

--- a/toolchain/compilation_database/compilation_database_util.cc
+++ b/toolchain/compilation_database/compilation_database_util.cc
@@ -42,7 +42,7 @@ auto ParseExtraActionInfo(gsl::not_null<std::istream*> input_stream)
 
   std::vector<std::string> arguments{};
   arguments.reserve(1 + compile_info.compiler_option().size());
-  arguments.push_back(compile_info.tool());
+  arguments.emplace_back(compile_info.tool());
   arguments.insert(std::end(arguments),
                    std::cbegin(compile_info.compiler_option()),
                    std::cend(compile_info.compiler_option()));


### PR DESCRIPTION
* Adds size properties to the runtime library's structs.
* Adds equality properties to the runtime library's structs and makes the `_spoor_runtime_ReleaseTraceFiles` function common between the runtime library and its stub. Note that these exist in both the full library and the stub at the expense of a 12k (4x) binary size increase to the stub. The total size of the stub library is now 16k (non-optimized x86_64).
* Refactors async callback tests to use `MockFunction`, `EXPECT_CALL`, and `absl::Notification` (recommended practice) instead of rolling our own solution with `std::future` and `std::promise`.
* Replaces `push_back` with `emplace_back` which is at least as efficient.
* Resolves a Bazel test size warning by making the sh_test size explicit, overriding the default value which was too big.