### PR TITLE
Upgrade dependencies

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -48,16 +48,16 @@ http_archive(
 
 http_archive(
     name = "com_google_absl",
-    sha256 = "bf3f13b13a0095d926b25640e060f7e13881bd8a792705dd9e161f3c2b9aa976",
-    strip_prefix = "abseil-cpp-20200923.2",
-    urls = ["https://github.com/abseil/abseil-cpp/archive/20200923.2.tar.gz"],
+    sha256 = "ebe2ad1480d27383e4bf4211e2ca2ef312d5e6a09eba869fd2e8a5c5d553ded2",
+    strip_prefix = "abseil-cpp-20200923.3",
+    urls = ["https://github.com/abseil/abseil-cpp/archive/20200923.3.tar.gz"],
 )
 
 http_archive(
     name = "com_google_protobuf",
-    sha256 = "50ec5a07c0c55d4ec536dd49021f2e194a26bfdbc531d03d1e9d4d3e27175659",
-    strip_prefix = "protobuf-3.14.0",
-    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v3.14.0/protobuf-cpp-3.14.0.tar.gz"],
+    sha256 = "3ddaffddd73d86e4005cd304c4a4fd962c1819f4c6aa9aad1c3bb2c7f1a35647",
+    strip_prefix = "protobuf-3.15.0",
+    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v3.15.0/protobuf-cpp-3.15.0.tar.gz"],
 )
 
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
@@ -80,23 +80,23 @@ http_archive(
 
 http_archive(
     name = "com_bazelbuild_bazel",
-    sha256 = "8d3bf2767f8797efc4ff59a1ad2e3c7dd789a288689bdbc44963d4f025286c98",
-    strip_prefix = "bazel-3.7.1",
-    urls = ["https://github.com/bazelbuild/bazel/archive/3.7.1.tar.gz"],
+    sha256 = "2b9999d06466815ab1f2eb9c6fc6fceb6061efc715b4086fa99eac041976fb4f",
+    strip_prefix = "bazel-4.0.0",
+    urls = ["https://github.com/bazelbuild/bazel/archive/4.0.0.tar.gz"],
 )
 
 http_archive(
     # Dependencies require deviating from the naming convention.
     name = "io_bazel_rules_go",
-    sha256 = "81eff5df9077783b18e93d0c7ff990d8ad7a3b8b3ca5b785e1c483aacdb342d7",
-    urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.24.9/rules_go-v0.24.9.tar.gz"],
+    sha256 = "52d0a57ea12139d727883c2fef03597970b89f2cc2a05722c42d1d7d41ec065b",
+    urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.24.13/rules_go-v0.24.13.tar.gz"],
 )
 
 http_archive(
     # Dependencies require deviating from the naming convention.
     name = "bazel_gazelle",
-    sha256 = "b85f48fa105c4403326e9525ad2b2cc437babaa6e15a3fc0b1dbab0ab064bc7c",
-    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.22.2/bazel-gazelle-v0.22.2.tar.gz"],
+    sha256 = "222e49f034ca7a1d1231422cdb67066b885819885c356673cb1f72f748a3c9d4",
+    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.22.3/bazel-gazelle-v0.22.3.tar.gz"],
 )
 
 load(


### PR DESCRIPTION
Upgrade Bazel dependencies to their latest release.