### PR TITLE
Magic number

### DIFF
--- a/spoor/runtime/flush_queue/disk_flush_queue.cc
+++ b/spoor/runtime/flush_queue/disk_flush_queue.cc
@@ -169,13 +169,15 @@ auto DiskFlushQueue::TraceFileHeader(const FlushInfo& flush_info) const
           .count();
   const auto event_count =
       gsl::narrow_cast<trace::EventCount>(flush_info.buffer.Size());
-  return trace::Header{.version = trace::kTraceFileVersion,
-                       .session_id = options_.session_id,
-                       .process_id = options_.process_id,
-                       .thread_id = flush_info.thread_id,
-                       .system_clock_timestamp = system_clock_timestamp,
-                       .steady_clock_timestamp = steady_clock_timestamp,
-                       .event_count = event_count};
+  return trace::Header{
+      .compression_strategy = trace::CompressionStrategy::kNone,
+      .version = trace::kTraceFileVersion,
+      .session_id = options_.session_id,
+      .process_id = options_.process_id,
+      .thread_id = flush_info.thread_id,
+      .system_clock_timestamp = system_clock_timestamp,
+      .steady_clock_timestamp = steady_clock_timestamp,
+      .event_count = event_count};
 }
 
 }  // namespace spoor::runtime::flush_queue

--- a/spoor/runtime/flush_queue/disk_flush_queue_test.cc
+++ b/spoor/runtime/flush_queue/disk_flush_queue_test.cc
@@ -26,9 +26,13 @@ namespace {
 
 using spoor::runtime::flush_queue::DiskFlushQueue;
 using spoor::runtime::flush_queue::kTraceFileExtension;
+using spoor::runtime::trace::CompressionStrategy;
 using spoor::runtime::trace::Event;
 using spoor::runtime::trace::EventType;
 using spoor::runtime::trace::Header;
+using spoor::runtime::trace::kEndianness;
+using spoor::runtime::trace::kMagicNumber;
+using spoor::runtime::trace::kTraceFileVersion;
 using spoor::runtime::trace::TimestampNanoseconds;
 using spoor::runtime::trace::TraceWriter;
 using spoor::runtime::trace::testing::TraceWriterMock;
@@ -161,7 +165,10 @@ TEST(DiskFlushQueue, WritesEvents) {  // NOLINT
   const auto matches_header = [&](const Header& header) {
     // Ignore the `thread_id` because it reflects the hash of the true value
     // which cannot be determined.
-    return header.version == spoor::runtime::trace::kTraceFileVersion &&
+    return header.magic_number == kMagicNumber &&
+           header.endianness == kEndianness &&
+           header.compression_strategy == CompressionStrategy::kNone &&
+           header.version == kTraceFileVersion &&
            header.session_id == kSessionId && header.process_id == kProcessId &&
            header.system_clock_timestamp == system_clock_timestamp &&
            header.steady_clock_timestamp == steady_clock_timestamp &&

--- a/spoor/runtime/runtime_manager/runtime_manager_test.cc
+++ b/spoor/runtime/runtime_manager/runtime_manager_test.cc
@@ -30,10 +30,10 @@ namespace {
 
 using spoor::runtime::event_logger::EventLogger;
 using spoor::runtime::runtime_manager::RuntimeManager;
+using spoor::runtime::trace::CompressionStrategy;
 using spoor::runtime::trace::Event;
 using spoor::runtime::trace::EventType;
 using spoor::runtime::trace::Header;
-using spoor::runtime::trace::kTraceFileVersion;
 using spoor::runtime::trace::TimestampNanoseconds;
 using spoor::runtime::trace::testing::TraceReaderMock;
 using testing::_;
@@ -286,7 +286,7 @@ TEST(RuntimeManager, DeleteFlushedTraceFilesOlderThan) {  // NOLINT
   };
   const auto make_timestamp = [](const int64 n) { return n * 1'000'000; };
   const auto make_header = [](TimestampNanoseconds system_clock_timestamp) {
-    return Header{.version = kTraceFileVersion,
+    return Header{.compression_strategy = CompressionStrategy::kNone,
                   .session_id = 0,
                   .process_id = 0,
                   .thread_id = 0,

--- a/spoor/runtime/trace/BUILD
+++ b/spoor/runtime/trace/BUILD
@@ -21,6 +21,7 @@ cc_library(
     deps = [
         "//spoor/runtime/buffer",
         "//util:numeric",
+        "//util/compression",
         "//util/file_system",
         "@com_google_absl//absl/base:endian",
         "@com_google_absl//absl/strings",

--- a/spoor/runtime/trace/trace.h
+++ b/spoor/runtime/trace/trace.h
@@ -8,39 +8,71 @@
 
 #include "absl/base/internal/endian.h"
 #include "gsl/gsl"
+#include "util/compression/compressor.h"
 #include "util/numeric.h"
 
 namespace spoor::runtime::trace {
 
+using CompressionStrategy = util::compression::Strategy;
 using DurationNanoseconds = int64;
 using EventCount = int32;
 using EventType = uint32;
 using FunctionId = uint64;
+using MagicNumber = std::array<uint8, 10>;
 using ProcessId = int64;  // pid_t is a signed integer
 using SessionId = uint64;
 using ThreadId = uint64;
 using TimestampNanoseconds = int64;
-using TraceFileVersion = uint64;
+using TraceFileVersion = uint32;
 
 // IMPORTANT: Increment the version number if the Header or Event structure
 // changes.
 constexpr TraceFileVersion kTraceFileVersion{0};
 
+// Inspired by PNG's magic number.
+constexpr MagicNumber kMagicNumber{
+    {// This eight-bit signature was chosen because:
+     // * By convention, setting the first byte's high bit signifies a binary
+     //   file format (instead of a text file format).
+     // * It is not an ASCII character.
+     // * It is unique from the list of well-known binary file signatures.
+     //   https://en.wikipedia.org/wiki/List_of_file_signatures
+     0b1100'1000,
+     // ASCII characters to easily identify the file format in a text editor.
+     'S', 'p', 'o', 'o', 'r',
+     // DOS-style line ending.
+     '\r', '\n',
+     // ASCII SUB control character that stops the file display under DOS when
+     // the command type has been used as the end of file character.
+     0x1a,
+     // Unix-style line ending.
+     '\n'}};
+
+enum class Endian : uint8 {
+  kLittle = 0,
+  kBig = 1,
+};
+
+constexpr Endian kEndianness{
+    absl::little_endian::IsLittleEndian() ? Endian::kLittle : Endian::kBig};
+
 struct alignas(8) Header {
-  TraceFileVersion version;  // IMPORTANT: Keep `version` as the first property.
+  MagicNumber magic_number{kMagicNumber};
+  Endian endianness{kEndianness};
+  CompressionStrategy compression_strategy;
+  TraceFileVersion version{kTraceFileVersion};
   SessionId session_id;
   ProcessId process_id;
   ThreadId thread_id;
   TimestampNanoseconds system_clock_timestamp;
   TimestampNanoseconds steady_clock_timestamp;
   EventCount event_count;
+  std::array<uint8, 4> padding{0};
 };
 
-static_assert(sizeof(Header) == 56);
+static_assert(sizeof(Header) == 64);
 
 constexpr auto operator==(const Header& lhs, const Header& rhs) -> bool;
-inline auto Serialize(Header header) -> std::array<char, sizeof(Header)>;
-inline auto Deserialize(std::array<char, sizeof(Header)> serialized) -> Header;
 
 class alignas(8) Event {
  public:
@@ -58,80 +90,22 @@ class alignas(8) Event {
 static_assert(sizeof(Event) == 24);
 
 constexpr auto operator==(const Event& lhs, const Event& rhs) -> bool;
-inline auto Serialize(Event event) -> std::array<char, sizeof(Event)>;
-inline auto Deserialize(std::array<char, sizeof(Event)> serialized) -> Event;
 
 constexpr auto operator==(const Header& lhs, const Header& rhs) -> bool {
-  return lhs.version == rhs.version && lhs.session_id == rhs.session_id &&
+  return lhs.magic_number == rhs.magic_number &&
+         lhs.endianness == rhs.endianness &&
+         lhs.compression_strategy == rhs.compression_strategy &&
+         lhs.version == rhs.version && lhs.session_id == rhs.session_id &&
          lhs.process_id == rhs.process_id && lhs.thread_id == rhs.thread_id &&
          lhs.system_clock_timestamp == rhs.system_clock_timestamp &&
          lhs.steady_clock_timestamp == rhs.steady_clock_timestamp &&
          lhs.event_count == rhs.event_count;
 }
 
-inline auto Serialize(const Header header) -> std::array<char, sizeof(Header)> {
-  std::array<char, sizeof(Header)> serialized{};
-  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-  auto* serialized_header = reinterpret_cast<Header*>(serialized.data());
-  serialized_header->version = absl::ghtonll(header.version);
-  serialized_header->session_id = absl::ghtonll(header.session_id);
-  serialized_header->process_id = absl::ghtonll(header.process_id);
-  serialized_header->thread_id = absl::ghtonll(header.thread_id);
-  serialized_header->system_clock_timestamp =
-      absl::ghtonll(header.system_clock_timestamp);
-  serialized_header->steady_clock_timestamp =
-      absl::ghtonll(header.steady_clock_timestamp);
-  serialized_header->event_count = absl::ghtonl(header.event_count);
-  return serialized;
-}
-
-inline auto Deserialize(std::array<char, sizeof(Header)> serialized) -> Header {
-  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-  auto* serialized_header = reinterpret_cast<Header*>(serialized.data());
-  return Header{
-      .version = absl::gntohll(serialized_header->version),
-      .session_id = absl::gntohll(serialized_header->session_id),
-      .process_id = gsl::narrow_cast<ProcessId>(
-          absl::gntohll(serialized_header->process_id)),
-      .thread_id = absl::gntohll(serialized_header->thread_id),
-      .system_clock_timestamp = gsl::narrow_cast<TimestampNanoseconds>(
-          absl::gntohll(serialized_header->system_clock_timestamp)),
-      .steady_clock_timestamp = gsl::narrow_cast<TimestampNanoseconds>(
-          absl::gntohll(serialized_header->steady_clock_timestamp)),
-      .event_count = gsl::narrow_cast<EventCount>(
-          absl::gntohl(serialized_header->event_count))};
-}
-
 constexpr auto operator==(const Event& lhs, const Event& rhs) -> bool {
   return lhs.steady_clock_timestamp == rhs.steady_clock_timestamp &&
          lhs.payload_1 == rhs.payload_1 && lhs.type == rhs.type &&
          lhs.payload_2 == rhs.payload_2;
-}
-
-inline auto Serialize(const Event event) -> std::array<char, sizeof(Event)> {
-  std::array<char, sizeof(Event)> serialized{};
-  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-  auto* serialized_event = reinterpret_cast<Event*>(serialized.data());
-  serialized_event->steady_clock_timestamp =
-      absl::ghtonll(event.steady_clock_timestamp);
-  serialized_event->payload_1 = absl::ghtonll(event.payload_1);
-  const auto type =
-      static_cast<std::underlying_type_t<Event::Type>>(event.type);
-  serialized_event->type = absl::ghtonl(type);
-  serialized_event->payload_2 = absl::ghtonl(event.payload_2);
-  return serialized;
-}
-
-inline auto Deserialize(std::array<char, sizeof(Event)> serialized) -> Event {
-  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-  auto* serialized_event = reinterpret_cast<Event*>(serialized.data());
-  const auto type =
-      static_cast<std::underlying_type_t<Event::Type>>(serialized_event->type);
-  return Event{.steady_clock_timestamp = gsl::narrow_cast<TimestampNanoseconds>(
-                   absl::gntohll(serialized_event->steady_clock_timestamp)),
-               .payload_1 = absl::gntohll(serialized_event->payload_1),
-               .type = absl::gntohl(type),
-               .payload_2 = absl::gntohl(serialized_event->payload_2)};
 }
 
 }  // namespace spoor::runtime::trace

--- a/spoor/runtime/trace/trace_file_writer.cc
+++ b/spoor/runtime/trace/trace_file_writer.cc
@@ -16,13 +16,11 @@ auto TraceFileWriter::Write(const std::filesystem::path& file_path,
     -> Result {
   std::ofstream file{file_path, std::ios::trunc | std::ios::binary};
   if (!file.is_open()) return Error::kFailedToOpenFile;
-  const auto serialized_header = Serialize(header);
-  file.write(serialized_header.data(), serialized_header.size());
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+  file.write(reinterpret_cast<const char*>(&header), sizeof(header));
   for (auto& chunk : events->ContiguousMemoryChunks()) {
-    for (const auto event : chunk) {
-      const auto serialized_event = Serialize(event);
-      file.write(serialized_event.data(), serialized_event.size());
-    }
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    file.write(reinterpret_cast<const char*>(chunk.data()), chunk.size_bytes());
   }
   return Result::Ok({});
 }

--- a/spoor/runtime/trace/trace_reader.h
+++ b/spoor/runtime/trace/trace_reader.h
@@ -15,6 +15,7 @@ class TraceReader {
  public:
   enum class Error {
     kFailedToOpenFile,
+    kMagicNumberDoesNotMatch,
     kUnknownVersion,
   };
 

--- a/spoor/runtime/trace/trace_test.cc
+++ b/spoor/runtime/trace/trace_test.cc
@@ -7,36 +7,61 @@
 
 namespace {
 
-using spoor::runtime::trace::Deserialize;
+using spoor::runtime::trace::CompressionStrategy;
+using spoor::runtime::trace::Endian;
 using spoor::runtime::trace::Event;
 using spoor::runtime::trace::EventType;
-using spoor::runtime::trace::FunctionId;
 using spoor::runtime::trace::Header;
-using spoor::runtime::trace::Serialize;
-using spoor::runtime::trace::TimestampNanoseconds;
+using spoor::runtime::trace::kMagicNumber;
 using Type = spoor::runtime::trace::Event::Type;
 
-TEST(Header, Serialization) {  // NOLINT
-  Header expected_header{.version = 1,
-                         .session_id = 2,
-                         .process_id = 3,
-                         .thread_id = 4,
-                         .system_clock_timestamp = 5,
-                         .steady_clock_timestamp = 6,
-                         .event_count = 7};
-  const auto serialized_header = Serialize(expected_header);
-  const auto deserialized_header = Deserialize(serialized_header);
-  ASSERT_EQ(deserialized_header, expected_header);
+TEST(Header, Equality) {  // NOLINT
+  constexpr Header header_a{.magic_number = kMagicNumber,
+                            .endianness = Endian::kLittle,
+                            .compression_strategy = CompressionStrategy::kNone,
+                            .version = 0,
+                            .session_id = 1,
+                            .process_id = 2,
+                            .thread_id = 3,
+                            .system_clock_timestamp = 4,
+                            .steady_clock_timestamp = 5,
+                            .event_count = 6};
+  constexpr Header header_b{.magic_number = kMagicNumber,
+                            .endianness = Endian::kLittle,
+                            .compression_strategy = CompressionStrategy::kNone,
+                            .version = 0,
+                            .session_id = 1,
+                            .process_id = 2,
+                            .thread_id = 3,
+                            .system_clock_timestamp = 4,
+                            .steady_clock_timestamp = 5,
+                            .event_count = 6};
+  constexpr Header header_c{
+      .magic_number = kMagicNumber,
+      .endianness = Endian::kBig,
+      .compression_strategy = CompressionStrategy::kSnappy,
+      .version = 10,
+      .session_id = 11,
+      .process_id = 12,
+      .thread_id = 13,
+      .system_clock_timestamp = 14,
+      .steady_clock_timestamp = 15,
+      .event_count = 16};
+  ASSERT_EQ(header_a, header_b);
+  ASSERT_NE(header_a, header_c);
 }
 
-TEST(Event, Serialization) {  // NOLINT
-  Event expected_event{.steady_clock_timestamp = 1,
-                       .payload_1 = 2,
-                       .type = static_cast<EventType>(Type::kFunctionEntry),
-                       .payload_2 = 3};
-  const auto serialized_event = Serialize(expected_event);
-  const auto deserialized_event = Deserialize(serialized_event);
-  ASSERT_EQ(deserialized_event, expected_event);
+TEST(Event, Equality) {  // NOLINT
+  constexpr Event event_a{
+      .steady_clock_timestamp = 0, .payload_1 = 1, .type = 2, .payload_2 = 3};
+  constexpr Event event_b{
+      .steady_clock_timestamp = 0, .payload_1 = 1, .type = 2, .payload_2 = 3};
+  constexpr Event event_c{.steady_clock_timestamp = 10,
+                          .payload_1 = 11,
+                          .type = 12,
+                          .payload_2 = 13};
+  ASSERT_EQ(event_a, event_b);
+  ASSERT_NE(event_a, event_c);
 }
 
 }  // namespace


### PR DESCRIPTION
* Adds a [magic number](https://en.wikipedia.org/wiki/File_format#Magic_number) to Spoor's binary trace file header.
* Encodes the system's endianness in the header to save us an O(n) pass over the events that converts them to network byte order before writing the file.

Thank you @dalemyers for the idea!