### PR TITLE
Binary file compression

### DIFF
--- a/spoor/runtime/BUILD
+++ b/spoor/runtime/BUILD
@@ -19,6 +19,7 @@ cc_library(
         "//spoor/runtime/runtime_manager",
         "//spoor/runtime/trace",
         "//util:numeric",
+        "//util/compression",
         "@com_google_absl//absl/strings",
         "@com_microsoft_gsl//:gsl",
     ],

--- a/spoor/runtime/config/BUILD
+++ b/spoor/runtime/config/BUILD
@@ -13,6 +13,7 @@ cc_library(
         "//spoor/runtime/buffer",
         "//spoor/runtime/trace",
         "//util:numeric",
+        "//util/compression",
         "//util/env",
         "@com_microsoft_gsl//:gsl",
     ],

--- a/spoor/runtime/config/config.cc
+++ b/spoor/runtime/config/config.cc
@@ -12,6 +12,9 @@ using util::env::GetEnvOrDefault;
 auto Config::FromEnv(const util::env::GetEnv& get_env) -> Config {
   return {.trace_file_path = GetEnvOrDefault(
               kTraceFilePathKey.data(), kTraceFilePathDefaultValue, get_env),
+          .compression_strategy = GetEnvOrDefault(
+              kCompressionStrategyKey.data(), kCompressionStrategyDefaultValue,
+              kCompressionStrategyMap, true, get_env),
           .session_id = GetEnvOrDefault(kSessionIdKey.data(),
                                         kSessionIdDefaultValue(), get_env),
           .thread_event_buffer_capacity =
@@ -44,6 +47,7 @@ auto Config::FromEnv(const util::env::GetEnv& get_env) -> Config {
 
 auto operator==(const Config& lhs, const Config& rhs) -> bool {
   return lhs.trace_file_path == rhs.trace_file_path &&
+         lhs.compression_strategy == rhs.compression_strategy &&
          lhs.session_id == rhs.session_id &&
          lhs.thread_event_buffer_capacity == rhs.thread_event_buffer_capacity &&
          lhs.max_reserved_event_buffer_slice_capacity ==

--- a/spoor/runtime/config/config.h
+++ b/spoor/runtime/config/config.h
@@ -7,17 +7,29 @@
 #include <filesystem>
 #include <limits>
 #include <random>
+#include <string>
 #include <string_view>
+#include <unordered_map>
 
 #include "spoor/runtime/buffer/circular_buffer.h"
 #include "spoor/runtime/trace/trace.h"
+#include "util/compression/compressor.h"
 #include "util/env/env.h"
 
 namespace spoor::runtime::config {
 
+using CompressionStrategy = util::compression::Strategy;
+
 constexpr std::string_view kTraceFilePathKey{"SPOOR_RUNTIME_TRACE_FILE_PATH"};
 // NOLINTNEXTLINE(fuchsia-statically-constructed-objects)
 const std::string kTraceFilePathDefaultValue{"."};
+constexpr std::string_view kCompressionStrategyKey{
+    "SPOOR_RUNTIME_COMPRESSION_STRATEGY"};
+// NOLINTNEXTLINE(fuchsia-statically-constructed-objects)
+const std::unordered_map<std::string_view, CompressionStrategy>
+    kCompressionStrategyMap{{"none", CompressionStrategy::kNone},
+                            {"snappy", CompressionStrategy::kSnappy}};
+constexpr auto kCompressionStrategyDefaultValue{CompressionStrategy::kSnappy};
 constexpr std::string_view kSessionIdKey{"SPOOR_RUNTIME_SESSION_ID"};
 // NOLINTNEXTLINE(fuchsia-statically-constructed-objects)
 constexpr auto kSessionIdDefaultValue = [] {
@@ -69,6 +81,7 @@ struct Config {
   }) -> Config;
 
   std::filesystem::path trace_file_path;
+  CompressionStrategy compression_strategy;
   trace::SessionId session_id;
   SizeType thread_event_buffer_capacity;
   SizeType max_reserved_event_buffer_slice_capacity;

--- a/spoor/runtime/config/config_test.cc
+++ b/spoor/runtime/config/config_test.cc
@@ -12,7 +12,9 @@
 
 namespace {
 
+using spoor::runtime::config::CompressionStrategy;
 using spoor::runtime::config::Config;
+using spoor::runtime::config::kCompressionStrategyKey;
 using spoor::runtime::config::kDynamicEventPoolCapacityKey;
 using spoor::runtime::config::kDynamicEventSliceBorrowCasAttemptsKey;
 using spoor::runtime::config::kEventBufferRetentionDurationNanosecondsKey;
@@ -31,6 +33,7 @@ TEST(Config, GetsUserProvidedValue) {  // NOLINT
   const auto get_env = [](const char* key) {
     const std::unordered_map<std::string_view, std::string_view> environment{
         {kTraceFilePathKey, "/path/to/file.extension"},
+        {kCompressionStrategyKey, "   SnApPy   "},
         {kSessionIdKey, "42"},
         {kThreadEventBufferCapacityKey, "42"},
         {kMaxReservedEventBufferSliceCapacityKey, "42"},
@@ -45,6 +48,7 @@ TEST(Config, GetsUserProvidedValue) {  // NOLINT
   };
   const Config expected_options{
       .trace_file_path = "/path/to/file.extension",
+      .compression_strategy = CompressionStrategy::kSnappy,
       .session_id = 42,
       .thread_event_buffer_capacity = 42,
       .max_reserved_event_buffer_slice_capacity = 42,
@@ -64,6 +68,7 @@ TEST(Config, UsesDefaultValueWhenNotSpecified) {  // NOLINT
   };
   Config expected_options{
       .trace_file_path{"."},
+      .compression_strategy = CompressionStrategy::kSnappy,
       .session_id = 0,  // Ignored
       .thread_event_buffer_capacity = 10'000,
       .max_reserved_event_buffer_slice_capacity = 1'000,

--- a/spoor/runtime/flush_queue/BUILD
+++ b/spoor/runtime/flush_queue/BUILD
@@ -66,6 +66,7 @@ cc_test(
         ":black_hole_flush_queue",
         "//spoor/runtime/buffer",
         "//spoor/runtime/trace",
+        "//util/compression",
         "@com_google_absl//absl/synchronization",
         "@com_google_absl//absl/time",
         "@com_google_googletest//:gtest_main",

--- a/spoor/runtime/flush_queue/disk_flush_queue.cc
+++ b/spoor/runtime/flush_queue/disk_flush_queue.cc
@@ -170,7 +170,7 @@ auto DiskFlushQueue::TraceFileHeader(const FlushInfo& flush_info) const
   const auto event_count =
       gsl::narrow_cast<trace::EventCount>(flush_info.buffer.Size());
   return trace::Header{
-      .compression_strategy = trace::CompressionStrategy::kNone,
+      .compression_strategy = {},  // Set by the trace file writer.
       .version = trace::kTraceFileVersion,
       .session_id = options_.session_id,
       .process_id = options_.process_id,

--- a/spoor/runtime/flush_queue/disk_flush_queue_test.cc
+++ b/spoor/runtime/flush_queue/disk_flush_queue_test.cc
@@ -19,6 +19,7 @@
 #include "spoor/runtime/buffer/reserved_buffer_slice_pool.h"
 #include "spoor/runtime/trace/trace.h"
 #include "spoor/runtime/trace/trace_writer_mock.h"
+#include "util/compression/compressor.h"
 #include "util/numeric.h"
 #include "util/time/clock_mock.h"
 

--- a/spoor/runtime/runtime.cc
+++ b/spoor/runtime/runtime.cc
@@ -21,7 +21,9 @@
 #include "spoor/runtime/trace/trace.h"
 #include "spoor/runtime/trace/trace_file_reader.h"
 #include "spoor/runtime/trace/trace_file_writer.h"
+#include "util/compression/compressor_factory.h"
 #include "util/file_system/local_file_system.h"
+#include "util/file_system/local_file_writer.h"
 #include "util/numeric.h"
 #include "util/time/clock.h"
 
@@ -47,10 +49,15 @@ util::time::SteadyClock steady_clock_{};
 // clang-format off NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables, fuchsia-statically-constructed-objects) clang-format on
 util::file_system::LocalFileSystem file_system_{};
 // clang-format off NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables, fuchsia-statically-constructed-objects) clang-format on
+util::file_system::LocalFileWriter file_writer_{};
+// clang-format off NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables, fuchsia-statically-constructed-objects) clang-format on
 spoor::runtime::trace::TraceFileReader trace_reader_{
     {.file_system = &file_system_}};
 // clang-format off NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables, fuchsia-statically-constructed-objects) clang-format on
-spoor::runtime::trace::TraceFileWriter trace_writer_{};
+spoor::runtime::trace::TraceFileWriter trace_writer_{
+    {.file_writer = &file_writer_,
+     .compression_strategy = kConfig.compression_strategy,
+     .initial_buffer_capacity = kConfig.thread_event_buffer_capacity}};
 // clang-format off NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables, fuchsia-statically-constructed-objects) clang-format on
 spoor::runtime::flush_queue::DiskFlushQueue flush_queue_{
     {.trace_file_path = kConfig.trace_file_path,

--- a/spoor/runtime/trace/BUILD
+++ b/spoor/runtime/trace/BUILD
@@ -37,7 +37,23 @@ cc_test(
     visibility = ["//visibility:private"],
     deps = [
         ":trace",
+        "//spoor/runtime/buffer",
         "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "trace_file_writer_test",
+    size = "small",
+    srcs = ["trace_file_writer_test.cc"],
+    copts = ["-Werror"],
+    visibility = ["//visibility:private"],
+    deps = [
+        ":trace",
+        "//util/compression",
+        "//util/file_system:file_system_mock",
+        "@com_google_googletest//:gtest_main",
+        "@com_microsoft_gsl//:gsl",
     ],
 )
 

--- a/spoor/runtime/trace/trace_file_writer.cc
+++ b/spoor/runtime/trace/trace_file_writer.cc
@@ -3,24 +3,58 @@
 
 #include "spoor/runtime/trace/trace_file_writer.h"
 
+#include <algorithm>
 #include <filesystem>
 #include <fstream>
 #include <ios>
 
+#include "gsl/gsl"
 #include "spoor/runtime/trace/trace.h"
+#include "util/compression/compressor_factory.h"
 
 namespace spoor::runtime::trace {
 
+TraceFileWriter::TraceFileWriter(Options options)
+    : options_{std::move(options)},
+      compressor_{MakeCompressor(options_.compression_strategy,
+                                 options_.initial_buffer_capacity)} {
+  buffer_.reserve(options_.initial_buffer_capacity);
+}
+
 auto TraceFileWriter::Write(const std::filesystem::path& file_path,
-                            const Header header, Events* events) const
+                            Header header, gsl::not_null<Events*> events)
     -> Result {
-  std::ofstream file{file_path, std::ios::trunc | std::ios::binary};
-  if (!file.is_open()) return Error::kFailedToOpenFile;
-  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-  file.write(reinterpret_cast<const char*>(&header), sizeof(header));
-  for (auto& chunk : events->ContiguousMemoryChunks()) {
+  buffer_.resize(0);
+  if (events->Empty()) return Result::Ok({});
+  auto& file = *options_.file_writer;
+  file.Open(file_path, std::ios::trunc | std::ios::binary);
+  if (!file.IsOpen()) return Error::kFailedToOpenFile;
+  auto finally = gsl::finally([&file] { file.Close(); });
+  const auto chunks = events->ContiguousMemoryChunks();
+  std::for_each(std::cbegin(chunks), std::cend(chunks),
+                [this](const auto chunk) {
+                  std::copy(std::cbegin(chunk), std::cend(chunk),
+                            std::back_inserter(buffer_));
+                });
+  const auto buffer_size_bytes = buffer_.size() * sizeof(Event);
+  const auto compression_result = compressor_->Compress(
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+      {reinterpret_cast<const char*>(buffer_.data()), buffer_size_bytes});
+  if (compression_result.IsErr() ||
+      buffer_size_bytes <= compression_result.Ok().size_bytes()) {
+    header.compression_strategy = util::compression::Strategy::kNone;
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-    file.write(reinterpret_cast<const char*>(chunk.data()), chunk.size_bytes());
+    file.Write({reinterpret_cast<const char*>(&header), sizeof(header)});
+    file.Write(  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+        {reinterpret_cast<const char*>(buffer_.data()), buffer_size_bytes});
+  } else {
+    const auto compressed = compression_result.Ok();
+    header.compression_strategy = compressor_->Strategy();
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    file.Write({reinterpret_cast<const char*>(&header), sizeof(header)});
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    file.Write({reinterpret_cast<const char*>(compressed.data()),
+                compressed.size_bytes()});
   }
   return Result::Ok({});
 }

--- a/spoor/runtime/trace/trace_file_writer.h
+++ b/spoor/runtime/trace/trace_file_writer.h
@@ -4,16 +4,32 @@
 #pragma once
 
 #include <filesystem>
+#include <memory>
+#include <vector>
 
 #include "spoor/runtime/trace/trace.h"
 #include "spoor/runtime/trace/trace_writer.h"
+#include "util/compression/compressor.h"
+#include "util/file_system/file_writer.h"
 
 namespace spoor::runtime::trace {
 
 class TraceFileWriter final : public TraceWriter {
  public:
+  struct Options {
+    gsl::not_null<util::file_system::FileWriter*> file_writer;
+    util::compression::Strategy compression_strategy;
+    util::compression::Compressor::SizeType initial_buffer_capacity;
+  };
+
+  explicit TraceFileWriter(Options options);
   auto Write(const std::filesystem::path& file, Header header,
-             Events* events) const -> Result override;
+             gsl::not_null<Events*> events) -> Result override;
+
+ private:
+  Options options_;
+  std::unique_ptr<util::compression::Compressor> compressor_;
+  std::vector<Event> buffer_;
 };
 
 }  // namespace spoor::runtime::trace

--- a/spoor/runtime/trace/trace_file_writer_test.cc
+++ b/spoor/runtime/trace/trace_file_writer_test.cc
@@ -1,0 +1,253 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "spoor/runtime/trace/trace_file_writer.h"
+
+#include "gmock/gmock.h"
+#include "gsl/gsl"
+#include "gtest/gtest.h"
+#include "spoor/runtime/buffer/circular_slice_buffer.h"
+#include "spoor/runtime/buffer/reserved_buffer_slice_pool.h"
+#include "trace.h"
+#include "util/compression/compressor.h"
+#include "util/compression/compressor_factory.h"
+#include "util/file_system/file_writer_mock.h"
+
+namespace {
+
+using spoor::runtime::trace::CompressionStrategy;
+using spoor::runtime::trace::Event;
+using spoor::runtime::trace::Header;
+using spoor::runtime::trace::kEndianness;
+using spoor::runtime::trace::kMagicNumber;
+using spoor::runtime::trace::kTraceFileVersion;
+using spoor::runtime::trace::TraceFileWriter;
+using testing::_;
+using testing::Return;
+using util::compression::MakeCompressor;
+using util::file_system::testing::FileWriterMock;
+using CircularSliceBuffer = spoor::runtime::buffer::CircularSliceBuffer<Event>;
+using Pool = spoor::runtime::buffer::ReservedBufferSlicePool<Event>;
+
+MATCHER_P(MatchesHeader, expected_header, "") {  // NOLINT
+  const gsl::span<const char> expected{
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+      reinterpret_cast<const char*>(&expected_header), sizeof(expected_header)};
+  return arg == expected;
+}
+
+MATCHER_P2(MatchesEvents, expected_events, compressor, "") {  // NOLINT
+  const gsl::span<const char> expected{
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+      reinterpret_cast<const char*>(expected_events.data()),
+      expected_events.size() *
+          sizeof(typename decltype(expected_events)::value_type)};
+  const auto result = compressor->Uncompress(arg);
+  if (result.IsErr()) return false;
+  const auto uncompressed = result.Ok();
+  return uncompressed == expected;
+}
+
+TEST(TraceFileWriter, Write) {  // NOLINT
+  const std::filesystem::path path{"/path/to/file.spoor"};
+  constexpr std::array<Event, 4> raw_events{{
+      {.steady_clock_timestamp = 0, .payload_1 = 1, .type = 1, .payload_2 = 2},
+      {.steady_clock_timestamp = 1, .payload_1 = 3, .type = 2, .payload_2 = 4},
+      {.steady_clock_timestamp = 2, .payload_1 = 5, .type = 2, .payload_2 = 6},
+      {.steady_clock_timestamp = 3, .payload_1 = 9, .type = 1, .payload_2 = 8},
+  }};
+  Pool pool{
+      {.max_slice_capacity = raw_events.size(), .capacity = raw_events.size()}};
+  CircularSliceBuffer events{
+      {.buffer_slice_pool = &pool, .capacity = raw_events.size()}};
+  std::for_each(std::cbegin(raw_events), std ::cend(raw_events),
+                [&events](const auto event) { events.Push(event); });
+  for (const auto compression_strategy : util::compression::kStrategies) {
+    const Header header{.magic_number = kMagicNumber,
+                        .endianness = kEndianness,
+                        .compression_strategy = compression_strategy,
+                        .version = kTraceFileVersion,
+                        .session_id = 1,
+                        .process_id = 2,
+                        .thread_id = 3,
+                        .system_clock_timestamp = 4,
+                        .steady_clock_timestamp = 5,
+                        .event_count = raw_events.size()};
+    auto compressor =
+        MakeCompressor(compression_strategy, raw_events.size() * sizeof(Event));
+    FileWriterMock file_writer{};
+    EXPECT_CALL(file_writer, Open(path, std::ios::trunc | std::ios::binary));
+    EXPECT_CALL(file_writer, IsOpen()).WillOnce(Return(true));
+    EXPECT_CALL(file_writer, Write(MatchesHeader(header)));
+    EXPECT_CALL(file_writer,
+                Write(MatchesEvents(raw_events, compressor.get())));
+    EXPECT_CALL(file_writer, Close());
+    TraceFileWriter trace_file_writer{
+        {.file_writer = &file_writer,
+         .compression_strategy = compression_strategy,
+         .initial_buffer_capacity = raw_events.size()}};
+    const auto result = trace_file_writer.Write(path, header, &events);
+    ASSERT_TRUE(result.IsOk());
+  }
+}
+
+TEST(TraceFileWriter, SetsHeaderCompressionStrategy) {  // NOLINT
+  const std::filesystem::path path{"/path/to/file.spoor"};
+  constexpr std::array<Event, 1> raw_events{{{.steady_clock_timestamp = 0,
+                                              .payload_1 = 1,
+                                              .type = 2,
+                                              .payload_2 = 3}}};
+  constexpr Header input_header{
+      .magic_number = kMagicNumber,
+      .endianness = kEndianness,
+      .compression_strategy = CompressionStrategy::kNone,
+      .version = kTraceFileVersion,
+      .session_id = 1,
+      .process_id = 2,
+      .thread_id = 3,
+      .system_clock_timestamp = 4,
+      .steady_clock_timestamp = 5,
+      .event_count = raw_events.size()};
+  constexpr auto compression_strategy{CompressionStrategy::kSnappy};
+  constexpr Header expected_header{
+      .magic_number = input_header.magic_number,
+      .endianness = input_header.endianness,
+      .compression_strategy = compression_strategy,
+      .version = input_header.version,
+      .session_id = input_header.session_id,
+      .process_id = input_header.process_id,
+      .thread_id = input_header.thread_id,
+      .system_clock_timestamp = input_header.system_clock_timestamp,
+      .steady_clock_timestamp = input_header.steady_clock_timestamp,
+      .event_count = input_header.event_count};
+  ASSERT_NE(input_header.compression_strategy,
+            expected_header.compression_strategy);
+  Pool pool{
+      {.max_slice_capacity = raw_events.size(), .capacity = raw_events.size()}};
+  CircularSliceBuffer events{
+      {.buffer_slice_pool = &pool, .capacity = raw_events.size()}};
+  std::for_each(std::cbegin(raw_events), std ::cend(raw_events),
+                [&events](const auto event) { events.Push(event); });
+  auto compressor =
+      MakeCompressor(compression_strategy, raw_events.size() * sizeof(Event));
+  FileWriterMock file_writer{};
+  EXPECT_CALL(file_writer, Open(path, std::ios::trunc | std::ios::binary));
+  EXPECT_CALL(file_writer, IsOpen()).WillOnce(Return(true));
+  EXPECT_CALL(file_writer, Write(MatchesHeader(expected_header)));
+  EXPECT_CALL(file_writer, Write(MatchesEvents(raw_events, compressor.get())));
+  EXPECT_CALL(file_writer, Close());
+  TraceFileWriter trace_file_writer{
+      {.file_writer = &file_writer,
+       .compression_strategy = CompressionStrategy::kSnappy,
+       .initial_buffer_capacity = raw_events.size()}};
+  const auto result = trace_file_writer.Write(path, input_header, &events);
+  ASSERT_TRUE(result.IsOk());
+}
+
+TEST(TraceFileWriter, DoesNotWriteZeroEvents) {  // NOLINT
+  const std::filesystem::path path{"/path/to/file.spoor"};
+  constexpr auto compression_strategy{CompressionStrategy::kNone};
+  constexpr std::array<Event, 0> raw_events{};
+  constexpr Header header{.magic_number = kMagicNumber,
+                          .endianness = kEndianness,
+                          .compression_strategy = compression_strategy,
+                          .version = kTraceFileVersion,
+                          .session_id = 1,
+                          .process_id = 2,
+                          .thread_id = 3,
+                          .system_clock_timestamp = 4,
+                          .steady_clock_timestamp = 5,
+                          .event_count = raw_events.size()};
+  Pool pool{{.max_slice_capacity = 0, .capacity = 0}};
+  CircularSliceBuffer events{{.buffer_slice_pool = &pool, .capacity = 0}};
+  FileWriterMock file_writer{};
+  EXPECT_CALL(file_writer, Open(_, _)).Times(0);
+  EXPECT_CALL(file_writer, IsOpen()).Times(0);
+  EXPECT_CALL(file_writer, Write(_)).Times(0);
+  EXPECT_CALL(file_writer, Close()).Times(0);
+  TraceFileWriter trace_file_writer{
+      {.file_writer = &file_writer,
+       .compression_strategy = compression_strategy,
+       .initial_buffer_capacity = raw_events.size()}};
+  const auto result = trace_file_writer.Write(path, header, &events);
+  ASSERT_TRUE(result.IsOk());
+}
+
+TEST(TraceFileWriter, WritesUncompressedIfCompressedIsLarger) {  // NOLINT
+  const std::filesystem::path path{"/path/to/file.spoor"};
+  constexpr std::array<Event, 1> raw_events{
+      {{.steady_clock_timestamp = 0x0123456789abcdef,
+        .payload_1 = 0xfedcba9876543210,
+        .type = 0xabab,
+        .payload_2 = 0x1a2b3c4d}}};
+  constexpr Header header{.magic_number = kMagicNumber,
+                          .endianness = kEndianness,
+                          .compression_strategy = CompressionStrategy::kNone,
+                          .version = kTraceFileVersion,
+                          .session_id = 1,
+                          .process_id = 2,
+                          .thread_id = 3,
+                          .system_clock_timestamp = 4,
+                          .steady_clock_timestamp = 5,
+                          .event_count = raw_events.size()};
+  Pool pool{
+      {.max_slice_capacity = raw_events.size(), .capacity = raw_events.size()}};
+  CircularSliceBuffer events{
+      {.buffer_slice_pool = &pool, .capacity = raw_events.size()}};
+  std::for_each(std::cbegin(raw_events), std ::cend(raw_events),
+                [&events](const auto event) { events.Push(event); });
+  auto compressor = MakeCompressor(CompressionStrategy::kNone,
+                                   raw_events.size() * sizeof(Event));
+  ASSERT_EQ(header.compression_strategy, compressor->Strategy());
+  FileWriterMock file_writer{};
+  EXPECT_CALL(file_writer, Open(path, std::ios::trunc | std::ios::binary));
+  EXPECT_CALL(file_writer, IsOpen()).WillOnce(Return(true));
+  EXPECT_CALL(file_writer, Write(MatchesHeader(header)));
+  EXPECT_CALL(file_writer, Write(MatchesEvents(raw_events, compressor.get())));
+  EXPECT_CALL(file_writer, Close());
+  TraceFileWriter trace_file_writer{
+      {.file_writer = &file_writer,
+       .compression_strategy = CompressionStrategy::kSnappy,
+       .initial_buffer_capacity = raw_events.size()}};
+  const auto result = trace_file_writer.Write(path, header, &events);
+  ASSERT_TRUE(result.IsOk());
+}
+
+TEST(TraceFileWriter, FailsIfFileCannotBeOpened) {  // NOLINT
+  const std::filesystem::path path{"/path/to/bad/file.spoor"};
+  constexpr auto compression_strategy{CompressionStrategy::kNone};
+  constexpr std::array<Event, 1> raw_events{{{.steady_clock_timestamp = 0,
+                                              .payload_1 = 1,
+                                              .type = 2,
+                                              .payload_2 = 3}}};
+  constexpr Header header{.magic_number = kMagicNumber,
+                          .endianness = kEndianness,
+                          .compression_strategy = compression_strategy,
+                          .version = kTraceFileVersion,
+                          .session_id = 1,
+                          .process_id = 2,
+                          .thread_id = 3,
+                          .system_clock_timestamp = 4,
+                          .steady_clock_timestamp = 5,
+                          .event_count = raw_events.size()};
+  Pool pool{
+      {.max_slice_capacity = raw_events.size(), .capacity = raw_events.size()}};
+  CircularSliceBuffer events{
+      {.buffer_slice_pool = &pool, .capacity = raw_events.size()}};
+  std::for_each(std::cbegin(raw_events), std ::cend(raw_events),
+                [&events](const auto event) { events.Push(event); });
+  FileWriterMock file_writer{};
+  EXPECT_CALL(file_writer, Open(path, std::ios::trunc | std::ios::binary));
+  EXPECT_CALL(file_writer, IsOpen()).WillOnce(Return(false));
+  EXPECT_CALL(file_writer, Write(_)).Times(0);
+  EXPECT_CALL(file_writer, Close()).Times(0);
+  TraceFileWriter trace_file_writer{
+      {.file_writer = &file_writer,
+       .compression_strategy = compression_strategy,
+       .initial_buffer_capacity = raw_events.size()}};
+  const auto result = trace_file_writer.Write(path, header, &events);
+  ASSERT_TRUE(result.IsErr());
+  ASSERT_EQ(result.Err(), TraceFileWriter::Error::kFailedToOpenFile);
+}
+
+}  // namespace

--- a/spoor/runtime/trace/trace_writer.h
+++ b/spoor/runtime/trace/trace_writer.h
@@ -5,6 +5,7 @@
 
 #include <filesystem>
 
+#include "gsl/gsl"
 #include "spoor/runtime/buffer/circular_slice_buffer.h"
 #include "spoor/runtime/trace/trace.h"
 #include "util/result.h"
@@ -28,7 +29,7 @@ class TraceWriter {
   virtual ~TraceWriter() = default;
 
   virtual auto Write(const std::filesystem::path& file, Header header,
-                     Events* events) const -> Result = 0;
+                     gsl::not_null<Events*> events) -> Result = 0;
 };
 
 }  // namespace spoor::runtime::trace

--- a/spoor/runtime/trace/trace_writer_mock.h
+++ b/spoor/runtime/trace/trace_writer_mock.h
@@ -4,6 +4,7 @@
 #include <filesystem>
 
 #include "gmock/gmock.h"
+#include "gsl/gsl"
 #include "spoor/runtime/trace/trace_writer.h"
 
 namespace spoor::runtime::trace::testing {
@@ -12,8 +13,9 @@ class TraceWriterMock final : public TraceWriter {
  public:
   MOCK_METHOD(  // NOLINT
       Result, Write,
-      (const std::filesystem::path& file, Header header, Events* events),
-      (const, override));
+      (const std::filesystem::path& file, Header header,
+       gsl::not_null<Events*> events),
+      (override));
 };
 
 }  // namespace spoor::runtime::trace::testing

--- a/util/compression/compressor.h
+++ b/util/compression/compressor.h
@@ -14,6 +14,9 @@ enum class Strategy : uint8 {
   kSnappy = 1,
 };
 
+constexpr std::array<Strategy, 2> kStrategies{
+    {Strategy::kNone, Strategy::kSnappy}};
+
 class Compressor {
  public:
   enum class CompressError {};

--- a/util/compression/compressor_test.cc
+++ b/util/compression/compressor_test.cc
@@ -17,14 +17,11 @@
 namespace {
 
 using util::compression::Compressor;
+using util::compression::kStrategies;
 using util::compression::MakeCompressor;
 using util::compression::NoneCompressor;
 using util::compression::SnappyCompressor;
-using util::compression::Strategy;
 using SizeType = util::compression::Compressor::SizeType;
-
-constexpr std::array<Strategy, 2> kCompressionStrategies{
-    {Strategy::kNone, Strategy::kSnappy}};
 
 constexpr std::array<std::string_view, 5> kTestData{
     {"", "abc", "xxxxxxxxxxxxxxxxx", "Hello, world!"}};
@@ -32,9 +29,9 @@ constexpr std::array<std::string_view, 5> kTestData{
 auto MakeCompressors(const SizeType initial_capacity)
     -> std::vector<std::unique_ptr<Compressor>> {
   std::vector<std::unique_ptr<Compressor>> result{};
-  result.reserve(kCompressionStrategies.size());
-  std::transform(std::cbegin(kCompressionStrategies),
-                 std::cend(kCompressionStrategies), std::back_inserter(result),
+  result.reserve(kStrategies.size());
+  std::transform(std::cbegin(kStrategies), std::cend(kStrategies),
+                 std::back_inserter(result),
                  [initial_capacity](const auto strategy) {
                    return MakeCompressor(strategy, initial_capacity);
                  });
@@ -42,7 +39,7 @@ auto MakeCompressors(const SizeType initial_capacity)
 }
 
 TEST(Compressor, CompressorFactory) {  // NOLINT
-  for (const auto strategy : kCompressionStrategies) {
+  for (const auto strategy : kStrategies) {
     const auto compressor = MakeCompressor(strategy, 0);
     ASSERT_EQ(compressor->Strategy(), strategy);
   }

--- a/util/env/BUILD
+++ b/util/env/BUILD
@@ -21,6 +21,7 @@ cc_test(
     deps = [
         ":env",
         "//util:numeric",
+        "@com_google_absl//absl/strings",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/util/env/env.cc
+++ b/util/env/env.cc
@@ -34,8 +34,7 @@ auto GetEnvOrDefault(const char* key, const bool default_value,
   const auto* user_value = get_env(key);
   if (user_value == nullptr) return default_value;
   std::string value{user_value};
-  std::transform(value.begin(), value.end(), value.begin(),
-                 [](unsigned char c) { return std::tolower(c); });
+  absl::AsciiStrToLower(&value);
   bool result{};
   const auto success = absl::SimpleAtob(value, &result);
   return success ? result : default_value;

--- a/util/env/env.h
+++ b/util/env/env.h
@@ -7,7 +7,9 @@
 #include <optional>
 #include <string>
 #include <type_traits>
+#include <unordered_map>
 
+#include "absl/strings/ascii.h"
 #include "absl/strings/numbers.h"
 
 namespace util::env {
@@ -26,12 +28,38 @@ auto GetEnvOrDefault(const char* key, bool default_value, const GetEnv& get_env)
 
 template <class T>
 auto GetEnvOrDefault(const char* key, T default_value, const GetEnv& get_env)
-    -> T requires(std::is_integral_v<T> && !std::is_same_v<T, bool>) {
+    -> T requires(std::is_integral_v<T> && !std::is_same_v<T, bool>);
+
+template <class T>
+auto GetEnvOrDefault(const char* key, const T& default_value,
+                     const std::unordered_map<std::string_view, T>& value_map,
+                     bool normalize, const GetEnv& get_env) -> T;
+
+template <class T>
+auto GetEnvOrDefault(const char* key, const T default_value,
+                     const GetEnv& get_env) -> T
+    requires(std::is_integral_v<T> && !std::is_same_v<T, bool>) {
   const auto* user_value = get_env(key);
   if (user_value == nullptr) return default_value;
   T value{};
   const auto success = absl::SimpleAtoi(user_value, &value);
   return success ? value : default_value;
+}
+
+template <class T>
+auto GetEnvOrDefault(const char* key, const T& default_value,
+                     const std::unordered_map<std::string_view, T>& value_map,
+                     const bool normalize, const GetEnv& get_env) -> T {
+  const auto* user_value = get_env(key);
+  if (user_value == nullptr) return default_value;
+  auto value = std::string{user_value};
+  if (normalize) {
+    absl::StripAsciiWhitespace(&value);
+    absl::AsciiStrToLower(&value);
+  }
+  const auto iterator = value_map.find(value);
+  if (iterator == std::cend(value_map)) return default_value;
+  return iterator->second;
 }
 
 }  // namespace util::env

--- a/util/file_system/BUILD
+++ b/util/file_system/BUILD
@@ -3,14 +3,22 @@
 
 cc_library(
     name = "file_system",
-    srcs = ["local_file_system.cc"],
+    srcs = [
+        "local_file_system.cc",
+        "local_file_writer.cc",
+    ],
     hdrs = [
         "file_system.h",
+        "file_writer.h",
         "local_file_system.h",
+        "local_file_writer.h",
     ],
     copts = ["-Werror"],
     visibility = ["//visibility:public"],
-    deps = ["//util:result"],
+    deps = [
+        "//util:result",
+        "@com_microsoft_gsl//:gsl",
+    ],
 )
 
 cc_library(
@@ -19,6 +27,7 @@ cc_library(
     hdrs = [
         "directory_entry_mock.h",
         "file_system_mock.h",
+        "file_writer_mock.h",
     ],
     copts = ["-Werror"],
     visibility = ["//visibility:public"],
@@ -26,5 +35,6 @@ cc_library(
         ":file_system",
         "//util:result",
         "@com_google_googletest//:gtest",
+        "@com_microsoft_gsl//:gsl",
     ],
 )

--- a/util/file_system/file_writer.h
+++ b/util/file_system/file_writer.h
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <filesystem>
+#include <ios>
+
+#include "gsl/gsl"
+
+namespace util::file_system {
+
+class FileWriter {
+ public:
+  FileWriter() = default;
+  FileWriter(const FileWriter&) = default;
+  FileWriter(FileWriter&&) noexcept = default;
+  auto operator=(const FileWriter&) -> FileWriter& = default;
+  auto operator=(FileWriter&&) noexcept -> FileWriter& = default;
+  virtual ~FileWriter() = default;
+
+  virtual auto Open(const std::filesystem::path& path,
+                    std::ios_base::openmode mode) -> void = 0;
+  [[nodiscard]] virtual auto IsOpen() const -> bool = 0;
+  virtual auto Write(gsl::span<const char> data) -> void = 0;
+  virtual auto Close() -> void = 0;
+};
+
+}  // namespace util::file_system

--- a/util/file_system/file_writer_mock.h
+++ b/util/file_system/file_writer_mock.h
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <filesystem>
+#include <ios>
+
+#include "gmock/gmock.h"
+#include "util/file_system/file_writer.h"
+
+namespace util::file_system::testing {
+
+class FileWriterMock final : public FileWriter {
+ public:
+  MOCK_METHOD(  // NOLINT
+      (void), Open,
+      (const std::filesystem::path& path, std::ios_base::openmode mode),
+      (override));
+  MOCK_METHOD(  // NOLINT
+      (bool), IsOpen, (), (const, override));
+  MOCK_METHOD(  // NOLINT
+      (void), Write, (gsl::span<const char> data), (override));
+  MOCK_METHOD(  // NOLINT
+      (void), Close, (), (override));
+};
+
+}  // namespace util::file_system::testing

--- a/util/file_system/local_file_writer.cc
+++ b/util/file_system/local_file_writer.cc
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "util/file_system/local_file_writer.h"
+
+#include <filesystem>
+#include <ios>
+
+namespace util::file_system {
+
+auto LocalFileWriter::Open(const std::filesystem::path& path,
+                           std::ios_base::openmode mode) -> void {
+  ofstream_.open(path.c_str(), mode);
+}
+
+auto LocalFileWriter::IsOpen() const -> bool { return ofstream_.is_open(); }
+
+auto LocalFileWriter::Write(const gsl::span<const char> data) -> void {
+  ofstream_.write(data.data(), data.size_bytes());
+}
+
+auto LocalFileWriter::Close() -> void { ofstream_.close(); }
+
+}  // namespace util::file_system

--- a/util/file_system/local_file_writer.h
+++ b/util/file_system/local_file_writer.h
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <filesystem>
+#include <fstream>
+#include <ios>
+
+#include "util/file_system/file_writer.h"
+
+namespace util::file_system {
+
+class LocalFileWriter final : public FileWriter {
+ public:
+  auto Open(const std::filesystem::path& path, std::ios_base::openmode mode)
+      -> void override;
+  [[nodiscard]] auto IsOpen() const -> bool override;
+  auto Write(gsl::span<const char> data) -> void override;
+  auto Close() -> void override;
+
+ private:
+  std::ofstream ofstream_;
+};
+
+}  // namespace util::file_system


### PR DESCRIPTION
Compresses trace file events before writing them to disk. The compression strategy is configurable via a runtime environment variable (default = Snappy).