### PR TITLE
Extensible binary trace format

### DIFF
--- a/spoor/runtime/event_logger/event_logger.h
+++ b/spoor/runtime/event_logger/event_logger.h
@@ -23,23 +23,23 @@ class EventLogger {
   using SizeType = Buffer::SizeType;
 
   struct Options {
-    gsl::not_null<util::time::SteadyClock*> steady_clock;
-    gsl::not_null<EventLoggerNotifier*> event_logger_notifier;
     gsl::not_null<flush_queue::FlushQueue<Buffer>*> flush_queue;
     SizeType preferred_capacity;
     bool flush_buffer_when_full;
   };
 
   EventLogger() = delete;
-  explicit EventLogger(Options options);
+  EventLogger(Options options, EventLoggerNotifier* event_logger_notifier);
   EventLogger(const EventLogger&) = delete;
   EventLogger(EventLogger&&) noexcept = delete;
   auto operator=(const EventLogger&) = delete;
   auto operator=(EventLogger&&) noexcept = delete;
   ~EventLogger();
 
+  auto SetEventLoggerNotifier(EventLoggerNotifier* event_logger_notifier)
+      -> void;
   auto SetPool(Pool* pool) -> void;
-  auto LogEvent(trace::Event::Type type, trace::FunctionId function_id) -> void;
+  auto LogEvent(trace::Event event) -> void;
 
   auto Flush() -> void;
   auto Clear() -> void;
@@ -51,6 +51,7 @@ class EventLogger {
 
  private:
   Options options_;
+  EventLoggerNotifier* event_logger_notifier_;
   Pool* pool_;
   std::optional<Buffer> buffer_;
 };

--- a/spoor/runtime/event_logger/event_logger_test.cc
+++ b/spoor/runtime/event_logger/event_logger_test.cc
@@ -3,9 +3,12 @@
 
 #include "spoor/runtime/event_logger/event_logger.h"
 
+#include <algorithm>
+#include <array>
 #include <chrono>
 #include <cstddef>
 #include <new>
+#include <vector>
 
 #include "event_logger_notifier.h"
 #include "gmock/gmock.h"
@@ -23,11 +26,9 @@ namespace {
 using spoor::runtime::event_logger::EventLogger;
 using spoor::runtime::event_logger::testing::EventLoggerNotifierMock;
 using spoor::runtime::trace::Event;
+using spoor::runtime::trace::EventType;
 using spoor::runtime::trace::TimestampNanoseconds;
 using testing::Eq;
-using testing::Invoke;
-using testing::Return;
-using util::time::testing::MakeTimePoint;
 using util::time::testing::SteadyClockMock;
 using util::time::testing::SystemClockMock;
 using SizeType = spoor::runtime::event_logger::EventLogger::SizeType;
@@ -37,13 +38,6 @@ using FlushQueueMock =
     spoor::runtime::flush_queue::testing::FlushQueueMock<Buffer>;
 
 TEST(EventLogger, LogsEvents) {  // NOLINT
-  TimestampNanoseconds time{0};
-  SteadyClockMock steady_clock{};
-  EXPECT_CALL(steady_clock, Now()).WillRepeatedly(Invoke([&time]() {
-    const auto time_point = MakeTimePoint<std::chrono::steady_clock>(time);
-    ++time;
-    return time_point;
-  }));
   EventLoggerNotifierMock event_logger_notifier{};
   EXPECT_CALL(event_logger_notifier, Subscribe);
   EXPECT_CALL(event_logger_notifier, Unsubscribe);
@@ -52,58 +46,75 @@ TEST(EventLogger, LogsEvents) {  // NOLINT
       {.max_slice_capacity = capacity, .capacity = capacity}};
   Buffer expected_buffer{
       {.buffer_slice_pool = &expected_buffer_pool, .capacity = capacity}};
-  expected_buffer.Push({Event::Type::kFunctionEntry, 3, 4});
-  expected_buffer.Push({Event::Type::kFunctionExit, 3, 5});
-  expected_buffer.Push({Event::Type::kFunctionExit, 2, 6});
-  expected_buffer.Push({Event::Type::kFunctionExit, 1, 7});
+  constexpr std::array<Event, 8> events{
+      {{.steady_clock_timestamp = 0,
+        .payload_1 = 1,
+        .type = static_cast<EventType>(Event::Type::kFunctionEntry),
+        .payload_2 = 0},
+       {.steady_clock_timestamp = 1,
+        .payload_1 = 2,
+        .type = static_cast<EventType>(Event::Type::kFunctionEntry),
+        .payload_2 = 0},
+       {.steady_clock_timestamp = 2,
+        .payload_1 = 3,
+        .type = static_cast<EventType>(Event::Type::kFunctionEntry),
+        .payload_2 = 0},
+       {.steady_clock_timestamp = 3,
+        .payload_1 = 3,
+        .type = static_cast<EventType>(Event::Type::kFunctionExit),
+        .payload_2 = 0},
+       {.steady_clock_timestamp = 4,
+        .payload_1 = 3,
+        .type = static_cast<EventType>(Event::Type::kFunctionEntry),
+        .payload_2 = 0},
+       {.steady_clock_timestamp = 5,
+        .payload_1 = 3,
+        .type = static_cast<EventType>(Event::Type::kFunctionExit),
+        .payload_2 = 0},
+       {.steady_clock_timestamp = 6,
+        .payload_1 = 2,
+        .type = static_cast<EventType>(Event::Type::kFunctionExit),
+        .payload_2 = 0},
+       {.steady_clock_timestamp = 7,
+        .payload_1 = 1,
+        .type = static_cast<EventType>(Event::Type::kFunctionExit),
+        .payload_2 = 0}}};
+  std::for_each(std::prev(std::cend(events), capacity), std::cend(events),
+                [&](const auto event) { expected_buffer.Push(event); });
   FlushQueueMock flush_queue{};
   EXPECT_CALL(flush_queue, Enqueue(Eq(std::cref(expected_buffer))));
   Pool pool{{.max_slice_capacity = capacity, .capacity = capacity}};
-  EventLogger event_logger{{.steady_clock = &steady_clock,
-                            .event_logger_notifier = &event_logger_notifier,
-                            .flush_queue = &flush_queue,
+  EventLogger event_logger{{.flush_queue = &flush_queue,
                             .preferred_capacity = capacity,
-                            .flush_buffer_when_full = false}};
+                            .flush_buffer_when_full = false},
+                           &event_logger_notifier};
   event_logger.SetPool(&pool);
-  event_logger.LogEvent(Event::Type::kFunctionEntry, 1);
-  event_logger.LogEvent(Event::Type::kFunctionEntry, 2);
-  event_logger.LogEvent(Event::Type::kFunctionEntry, 3);
-  event_logger.LogEvent(Event::Type::kFunctionExit, 3);
-  event_logger.LogEvent(Event::Type::kFunctionEntry, 3);
-  event_logger.LogEvent(Event::Type::kFunctionExit, 3);
-  event_logger.LogEvent(Event::Type::kFunctionExit, 2);
-  event_logger.LogEvent(Event::Type::kFunctionExit, 1);
+  std::for_each(std::cbegin(events), std::cend(events),
+                [&](const auto event) { event_logger.LogEvent(event); });
 }
 
 TEST(EventLogger, DoesNotLogEventsWithoutPool) {  // NOLINT
-  SteadyClockMock steady_clock{};
-  EXPECT_CALL(steady_clock, Now())
-      .WillRepeatedly(Return(MakeTimePoint<std::chrono::steady_clock>(0)));
   EventLoggerNotifierMock event_logger_notifier{};
   EXPECT_CALL(event_logger_notifier, Subscribe);
   EXPECT_CALL(event_logger_notifier, Unsubscribe);
   FlushQueueMock flush_queue{};
   EXPECT_CALL(flush_queue, Enqueue).Times(0);
-  EventLogger event_logger{{.steady_clock = &steady_clock,
-                            .event_logger_notifier = &event_logger_notifier,
-                            .flush_queue = &flush_queue,
+  EventLogger event_logger{{.flush_queue = &flush_queue,
                             .preferred_capacity = 3,
-                            .flush_buffer_when_full = false}};
+                            .flush_buffer_when_full = false},
+                           &event_logger_notifier};
   ASSERT_TRUE(event_logger.Empty());
-  event_logger.LogEvent(Event::Type::kFunctionEntry, 1);
+  event_logger.LogEvent({});
   ASSERT_TRUE(event_logger.Empty());
-  event_logger.LogEvent(Event::Type::kFunctionEntry, 2);
+  event_logger.LogEvent({});
   ASSERT_TRUE(event_logger.Empty());
-  event_logger.LogEvent(Event::Type::kFunctionEntry, 3);
+  event_logger.LogEvent({});
   ASSERT_TRUE(event_logger.Empty());
   event_logger.Flush();
   ASSERT_TRUE(event_logger.Empty());
 }
 
 TEST(EventLogger, PushWithZeroCapacity) {  // NOLINT
-  SteadyClockMock steady_clock{};
-  EXPECT_CALL(steady_clock, Now())
-      .WillRepeatedly(Return(MakeTimePoint<std::chrono::steady_clock>(0)));
   EventLoggerNotifierMock event_logger_notifier{};
   EXPECT_CALL(event_logger_notifier, Subscribe);
   EXPECT_CALL(event_logger_notifier, Unsubscribe);
@@ -111,49 +122,37 @@ TEST(EventLogger, PushWithZeroCapacity) {  // NOLINT
   EXPECT_CALL(flush_queue, Enqueue).Times(0);
   constexpr SizeType capacity{0};
   Pool pool{{.max_slice_capacity = capacity, .capacity = capacity}};
-  EventLogger event_logger{{.steady_clock = &steady_clock,
-                            .event_logger_notifier = &event_logger_notifier,
-                            .flush_queue = &flush_queue,
+  EventLogger event_logger{{.flush_queue = &flush_queue,
                             .preferred_capacity = 8,
-                            .flush_buffer_when_full = false}};
+                            .flush_buffer_when_full = false},
+                           &event_logger_notifier};
   event_logger.SetPool(&pool);
-  event_logger.LogEvent(Event::Type::kFunctionExit, 0);
-  event_logger.LogEvent(Event::Type::kFunctionExit, 0);
-  event_logger.LogEvent(Event::Type::kFunctionExit, 0);
-  event_logger.LogEvent(Event::Type::kFunctionExit, 0);
+  event_logger.LogEvent({});
+  event_logger.LogEvent({});
+  event_logger.LogEvent({});
+  event_logger.LogEvent({});
   ASSERT_TRUE(event_logger.Empty());
 }
 
 TEST(EventLogger, RaiiSubscribeToAndUnsubscribeFromNotifier) {  // NOLINT
-  SteadyClockMock steady_clock{};
   FlushQueueMock flush_queue{};
   constexpr SizeType capacity{0};
   Pool pool{{.max_slice_capacity = capacity, .capacity = capacity}};
   EventLoggerNotifierMock event_logger_notifier{};
-  EventLogger::Options event_logger_options{
-      .steady_clock = &steady_clock,
-      .event_logger_notifier = &event_logger_notifier,
-      .flush_queue = &flush_queue,
-      .preferred_capacity = capacity,
-      .flush_buffer_when_full = false};
   std::array<std::byte, sizeof(EventLogger)> buffer{};
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
   const auto* event_logger_ptr = reinterpret_cast<EventLogger*>(buffer.data());
   EXPECT_CALL(event_logger_notifier, Subscribe(Eq(event_logger_ptr)));
   const auto* event_logger = gsl::owner<EventLogger*>(
-      new (buffer.data()) EventLogger{event_logger_options});
+      new (buffer.data()) EventLogger{{.flush_queue = &flush_queue,
+                                       .preferred_capacity = capacity,
+                                       .flush_buffer_when_full = false},
+                                      &event_logger_notifier});
   EXPECT_CALL(event_logger_notifier, Unsubscribe(Eq(event_logger_ptr)));
   event_logger->~EventLogger();
 }
 
 TEST(EventLogger, FlushWhenFull) {  // NOLINT
-  TimestampNanoseconds time{0};
-  SteadyClockMock steady_clock{};
-  EXPECT_CALL(steady_clock, Now()).WillRepeatedly(Invoke([&time]() {
-    const auto time_point = MakeTimePoint<std::chrono::steady_clock>(time);
-    ++time;
-    return time_point;
-  }));
   constexpr SizeType capacity{5};
   for (const SizeType multiplier : {1, 2, 5, 10}) {
     EventLoggerNotifierMock event_logger_notifier{};
@@ -163,22 +162,19 @@ TEST(EventLogger, FlushWhenFull) {  // NOLINT
     EXPECT_CALL(flush_queue, Enqueue).Times(multiplier).RetiresOnSaturation();
     Pool pool{
         {.max_slice_capacity = capacity, .capacity = multiplier * capacity}};
-    EventLogger event_logger{{.steady_clock = &steady_clock,
-                              .event_logger_notifier = &event_logger_notifier,
-                              .flush_queue = &flush_queue,
+    EventLogger event_logger{{.flush_queue = &flush_queue,
                               .preferred_capacity = capacity,
-                              .flush_buffer_when_full = true}};
+                              .flush_buffer_when_full = true},
+                             &event_logger_notifier};
     event_logger.SetPool(&pool);
     for (SizeType i{0}; i < multiplier * capacity; ++i) {
-      event_logger.LogEvent(Event::Type::kFunctionEntry, 0);
+      event_logger.LogEvent({});
+      ASSERT_EQ(event_logger.Empty(), (i + 1) % capacity == 0);
     }
   }
 }
 
 TEST(EventLogger, FlushesOnDestruction) {  // NOLINT
-  SteadyClockMock steady_clock{};
-  EXPECT_CALL(steady_clock, Now())
-      .WillRepeatedly(Return(MakeTimePoint<std::chrono::steady_clock>(0)));
   EventLoggerNotifierMock event_logger_notifier{};
   EXPECT_CALL(event_logger_notifier, Subscribe);
   EXPECT_CALL(event_logger_notifier, Unsubscribe);
@@ -186,21 +182,17 @@ TEST(EventLogger, FlushesOnDestruction) {  // NOLINT
   EXPECT_CALL(flush_queue, Enqueue);
   constexpr SizeType capacity{3};
   Pool pool{{.max_slice_capacity = capacity, .capacity = capacity}};
-  EventLogger event_logger{{.steady_clock = &steady_clock,
-                            .event_logger_notifier = &event_logger_notifier,
-                            .flush_queue = &flush_queue,
+  EventLogger event_logger{{.flush_queue = &flush_queue,
                             .preferred_capacity = capacity,
-                            .flush_buffer_when_full = false}};
+                            .flush_buffer_when_full = false},
+                           &event_logger_notifier};
   event_logger.SetPool(&pool);
-  event_logger.LogEvent(Event::Type::kFunctionEntry, 0);
-  event_logger.LogEvent(Event::Type::kFunctionEntry, 0);
-  event_logger.LogEvent(Event::Type::kFunctionEntry, 0);
+  event_logger.LogEvent({});
+  event_logger.LogEvent({});
+  event_logger.LogEvent({});
 }
 
 TEST(EventLogger, DoesNotFlushWhenEmpty) {  // NOLINT
-  SteadyClockMock steady_clock{};
-  EXPECT_CALL(steady_clock, Now())
-      .WillRepeatedly(Return(MakeTimePoint<std::chrono::steady_clock>(0)));
   EventLoggerNotifierMock event_logger_notifier{};
   EXPECT_CALL(event_logger_notifier, Subscribe);
   EXPECT_CALL(event_logger_notifier, Unsubscribe);
@@ -208,12 +200,13 @@ TEST(EventLogger, DoesNotFlushWhenEmpty) {  // NOLINT
   EXPECT_CALL(flush_queue, Enqueue).Times(0);
   constexpr SizeType capacity{0};
   Pool pool{{.max_slice_capacity = capacity, .capacity = capacity}};
-  EventLogger event_logger{{.steady_clock = &steady_clock,
-                            .event_logger_notifier = &event_logger_notifier,
-                            .flush_queue = &flush_queue,
+  EventLogger event_logger{{.flush_queue = &flush_queue,
                             .preferred_capacity = capacity,
-                            .flush_buffer_when_full = false}};
+                            .flush_buffer_when_full = false},
+                           &event_logger_notifier};
   event_logger.SetPool(&pool);
+  ASSERT_TRUE(event_logger.Empty());
+  event_logger.Flush();
   ASSERT_TRUE(event_logger.Empty());
   event_logger.Flush();
   event_logger.Flush();
@@ -222,9 +215,6 @@ TEST(EventLogger, DoesNotFlushWhenEmpty) {  // NOLINT
 }
 
 TEST(EventLogger, SizeEmptyCapacityFull) {  // NOLINT
-  SteadyClockMock steady_clock{};
-  EXPECT_CALL(steady_clock, Now())
-      .WillRepeatedly(Return(MakeTimePoint<std::chrono::steady_clock>(0)));
   for (const SizeType capacity : {0, 1, 2, 5, 10}) {
     EventLoggerNotifierMock event_logger_notifier{};
     EXPECT_CALL(event_logger_notifier, Subscribe).RetiresOnSaturation();
@@ -232,11 +222,10 @@ TEST(EventLogger, SizeEmptyCapacityFull) {  // NOLINT
     FlushQueueMock flush_queue{};
     if (0 < capacity) EXPECT_CALL(flush_queue, Enqueue).RetiresOnSaturation();
     Pool pool{{.max_slice_capacity = capacity, .capacity = capacity}};
-    EventLogger event_logger{{.steady_clock = &steady_clock,
-                              .event_logger_notifier = &event_logger_notifier,
-                              .flush_queue = &flush_queue,
+    EventLogger event_logger{{.flush_queue = &flush_queue,
                               .preferred_capacity = capacity,
-                              .flush_buffer_when_full = false}};
+                              .flush_buffer_when_full = false},
+                             &event_logger_notifier};
     event_logger.SetPool(&pool);
     ASSERT_TRUE(event_logger.Empty());
     ASSERT_EQ(event_logger.Size(), 0);
@@ -244,7 +233,7 @@ TEST(EventLogger, SizeEmptyCapacityFull) {  // NOLINT
     ASSERT_EQ(event_logger.Full(), capacity == 0);
     for (SizeType i{0}; i < capacity; ++i) {
       ASSERT_FALSE(event_logger.Full());
-      event_logger.LogEvent(Event::Type::kFunctionEntry, 0);
+      event_logger.LogEvent({});
       ASSERT_FALSE(event_logger.Empty());
       ASSERT_EQ(event_logger.Size(), i + 1);
     }

--- a/spoor/runtime/flush_queue/disk_flush_queue.cc
+++ b/spoor/runtime/flush_queue/disk_flush_queue.cc
@@ -67,7 +67,7 @@ auto DiskFlushQueue::Run() -> void {
       }
       const auto result = options_.trace_writer->Write(
           TraceFilePath(flush_info), TraceFileHeader(flush_info),
-          &flush_info.buffer, trace::Footer{});
+          &flush_info.buffer);
       --flush_info.remaining_flush_attempts;
       if (result.IsErr() && 0 < flush_info.remaining_flush_attempts) {
         std::unique_lock lock{lock_};

--- a/spoor/runtime/runtime.cc
+++ b/spoor/runtime/runtime.cc
@@ -10,6 +10,7 @@
 #include <cstddef>
 #include <filesystem>
 #include <system_error>
+#include <type_traits>
 #include <utility>
 
 #include "absl/strings/str_format.h"
@@ -27,6 +28,15 @@
 namespace {
 
 using spoor::runtime::runtime_manager::RuntimeManager;
+
+static_assert(
+    std::is_same_v<_spoor_runtime_EventType, spoor::runtime::trace::EventType>);
+static_assert(std::is_same_v<_spoor_runtime_FunctionId,
+                             spoor::runtime::trace::FunctionId>);
+static_assert(
+    std::is_same_v<_spoor_runtime_SessionId, spoor::runtime::trace::SessionId>);
+static_assert(std::is_same_v<_spoor_runtime_TimestampNanoseconds,
+                             spoor::runtime::trace::TimestampNanoseconds>);
 
 // NOLINTNEXTLINE(fuchsia-statically-constructed-objects)
 const auto kConfig = spoor::runtime::config::Config::FromEnv();
@@ -86,16 +96,27 @@ auto _spoor_runtime_DisableRuntime() -> void { runtime_.Disable(); }
 
 auto _spoor_runtime_RuntimeEnabled() -> bool { return runtime_.Enabled(); }
 
+auto _spoor_runtime_LogEventWithTimestamp(
+    const _spoor_runtime_EventType event,
+    const _spoor_runtime_TimestampNanoseconds steady_clock_timestamp,
+    const uint64_t payload_1, const uint32_t payload_2) -> void {
+  runtime_.LogEvent(event, steady_clock_timestamp, payload_1, payload_2);
+}
+
+auto _spoor_runtime_LogEvent(const _spoor_runtime_EventType event,
+                             const uint64_t payload_1, const uint32_t payload_2)
+    -> void {
+  runtime_.LogEvent(event, payload_1, payload_2);
+}
+
 auto _spoor_runtime_LogFunctionEntry(
     const _spoor_runtime_FunctionId function_id) -> void {
-  runtime_.LogEvent(spoor::runtime::trace::Event::Type::kFunctionEntry,
-                    function_id);
+  runtime_.LogFunctionEntry(function_id);
 }
 
 auto _spoor_runtime_LogFunctionExit(const _spoor_runtime_FunctionId function_id)
     -> void {
-  runtime_.LogEvent(spoor::runtime::trace::Event::Type::kFunctionExit,
-                    function_id);
+  runtime_.LogFunctionExit(function_id);
 }
 
 auto _spoor_runtime_FlushTraceEvents(

--- a/spoor/runtime/runtime.h
+++ b/spoor/runtime/runtime.h
@@ -11,11 +11,13 @@ extern "C" {
 #include <stdint.h>
 #endif
 
-typedef uint64_t _spoor_runtime_SizeType;
+typedef int64_t _spoor_runtime_DurationNanoseconds;
+typedef uint32_t _spoor_runtime_EventType;
 typedef uint64_t _spoor_runtime_FunctionId;
 typedef uint64_t _spoor_runtime_SessionId;
-typedef int64_t _spoor_runtime_DurationNanoseconds;
+typedef uint64_t _spoor_runtime_SizeType;
 typedef int64_t _spoor_runtime_SystemTimestampSeconds;
+typedef int64_t _spoor_runtime_TimestampNanoseconds;
 
 typedef struct _spoor_runtime_TraceFiles {
   _spoor_runtime_SizeType file_paths_size;
@@ -73,6 +75,19 @@ void _spoor_runtime_DisableRuntime();
 
 // Check if runtime logging is enabled.
 bool _spoor_runtime_RuntimeEnabled();
+
+// Log that the program generated an event. The function internally checks if
+// the runtime is enabled before logging the event.
+void _spoor_runtime_LogEventWithTimestamp(
+    _spoor_runtime_EventType event,
+    _spoor_runtime_TimestampNanoseconds steady_clock_timestamp,
+    uint64_t payload_1, uint32_t payload_2);
+
+// Log that the program generated an event. The function internally checks if
+// the runtime is enabled before collecting the current timestamp and logging
+// the event.
+void _spoor_runtime_LogEvent(_spoor_runtime_EventType event, uint64_t payload_1,
+                             uint32_t payload_2);
 
 // Log that the program entered a function. The function internally checks if
 // the runtime is enabled before collecting the current timestamp and logging

--- a/spoor/runtime/runtime_manager/runtime_manager.h
+++ b/spoor/runtime/runtime_manager/runtime_manager.h
@@ -63,7 +63,14 @@ class RuntimeManager final : public event_logger::EventLoggerNotifier {
   auto Unsubscribe(gsl::not_null<event_logger::EventLogger*> subscriber)
       -> void override;
 
-  auto LogEvent(trace::Event::Type type, trace::FunctionId function_id) -> void;
+  auto LogEvent(trace::Event event) -> void;
+  auto LogEvent(trace::EventType type,
+                trace::TimestampNanoseconds steady_clock_timestamp,
+                uint64 payload_1, uint32 payload_2) -> void;
+  auto LogEvent(trace::EventType type, uint64 payload_1, uint32 payload_2)
+      -> void;
+  auto LogFunctionEntry(trace::FunctionId function_id) -> void;
+  auto LogFunctionExit(trace::FunctionId function_id) -> void;
 
   auto Flush(const std::function<void()>& completion) -> void;
   auto Clear() -> void;

--- a/spoor/runtime/runtime_manager/runtime_manager_benchmark.cc
+++ b/spoor/runtime/runtime_manager/runtime_manager_benchmark.cc
@@ -18,7 +18,6 @@ namespace {
 
 using spoor::runtime::flush_queue::BlackHoleFlushQueue;
 using spoor::runtime::runtime_manager::RuntimeManager;
-using spoor::runtime::trace::Event;
 
 constexpr bool kFlushAllEvents{true};
 // NOLINTNEXTLINE(fuchsia-statically-constructed-objects)
@@ -43,14 +42,14 @@ auto FibonacciInstrumented(const uint64 n,
                            gsl::not_null<RuntimeManager*> runtime_manager)
     -> uint64 {
   constexpr uint64 function_id{42};
-  runtime_manager->LogEvent(Event::Type::kFunctionEntry, function_id);
+  runtime_manager->LogFunctionEntry(function_id);
   if (n < 2) {
-    runtime_manager->LogEvent(Event::Type::kFunctionExit, function_id);
+    runtime_manager->LogFunctionExit(function_id);
     return n;
   }
   const auto result = FibonacciInstrumented(n - 1, runtime_manager) +
                       FibonacciInstrumented(n - 2, runtime_manager);
-  runtime_manager->LogEvent(Event::Type::kFunctionExit, function_id);
+  runtime_manager->LogFunctionExit(function_id);
   return result;
 }
 

--- a/spoor/runtime/runtime_manager/runtime_manager_test.cc
+++ b/spoor/runtime/runtime_manager/runtime_manager_test.cc
@@ -4,11 +4,13 @@
 #include "spoor/runtime/runtime_manager/runtime_manager.h"
 
 #include <algorithm>
+#include <array>
 #include <chrono>
 #include <map>
 #include <system_error>
 #include <thread>
 #include <utility>
+#include <vector>
 
 #include "absl/strings/str_format.h"
 #include "absl/synchronization/notification.h"
@@ -16,6 +18,7 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "spoor/runtime/buffer/circular_slice_buffer.h"
+#include "spoor/runtime/buffer/reserved_buffer_slice_pool.h"
 #include "spoor/runtime/event_logger/event_logger.h"
 #include "spoor/runtime/flush_queue/flush_queue_mock.h"
 #include "spoor/runtime/trace/trace_reader_mock.h"
@@ -25,15 +28,17 @@
 
 namespace {
 
-using spoor::runtime::buffer::CircularSliceBuffer;
 using spoor::runtime::event_logger::EventLogger;
 using spoor::runtime::runtime_manager::RuntimeManager;
 using spoor::runtime::trace::Event;
+using spoor::runtime::trace::EventType;
 using spoor::runtime::trace::Header;
 using spoor::runtime::trace::kTraceFileVersion;
 using spoor::runtime::trace::TimestampNanoseconds;
 using spoor::runtime::trace::testing::TraceReaderMock;
 using testing::_;
+using testing::Eq;
+using testing::Invoke;
 using testing::MockFunction;
 using testing::Return;
 using util::file_system::testing::DirectoryEntryMock;
@@ -41,8 +46,10 @@ using util::file_system::testing::FileSystemMock;
 using util::result::None;
 using util::time::testing::MakeTimePoint;
 using util::time::testing::SteadyClockMock;
-using FlushQueueMock = spoor::runtime::flush_queue::testing::FlushQueueMock<
-    CircularSliceBuffer<Event>>;
+using CircularSliceBuffer = spoor::runtime::buffer::CircularSliceBuffer<Event>;
+using FlushQueueMock =
+    spoor::runtime::flush_queue::testing::FlushQueueMock<CircularSliceBuffer>;
+using Pool = spoor::runtime::buffer::ReservedBufferSlicePool<Event>;
 using SizeType = EventLogger::SizeType;
 
 constexpr absl::Duration kNotificationTimeout{absl::Milliseconds(1'000)};
@@ -58,17 +65,16 @@ TEST(RuntimeManager, Initialize) {  // NOLINT
   EXPECT_CALL(flush_queue, Run()).Times(iterations);
   EXPECT_CALL(flush_queue, Clear()).Times(iterations);
   EXPECT_CALL(flush_queue, DrainAndStop()).Times(iterations);
-  const RuntimeManager::Options options{.steady_clock = &steady_clock,
-                                        .flush_queue = &flush_queue,
-                                        .thread_event_buffer_capacity = 0,
-                                        .reserved_pool_capacity = 0,
-                                        .reserved_pool_max_slice_capacity = 0,
-                                        .dynamic_pool_capacity = 0,
-                                        .dynamic_pool_max_slice_capacity = 0,
-                                        .dynamic_pool_borrow_cas_attempts = 0,
-                                        .max_buffer_flush_attempts = 0,
-                                        .flush_all_events = false};
-  RuntimeManager runtime_manager{options};
+  RuntimeManager runtime_manager{{.steady_clock = &steady_clock,
+                                  .flush_queue = &flush_queue,
+                                  .thread_event_buffer_capacity = 0,
+                                  .reserved_pool_capacity = 0,
+                                  .reserved_pool_max_slice_capacity = 0,
+                                  .dynamic_pool_capacity = 0,
+                                  .dynamic_pool_max_slice_capacity = 0,
+                                  .dynamic_pool_borrow_cas_attempts = 0,
+                                  .max_buffer_flush_attempts = 0,
+                                  .flush_all_events = false}};
   for (auto iteration{0}; iteration < iterations; ++iteration) {
     ASSERT_FALSE(runtime_manager.Enabled());
     ASSERT_FALSE(runtime_manager.Initialized());
@@ -93,17 +99,16 @@ TEST(RuntimeManager, RaiiDeinitializeOnDestruction) {  // NOLINT
   EXPECT_CALL(flush_queue, Run());
   EXPECT_CALL(flush_queue, Clear());
   EXPECT_CALL(flush_queue, DrainAndStop());
-  const RuntimeManager::Options options{.steady_clock = &steady_clock,
-                                        .flush_queue = &flush_queue,
-                                        .thread_event_buffer_capacity = 0,
-                                        .reserved_pool_capacity = 0,
-                                        .reserved_pool_max_slice_capacity = 0,
-                                        .dynamic_pool_capacity = 0,
-                                        .dynamic_pool_max_slice_capacity = 0,
-                                        .dynamic_pool_borrow_cas_attempts = 0,
-                                        .max_buffer_flush_attempts = 0,
-                                        .flush_all_events = false};
-  RuntimeManager runtime_manager{options};
+  RuntimeManager runtime_manager{{.steady_clock = &steady_clock,
+                                  .flush_queue = &flush_queue,
+                                  .thread_event_buffer_capacity = 0,
+                                  .reserved_pool_capacity = 0,
+                                  .reserved_pool_max_slice_capacity = 0,
+                                  .dynamic_pool_capacity = 0,
+                                  .dynamic_pool_max_slice_capacity = 0,
+                                  .dynamic_pool_borrow_cas_attempts = 0,
+                                  .max_buffer_flush_attempts = 0,
+                                  .flush_all_events = false}};
   ASSERT_FALSE(runtime_manager.Initialized());
   runtime_manager.Initialize();
   ASSERT_TRUE(runtime_manager.Initialized());
@@ -115,17 +120,16 @@ TEST(RuntimeManager, Enable) {  // NOLINT
   EXPECT_CALL(flush_queue, Run());
   EXPECT_CALL(flush_queue, Clear());
   EXPECT_CALL(flush_queue, DrainAndStop());
-  const RuntimeManager::Options options{.steady_clock = &steady_clock,
-                                        .flush_queue = &flush_queue,
-                                        .thread_event_buffer_capacity = 0,
-                                        .reserved_pool_capacity = 0,
-                                        .reserved_pool_max_slice_capacity = 0,
-                                        .dynamic_pool_capacity = 0,
-                                        .dynamic_pool_max_slice_capacity = 0,
-                                        .dynamic_pool_borrow_cas_attempts = 0,
-                                        .max_buffer_flush_attempts = 0,
-                                        .flush_all_events = false};
-  RuntimeManager runtime_manager{options};
+  RuntimeManager runtime_manager{{.steady_clock = &steady_clock,
+                                  .flush_queue = &flush_queue,
+                                  .thread_event_buffer_capacity = 0,
+                                  .reserved_pool_capacity = 0,
+                                  .reserved_pool_max_slice_capacity = 0,
+                                  .dynamic_pool_capacity = 0,
+                                  .dynamic_pool_max_slice_capacity = 0,
+                                  .dynamic_pool_borrow_cas_attempts = 0,
+                                  .max_buffer_flush_attempts = 0,
+                                  .flush_all_events = false}};
   ASSERT_FALSE(runtime_manager.Enabled());
   runtime_manager.Initialize();
   ASSERT_FALSE(runtime_manager.Enabled());
@@ -148,36 +152,93 @@ TEST(RuntimeManager, Enable) {  // NOLINT
 
 TEST(RuntimeManager, Subscribe) {  // NOLINT
   SteadyClockMock steady_clock{};
-  EXPECT_CALL(steady_clock, Now())
-      .WillOnce(Return(MakeTimePoint<std::chrono::steady_clock>(0)));
   FlushQueueMock flush_queue{};
   EXPECT_CALL(flush_queue, Run());
   EXPECT_CALL(flush_queue, Enqueue(_));
   EXPECT_CALL(flush_queue, Clear());
   EXPECT_CALL(flush_queue, DrainAndStop());
   constexpr SizeType capacity{1};
-  const RuntimeManager::Options runtime_manager_options{
-      .steady_clock = &steady_clock,
-      .flush_queue = &flush_queue,
-      .thread_event_buffer_capacity = capacity,
-      .reserved_pool_capacity = capacity,
-      .reserved_pool_max_slice_capacity = capacity,
-      .dynamic_pool_capacity = 0,
-      .dynamic_pool_max_slice_capacity = 0,
-      .dynamic_pool_borrow_cas_attempts = 0,
-      .max_buffer_flush_attempts = 1,
-      .flush_all_events = false};
-  RuntimeManager runtime_manager{runtime_manager_options};
+  RuntimeManager runtime_manager{{.steady_clock = &steady_clock,
+                                  .flush_queue = &flush_queue,
+                                  .thread_event_buffer_capacity = capacity,
+                                  .reserved_pool_capacity = capacity,
+                                  .reserved_pool_max_slice_capacity = capacity,
+                                  .dynamic_pool_capacity = 0,
+                                  .dynamic_pool_max_slice_capacity = 0,
+                                  .dynamic_pool_borrow_cas_attempts = 0,
+                                  .max_buffer_flush_attempts = 1,
+                                  .flush_all_events = false}};
   runtime_manager.Initialize();
-  const EventLogger::Options event_logger_options{
-      .steady_clock = &steady_clock,
-      .event_logger_notifier = &runtime_manager,
-      .flush_queue = &flush_queue,
-      .preferred_capacity = capacity,
-      .flush_buffer_when_full = false};
-  EventLogger event_logger{event_logger_options};
-  event_logger.LogEvent(Event::Type::kFunctionEntry, 42);
+  EventLogger event_logger{{.flush_queue = &flush_queue,
+                            .preferred_capacity = capacity,
+                            .flush_buffer_when_full = false},
+                           &runtime_manager};
+  event_logger.LogEvent(
+      {.steady_clock_timestamp = 0,
+       .payload_1 = 1,
+       .type = static_cast<EventType>(Event::Type::kFunctionEntry),
+       .payload_2 = 2});
   ASSERT_EQ(event_logger.Size(), capacity);
+}
+
+TEST(RuntimeManager, LogEvent) {  // NOLINT
+  TimestampNanoseconds time{0};
+  SteadyClockMock steady_clock{};
+  EXPECT_CALL(steady_clock, Now()).WillRepeatedly(Invoke([&time]() {
+    const auto time_point = MakeTimePoint<std::chrono::steady_clock>(time);
+    ++time;
+    return time_point;
+  }));
+  constexpr std::array<Event, 4> events{
+      {{.steady_clock_timestamp = 0,
+        .payload_1 = 1,
+        .type = static_cast<EventType>(Event::Type::kFunctionEntry),
+        .payload_2 = 0},
+       {.steady_clock_timestamp = 1,
+        .payload_1 = 2,
+        .type = static_cast<EventType>(Event::Type::kFunctionExit),
+        .payload_2 = 0},
+       {.steady_clock_timestamp = 2,
+        .payload_1 = 3,
+        .type = static_cast<EventType>(Event::Type::kFunctionEntry),
+        .payload_2 = 3},
+       {.steady_clock_timestamp = 3,
+        .payload_1 = 4,
+        .type = static_cast<EventType>(Event::Type::kFunctionExit),
+        .payload_2 = 4}}};
+  Pool expected_buffer_pool{
+      {.max_slice_capacity = std::size(events), .capacity = std::size(events)}};
+  CircularSliceBuffer expected_buffer{
+      {.buffer_slice_pool = &expected_buffer_pool,
+       .capacity = std::size(events)}};
+  std::for_each(std::cbegin(events), std::cend(events),
+                [&](const auto event) { expected_buffer.Push(event); });
+  FlushQueueMock flush_queue{};
+  EXPECT_CALL(flush_queue, Run());
+  EXPECT_CALL(flush_queue, Enqueue(Eq(std::cref(expected_buffer))));
+  EXPECT_CALL(flush_queue, Clear());
+  EXPECT_CALL(flush_queue, DrainAndStop());
+  RuntimeManager runtime_manager{
+      {.steady_clock = &steady_clock,
+       .flush_queue = &flush_queue,
+       .thread_event_buffer_capacity = std::size(events),
+       .reserved_pool_capacity = std::size(events),
+       .reserved_pool_max_slice_capacity = std::size(events),
+       .dynamic_pool_capacity = 0,
+       .dynamic_pool_max_slice_capacity = 0,
+       .dynamic_pool_borrow_cas_attempts = 0,
+       .max_buffer_flush_attempts = 1,
+       .flush_all_events = false}};
+  runtime_manager.Initialize();
+  runtime_manager.Enable();
+  ASSERT_EQ(events[0].type,
+            static_cast<EventType>(Event::Type::kFunctionEntry));
+  runtime_manager.LogFunctionEntry(events[0].payload_1);
+  ASSERT_EQ(events[1].type, static_cast<EventType>(Event::Type::kFunctionExit));
+  runtime_manager.LogFunctionExit(events[1].payload_1);
+  runtime_manager.LogEvent(events[2].type, events[2].payload_1,
+                           events[2].payload_2);
+  runtime_manager.LogEvent(events[3]);
 }
 
 TEST(RuntimeManager, FlushedTraceFiles) {  // NOLINT
@@ -231,8 +292,7 @@ TEST(RuntimeManager, DeleteFlushedTraceFilesOlderThan) {  // NOLINT
                   .thread_id = 0,
                   .system_clock_timestamp = system_clock_timestamp,
                   .steady_clock_timestamp = 0,
-                  .event_count = 0,
-                  .padding{}};
+                  .event_count = 0};
   };
   const auto make_file_size = [](const SizeType n) { return 1ULL << n; };
   FileSystemMock file_system{};

--- a/spoor/runtime/runtime_stub.cc
+++ b/spoor/runtime/runtime_stub.cc
@@ -15,6 +15,15 @@ auto _spoor_runtime_DisableRuntime() -> void {}
 
 auto _spoor_runtime_RuntimeEnabled() -> bool { return false; }
 
+auto _spoor_runtime_LogEventWithTimestamp(
+    _spoor_runtime_EventType /*unused*/,
+    _spoor_runtime_TimestampNanoseconds /*unused*/, uint64_t /*unused*/,
+    uint32_t /*unused*/) -> void {}
+
+auto _spoor_runtime_LogEvent(_spoor_runtime_EventType /*unused*/,
+                             uint64_t /*unused*/, uint32_t /*unused*/) -> void {
+}
+
 auto _spoor_runtime_LogFunctionEntry(const _spoor_runtime_FunctionId /*unused*/)
     -> void {}
 

--- a/spoor/runtime/runtime_stub_test.cc
+++ b/spoor/runtime/runtime_stub_test.cc
@@ -28,6 +28,13 @@ TEST(Runtime, Enable) {  // NOLINT
   ASSERT_FALSE(_spoor_runtime_RuntimeEnabled());
 }
 
+TEST(Runtime, LogEvent) {  // NOLINT
+  _spoor_runtime_LogEventWithTimestamp(1, 2, 3, 4);
+  _spoor_runtime_LogEvent(1, 2, 3);
+  _spoor_runtime_LogFunctionEntry(1);
+  _spoor_runtime_LogFunctionExit(1);
+}
+
 namespace flush_trace_events_test {
 
 // clang-format off NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables, fuchsia-statically-constructed-objects) clang-format on

--- a/spoor/runtime/trace/trace.h
+++ b/spoor/runtime/trace/trace.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <array>
+#include <type_traits>
 
 #include "absl/base/internal/endian.h"
 #include "gsl/gsl"
@@ -13,15 +14,16 @@ namespace spoor::runtime::trace {
 
 using DurationNanoseconds = int64;
 using EventCount = int32;
+using EventType = uint32;
 using FunctionId = uint64;
 using ProcessId = int64;  // pid_t is a signed integer
 using SessionId = uint64;
 using ThreadId = uint64;
 using TimestampNanoseconds = int64;
-using TraceFileVersion = int64;
+using TraceFileVersion = uint64;
 
-// IMPORTANT: Increment the version number if the header, event, or footer
-// structure changes.
+// IMPORTANT: Increment the version number if the Header or Event structure
+// changes.
 constexpr TraceFileVersion kTraceFileVersion{0};
 
 struct alignas(8) Header {
@@ -32,78 +34,32 @@ struct alignas(8) Header {
   TimestampNanoseconds system_clock_timestamp;
   TimestampNanoseconds steady_clock_timestamp;
   EventCount event_count;
-  std::array<std::byte, 4> padding;
 };
 
 static_assert(sizeof(Header) == 56);
 
+constexpr auto operator==(const Header& lhs, const Header& rhs) -> bool;
+inline auto Serialize(Header header) -> std::array<char, sizeof(Header)>;
+inline auto Deserialize(std::array<char, sizeof(Header)> serialized) -> Header;
+
 class alignas(8) Event {
  public:
-  enum class Type : bool {
-    kFunctionExit = false,
-    kFunctionEntry = true,
+  enum class Type : EventType {
+    kFunctionEntry = 1,
+    kFunctionExit = 2,
   };
 
-  constexpr Event() = default;
-  constexpr Event(Type type, FunctionId function_id,
-                  TimestampNanoseconds timestamp);
-
-  [[nodiscard]] constexpr auto GetType() const -> Type;
-  [[nodiscard]] constexpr auto GetFunctionId() const -> FunctionId;
-  [[nodiscard]] constexpr auto GetTimestamp() const -> TimestampNanoseconds;
-
- private:
-  friend constexpr auto operator==(const Event& lhs, const Event& rhs) -> bool;
-  friend inline auto Serialize(Event event) -> std::array<char, 16>;
-  friend inline auto Deserialize(std::array<char, 16> serialized) -> Event;
-
-  FunctionId function_id_;
-  // Use the most significant bit for the event and the least significant 63
-  // bits for the timestamp (in nanoseconds). The STL represents times as
-  // signed integers but we only expect nonnegative values. Therefore, there is
-  // no risk of data loss with this space-saving optimization.
-  uint64 type_and_timestamp_;
-
-  static constexpr auto MakeTypeAndTimestamp(Type type,
-                                             TimestampNanoseconds timestamp)
-      -> uint64;
+  TimestampNanoseconds steady_clock_timestamp;
+  uint64 payload_1;
+  EventType type;
+  uint32 payload_2;
 };
 
-static_assert(sizeof(Event) == 16);
+static_assert(sizeof(Event) == 24);
 
-struct alignas(1) Footer {
- private:
-  friend constexpr auto operator==(const Footer& lhs, const Footer& rhs)
-      -> bool;
-};
-
-static_assert(sizeof(Footer) == 1);
-
-constexpr Event::Event(const Type type, const FunctionId function_id,
-                       const TimestampNanoseconds timestamp)
-    : function_id_{function_id},
-      type_and_timestamp_{MakeTypeAndTimestamp(type, timestamp)} {}
-
-constexpr auto Event::GetType() const -> Type {
-  return static_cast<Type>(type_and_timestamp_ >> uint64{63});
-}
-
-constexpr auto Event::GetFunctionId() const -> FunctionId {
-  return function_id_;
-}
-
-constexpr auto Event::GetTimestamp() const -> TimestampNanoseconds {
-  return type_and_timestamp_ & ~(uint64{1} << uint64{63});
-}
-
-constexpr auto Event::MakeTypeAndTimestamp(const Type type,
-                                           const TimestampNanoseconds timestamp)
-    -> uint64 {
-  auto type_and_timestamp = static_cast<uint64>(type) << uint64{63};
-  type_and_timestamp |=
-      gsl::narrow_cast<uint64>(timestamp) & uint64{0x7fffffffffffffff};
-  return type_and_timestamp;
-}
+constexpr auto operator==(const Event& lhs, const Event& rhs) -> bool;
+inline auto Serialize(Event event) -> std::array<char, sizeof(Event)>;
+inline auto Deserialize(std::array<char, sizeof(Event)> serialized) -> Event;
 
 constexpr auto operator==(const Header& lhs, const Header& rhs) -> bool {
   return lhs.version == rhs.version && lhs.session_id == rhs.session_id &&
@@ -111,16 +67,6 @@ constexpr auto operator==(const Header& lhs, const Header& rhs) -> bool {
          lhs.system_clock_timestamp == rhs.system_clock_timestamp &&
          lhs.steady_clock_timestamp == rhs.steady_clock_timestamp &&
          lhs.event_count == rhs.event_count;
-}
-
-constexpr auto operator==(const Event& lhs, const Event& rhs) -> bool {
-  return lhs.function_id_ == rhs.function_id_ &&
-         lhs.type_and_timestamp_ == rhs.type_and_timestamp_;
-}
-
-constexpr auto operator==(const Footer& /*unused*/, const Footer& /*unused*/)
-    -> bool {
-  return true;
 }
 
 inline auto Serialize(const Header header) -> std::array<char, sizeof(Header)> {
@@ -142,46 +88,50 @@ inline auto Serialize(const Header header) -> std::array<char, sizeof(Header)> {
 inline auto Deserialize(std::array<char, sizeof(Header)> serialized) -> Header {
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
   auto* serialized_header = reinterpret_cast<Header*>(serialized.data());
-  Header header{};
-  header.version = absl::gntohll(serialized_header->version);
-  header.session_id = absl::gntohll(serialized_header->session_id);
-  header.process_id = absl::gntohll(serialized_header->process_id);
-  header.thread_id = absl::gntohll(serialized_header->thread_id);
-  header.system_clock_timestamp =
-      absl::gntohll(serialized_header->system_clock_timestamp);
-  header.steady_clock_timestamp =
-      absl::gntohll(serialized_header->steady_clock_timestamp);
-  header.event_count = absl::gntohl(serialized_header->event_count);
-  return header;
+  return Header{
+      .version = absl::gntohll(serialized_header->version),
+      .session_id = absl::gntohll(serialized_header->session_id),
+      .process_id = gsl::narrow_cast<ProcessId>(
+          absl::gntohll(serialized_header->process_id)),
+      .thread_id = absl::gntohll(serialized_header->thread_id),
+      .system_clock_timestamp = gsl::narrow_cast<TimestampNanoseconds>(
+          absl::gntohll(serialized_header->system_clock_timestamp)),
+      .steady_clock_timestamp = gsl::narrow_cast<TimestampNanoseconds>(
+          absl::gntohll(serialized_header->steady_clock_timestamp)),
+      .event_count = gsl::narrow_cast<EventCount>(
+          absl::gntohl(serialized_header->event_count))};
+}
+
+constexpr auto operator==(const Event& lhs, const Event& rhs) -> bool {
+  return lhs.steady_clock_timestamp == rhs.steady_clock_timestamp &&
+         lhs.payload_1 == rhs.payload_1 && lhs.type == rhs.type &&
+         lhs.payload_2 == rhs.payload_2;
 }
 
 inline auto Serialize(const Event event) -> std::array<char, sizeof(Event)> {
   std::array<char, sizeof(Event)> serialized{};
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
   auto* serialized_event = reinterpret_cast<Event*>(serialized.data());
-  serialized_event->function_id_ = absl::ghtonll(event.function_id_);
-  serialized_event->type_and_timestamp_ =
-      absl::ghtonll(event.type_and_timestamp_);
+  serialized_event->steady_clock_timestamp =
+      absl::ghtonll(event.steady_clock_timestamp);
+  serialized_event->payload_1 = absl::ghtonll(event.payload_1);
+  const auto type =
+      static_cast<std::underlying_type_t<Event::Type>>(event.type);
+  serialized_event->type = absl::ghtonl(type);
+  serialized_event->payload_2 = absl::ghtonl(event.payload_2);
   return serialized;
 }
 
 inline auto Deserialize(std::array<char, sizeof(Event)> serialized) -> Event {
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
   auto* serialized_event = reinterpret_cast<Event*>(serialized.data());
-  Event event{};
-  event.function_id_ = absl::gntohll(serialized_event->function_id_);
-  event.type_and_timestamp_ =
-      absl::gntohll(serialized_event->type_and_timestamp_);
-  return event;
-}
-
-inline auto Serialize(const Footer /*unused*/)
-    -> std::array<char, sizeof(Footer)> {
-  return {};
-}
-
-inline auto Deserialize(std::array<char, sizeof(Footer)> /*unused*/) -> Footer {
-  return {};
+  const auto type =
+      static_cast<std::underlying_type_t<Event::Type>>(serialized_event->type);
+  return Event{.steady_clock_timestamp = gsl::narrow_cast<TimestampNanoseconds>(
+                   absl::gntohll(serialized_event->steady_clock_timestamp)),
+               .payload_1 = absl::gntohll(serialized_event->payload_1),
+               .type = absl::gntohl(type),
+               .payload_2 = absl::gntohl(serialized_event->payload_2)};
 }
 
 }  // namespace spoor::runtime::trace

--- a/spoor/runtime/trace/trace_file_writer.cc
+++ b/spoor/runtime/trace/trace_file_writer.cc
@@ -12,8 +12,8 @@
 namespace spoor::runtime::trace {
 
 auto TraceFileWriter::Write(const std::filesystem::path& file_path,
-                            const Header header, Events* events,
-                            const Footer footer) const -> Result {
+                            const Header header, Events* events) const
+    -> Result {
   std::ofstream file{file_path, std::ios::trunc | std::ios::binary};
   if (!file.is_open()) return Error::kFailedToOpenFile;
   const auto serialized_header = Serialize(header);
@@ -24,8 +24,6 @@ auto TraceFileWriter::Write(const std::filesystem::path& file_path,
       file.write(serialized_event.data(), serialized_event.size());
     }
   }
-  const auto serialized_footer = Serialize(footer);
-  file.write(serialized_footer.data(), serialized_footer.size());
   return Result::Ok({});
 }
 

--- a/spoor/runtime/trace/trace_file_writer.h
+++ b/spoor/runtime/trace/trace_file_writer.h
@@ -12,8 +12,8 @@ namespace spoor::runtime::trace {
 
 class TraceFileWriter final : public TraceWriter {
  public:
-  auto Write(const std::filesystem::path& file, Header header, Events* events,
-             Footer footer) const -> Result override;
+  auto Write(const std::filesystem::path& file, Header header,
+             Events* events) const -> Result override;
 };
 
 }  // namespace spoor::runtime::trace

--- a/spoor/runtime/trace/trace_test.cc
+++ b/spoor/runtime/trace/trace_test.cc
@@ -9,35 +9,12 @@ namespace {
 
 using spoor::runtime::trace::Deserialize;
 using spoor::runtime::trace::Event;
-using spoor::runtime::trace::Footer;
+using spoor::runtime::trace::EventType;
 using spoor::runtime::trace::FunctionId;
 using spoor::runtime::trace::Header;
 using spoor::runtime::trace::Serialize;
 using spoor::runtime::trace::TimestampNanoseconds;
 using Type = spoor::runtime::trace::Event::Type;
-
-TEST(Event, StoresProperties) {  // NOLINT
-  const FunctionId function_id{0xffffffffffffffff};
-  const TimestampNanoseconds timestamp{0x7fffffffffffffff};
-  for (const auto type : {Type::kFunctionEntry, Type::kFunctionExit}) {
-    const Event event{type, function_id, timestamp};
-    ASSERT_EQ(event.GetType(), type);
-    ASSERT_EQ(event.GetFunctionId(), function_id);
-    ASSERT_EQ(event.GetTimestamp(), timestamp);
-  }
-}
-
-TEST(Event, DropsMostSignificantTimestampBit) {  // NOLINT
-  const FunctionId function_id{0xffffffffffffffff};
-  const auto timestamp = static_cast<TimestampNanoseconds>(0xffffffffffffffff);
-  const TimestampNanoseconds expected_timestamp{0x7fffffffffffffff};
-  for (const auto type : {Type::kFunctionEntry, Type::kFunctionExit}) {
-    const Event event{type, function_id, timestamp};
-    ASSERT_EQ(event.GetType(), type);
-    ASSERT_EQ(event.GetFunctionId(), function_id);
-    ASSERT_EQ(event.GetTimestamp(), expected_timestamp);
-  }
-}
 
 TEST(Header, Serialization) {  // NOLINT
   Header expected_header{.version = 1,
@@ -53,17 +30,13 @@ TEST(Header, Serialization) {  // NOLINT
 }
 
 TEST(Event, Serialization) {  // NOLINT
-  Event expected_event{Type::kFunctionEntry, 42, 7};
+  Event expected_event{.steady_clock_timestamp = 1,
+                       .payload_1 = 2,
+                       .type = static_cast<EventType>(Type::kFunctionEntry),
+                       .payload_2 = 3};
   const auto serialized_event = Serialize(expected_event);
   const auto deserialized_event = Deserialize(serialized_event);
   ASSERT_EQ(deserialized_event, expected_event);
-}
-
-TEST(Footer, Serialization) {  // NOLINT
-  Footer expected_footer{};
-  const auto serialized_footer = Serialize(expected_footer);
-  const auto deserialized_footer = Deserialize(serialized_footer);
-  ASSERT_EQ(deserialized_footer, expected_footer);
 }
 
 }  // namespace

--- a/spoor/runtime/trace/trace_writer.h
+++ b/spoor/runtime/trace/trace_writer.h
@@ -28,7 +28,7 @@ class TraceWriter {
   virtual ~TraceWriter() = default;
 
   virtual auto Write(const std::filesystem::path& file, Header header,
-                     Events* events, Footer footer) const -> Result = 0;
+                     Events* events) const -> Result = 0;
 };
 
 }  // namespace spoor::runtime::trace

--- a/spoor/runtime/trace/trace_writer_mock.h
+++ b/spoor/runtime/trace/trace_writer_mock.h
@@ -12,8 +12,7 @@ class TraceWriterMock final : public TraceWriter {
  public:
   MOCK_METHOD(  // NOLINT
       Result, Write,
-      (const std::filesystem::path& file, Header header, Events* events,
-       Footer footer),
+      (const std::filesystem::path& file, Header header, Events* events),
       (const, override));
 };
 


### PR DESCRIPTION
* New extensible binary trace format that supports event types other than just function entry/exits. Note that this increases each event's size from 16 to 24 bytes.
* Fixes a crash where the runtime logger's destructor is called before the event logger's destructor on the main thread.
* More unit tests.
* Gardening.

#### Binary trace format
```
64 bits: Timestamp
64 bits: Payload 1
32 bits: Event ID
32 bits: Payload 2
```