### PR TITLE
Snappy Bazel

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -6,17 +6,6 @@ workspace(name = "spoor")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
-    name = "rules_foreign_cc",
-    sha256 = "2215d55b9a818af7281cba054a897c0f28f34b7fba3365964fa28b10f64963c3",
-    strip_prefix = "rules_foreign_cc-eae19778d5fe8605f0f37332a712f05d4a17dc3b",
-    urls = ["https://github.com/bazelbuild/rules_foreign_cc/archive/eae19778d5fe8605f0f37332a712f05d4a17dc3b.tar.gz"],
-)
-
-load("@rules_foreign_cc//foreign_cc:repositories.bzl", "rules_foreign_cc_dependencies")
-
-rules_foreign_cc_dependencies()
-
-http_archive(
     name = "com_microsoft_gsl",
     build_file = "//toolchain:gsl.BUILD",
     sha256 = "ca3f015ea80a8d9163714dbf6b377a424e196bd5c8b254fdb5e5770ea3f84a55",
@@ -75,17 +64,9 @@ load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 
 protobuf_deps()
 
-_ALL_CONTENT = """\
-filegroup(
-    name = "all_srcs",
-    srcs = glob(["**"]),
-    visibility = ["//visibility:public"],
-)
-"""
-
 http_archive(
     name = "com_google_snappy",
-    build_file_content = _ALL_CONTENT,
+    build_file = "//toolchain:snappy.BUILD",
     sha256 = "16b677f07832a612b0836178db7f374e414f94657c138e6993cbfc5dcc58651f",
     strip_prefix = "snappy-1.1.8",
     urls = ["https://github.com/google/snappy/archive/1.1.8.tar.gz"],

--- a/toolchain/snappy.BUILD
+++ b/toolchain/snappy.BUILD
@@ -1,0 +1,34 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+cc_library(
+    name = "snappy",
+    srcs = [
+        "snappy.cc",
+        "snappy.h",
+        "snappy-internal.h",
+        "snappy-sinksource.cc",
+        "snappy-sinksource.h",
+        "snappy-stubs-internal.cc",
+        "snappy-stubs-internal.h",
+        "snappy-stubs-public.h",
+    ],
+    hdrs = ["snappy.h"],
+    include_prefix = "snappy",
+    visibility = ["//visibility:public"],
+)
+
+genrule(
+    name = "snappy_stubs_public_h",
+    srcs = ["snappy-stubs-public.h.in"],
+    outs = ["snappy-stubs-public.h"],
+    cmd = "sed " + " ".join([
+        "-e 's/$${HAVE_SYS_UIO_H_01}/1/g'",
+        "-e 's/$${PROJECT_VERSION_MAJOR}/'$$(sed -En 's/^.*VERSION ([0-9]+).[0-9]+.[0-9]+.*$$/\1/p' CMakeLists.txt)'/g'",
+        "-e 's/$${PROJECT_VERSION_MINOR}/'$$(sed -En 's/^.*VERSION [0-9]+.([0-9]+).[0-9]+.*$$/\1/p' CMakeLists.txt)'/g'",
+        "-e 's/$${PROJECT_VERSION_PATCH}/'$$(sed -En 's/^.*VERSION [0-9]+.[0-9]+.([0-9]+).*$$/\1/p' CMakeLists.txt)'/g'",
+    ]) + " $< >$@",
+    visibility = ["//visibility:private"],
+)

--- a/util/compression/BUILD
+++ b/util/compression/BUILD
@@ -2,14 +2,6 @@
 # Licensed under the MIT License.
 
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
-load("@rules_foreign_cc//foreign_cc:defs.bzl", "cmake")
-
-cmake(
-    name = "snappy",
-    lib_source = "@com_google_snappy//:all_srcs",
-    out_static_libs = ["libsnappy.a"],
-    visibility = ["//visibility:private"],
-)
 
 cc_library(
     name = "compression",
@@ -27,9 +19,9 @@ cc_library(
     copts = ["-Werror"],
     visibility = ["//visibility:public"],
     deps = [
-        ":snappy",
         "//util:numeric",
         "//util:result",
+        "@com_google_snappy//:snappy",
         "@com_microsoft_gsl//:gsl",
     ],
 )

--- a/util/compression/compressor_test.cc
+++ b/util/compression/compressor_test.cc
@@ -23,7 +23,7 @@ using util::compression::NoneCompressor;
 using util::compression::SnappyCompressor;
 using SizeType = util::compression::Compressor::SizeType;
 
-constexpr std::array<std::string_view, 5> kTestData{
+constexpr std::array<std::string_view, 4> kTestData{
     {"", "abc", "xxxxxxxxxxxxxxxxx", "Hello, world!"}};
 
 auto MakeCompressors(const SizeType initial_capacity)

--- a/util/compression/snappy_compressor.cc
+++ b/util/compression/snappy_compressor.cc
@@ -4,8 +4,8 @@
 #include "util/compression/snappy_compressor.h"
 
 #include "gsl/gsl"
+#include "snappy/snappy.h"
 #include "util/compression/compressor.h"
-#include "util/compression/snappy/include/snappy.h"
 
 namespace util::compression {
 


### PR DESCRIPTION
Build Snappy with a custom Bazel build rule instead of using `rules_foreign_cc`'s `cmake` rule which fails when cross compiling. This PR doesn't supply a config.h to Snappy but we can in a future PR if needed.