### PR TITLE
FlatMap

### DIFF
--- a/spoor/instrumentation/config/BUILD
+++ b/spoor/instrumentation/config/BUILD
@@ -24,6 +24,7 @@ cc_test(
     deps = [
         ":config",
         "//util:numeric",
+        "//util/flat_map",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/spoor/instrumentation/config/config.cc
+++ b/spoor/instrumentation/config/config.cc
@@ -10,25 +10,26 @@ namespace spoor::instrumentation::config {
 using util::env::GetEnvOrDefault;
 
 auto Config::FromEnv(const util::env::GetEnv& get_env) -> Config {
-  return {.instrumented_function_map_output_path = GetEnvOrDefault(
-              kInstrumentedFunctionMapOutputPathKey.data(),
-              kInstrumentedFunctionMapOutputPathDefaultValue, get_env),
-          .initialize_runtime =
-              GetEnvOrDefault(kInitializeRuntimeKey.data(),
-                              kInitializeRuntimeDefaultValue, get_env),
-          .enable_runtime = GetEnvOrDefault(
-              kEnableRuntimeKey.data(), kEnableRuntimeDefaultValue, get_env),
-          .min_instruction_threshold =
-              GetEnvOrDefault(kMinInstructionThresholdKey.data(),
-                              kMinInstructionThresholdDefaultValue, get_env),
-          .module_id = GetEnvOrDefault(kModuleIdKey.data(),
-                                       kModuleIdDefaultValue, true, get_env),
-          .function_allow_list_file = GetEnvOrDefault(
-              kFunctionAllowListFileKey.data(),
-              kFunctionAllowListFileDefaultValue, true, get_env),
-          .function_blocklist_file = GetEnvOrDefault(
-              kFunctionBlocklistFileKey.data(),
-              kFunctionBlocklistFileDefaultValue, true, get_env)};
+  return {
+      .instrumented_function_map_output_path = GetEnvOrDefault(
+          kInstrumentedFunctionMapOutputPathKey.data(),
+          std::string{kInstrumentedFunctionMapOutputPathDefaultValue}, get_env),
+      .initialize_runtime =
+          GetEnvOrDefault(kInitializeRuntimeKey.data(),
+                          kInitializeRuntimeDefaultValue, get_env),
+      .enable_runtime = GetEnvOrDefault(kEnableRuntimeKey.data(),
+                                        kEnableRuntimeDefaultValue, get_env),
+      .min_instruction_threshold =
+          GetEnvOrDefault(kMinInstructionThresholdKey.data(),
+                          kMinInstructionThresholdDefaultValue, get_env),
+      .module_id = GetEnvOrDefault(kModuleIdKey.data(), kModuleIdDefaultValue,
+                                   true, get_env),
+      .function_allow_list_file =
+          GetEnvOrDefault(kFunctionAllowListFileKey.data(),
+                          kFunctionAllowListFileDefaultValue, true, get_env),
+      .function_blocklist_file =
+          GetEnvOrDefault(kFunctionBlocklistFileKey.data(),
+                          kFunctionBlocklistFileDefaultValue, true, get_env)};
 }
 
 auto operator==(const Config& lhs, const Config& rhs) -> bool {

--- a/spoor/instrumentation/config/config.h
+++ b/spoor/instrumentation/config/config.h
@@ -15,8 +15,7 @@ namespace spoor::instrumentation::config {
 
 constexpr std::string_view kInstrumentedFunctionMapOutputPathKey{
     "SPOOR_INSTRUMENTATION_INSTRUMENTED_FUNCTION_MAP_OUTPUT_PATH"};
-// NOLINTNEXTLINE(fuchsia-statically-constructed-objects)
-const std::string kInstrumentedFunctionMapOutputPathDefaultValue{"."};
+constexpr std::string_view kInstrumentedFunctionMapOutputPathDefaultValue{"."};
 constexpr std::string_view kInitializeRuntimeKey{
     "SPOOR_INSTRUMENTATION_RUNTIME_INITIALIZE_RUNTIME"};
 constexpr bool kInitializeRuntimeDefaultValue{true};
@@ -39,9 +38,7 @@ constexpr std::string_view kFunctionBlocklistFileKey{
 const std::optional<std::string> kFunctionBlocklistFileDefaultValue{};
 
 struct Config {
-  static auto FromEnv(const util::env::GetEnv& get_env = [](const char* key) {
-    return std::getenv(key);
-  }) -> Config;
+  static auto FromEnv(const util::env::GetEnv& get_env = std::getenv) -> Config;
 
   std::string instrumented_function_map_output_path;
   bool initialize_runtime;

--- a/spoor/instrumentation/config/config_test.cc
+++ b/spoor/instrumentation/config/config_test.cc
@@ -4,9 +4,9 @@
 #include "spoor/instrumentation/config/config.h"
 
 #include <limits>
-#include <unordered_map>
 
 #include "gtest/gtest.h"
+#include "util/flat_map/flat_map.h"
 #include "util/numeric.h"
 
 namespace {
@@ -22,15 +22,15 @@ using spoor::instrumentation::config::kModuleIdKey;
 
 TEST(Config, GetsUserProvidedValue) {  // NOLINT
   const auto get_env = [](const char* key) {
-    const std::unordered_map<std::string_view, std::string_view> environment{
-        {kInstrumentedFunctionMapOutputPathKey, "/path/to/output/"},
-        {kInitializeRuntimeKey, "false"},
-        {kEnableRuntimeKey, "false"},
-        {kMinInstructionThresholdKey, "42"},
-        {kModuleIdKey, "ModuleId"},
-        {kFunctionAllowListFileKey, "/path/to/allow_list.txt"},
-        {kFunctionBlocklistFileKey, "/path/to/blocklist.txt"}};
-    return environment.at(key).data();
+    constexpr util::flat_map::FlatMap<std::string_view, std::string_view, 7>
+        environment{{kInstrumentedFunctionMapOutputPathKey, "/path/to/output/"},
+                    {kInitializeRuntimeKey, "false"},
+                    {kEnableRuntimeKey, "false"},
+                    {kMinInstructionThresholdKey, "42"},
+                    {kModuleIdKey, "ModuleId"},
+                    {kFunctionAllowListFileKey, "/path/to/allow_list.txt"},
+                    {kFunctionBlocklistFileKey, "/path/to/blocklist.txt"}};
+    return environment.At(key).value_or(nullptr).data();
   };
   const Config expected_options{
       .instrumented_function_map_output_path = "/path/to/output/",
@@ -59,15 +59,15 @@ TEST(Config, UsesDefaultValueWhenNotSpecified) {  // NOLINT
 
 TEST(Config, UsesDefaultValueForEmptyStringValues) {  // NOLINT
   const auto get_env = [](const char* key) {
-    const std::unordered_map<std::string_view, std::string_view> environment{
-        {kInstrumentedFunctionMapOutputPathKey, ""},
-        {kInitializeRuntimeKey, ""},
-        {kEnableRuntimeKey, ""},
-        {kMinInstructionThresholdKey, ""},
-        {kModuleIdKey, ""},
-        {kFunctionAllowListFileKey, ""},
-        {kFunctionBlocklistFileKey, ""}};
-    return environment.at(key).data();
+    constexpr util::flat_map::FlatMap<std::string_view, std::string_view, 7>
+        environment{{kInstrumentedFunctionMapOutputPathKey, ""},
+                    {kInitializeRuntimeKey, ""},
+                    {kEnableRuntimeKey, ""},
+                    {kMinInstructionThresholdKey, ""},
+                    {kModuleIdKey, ""},
+                    {kFunctionAllowListFileKey, ""},
+                    {kFunctionBlocklistFileKey, ""}};
+    return environment.At(key).value_or(nullptr).data();
   };
   const Config expected_options{.instrumented_function_map_output_path = "",
                                 .initialize_runtime = true,

--- a/spoor/instrumentation/inject_runtime/inject_runtime.cc
+++ b/spoor/instrumentation/inject_runtime/inject_runtime.cc
@@ -11,7 +11,6 @@
 #include <iterator>
 #include <string_view>
 #include <system_error>
-#include <unordered_map>
 #include <utility>
 
 #include "google/protobuf/timestamp.pb.h"

--- a/spoor/runtime/config/BUILD
+++ b/spoor/runtime/config/BUILD
@@ -15,6 +15,7 @@ cc_library(
         "//util:numeric",
         "//util/compression",
         "//util/env",
+        "//util/flat_map",
         "@com_microsoft_gsl//:gsl",
     ],
 )
@@ -27,6 +28,7 @@ cc_test(
     visibility = ["//visibility:private"],
     deps = [
         ":config",
+        "//util/flat_map",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/spoor/runtime/config/config.cc
+++ b/spoor/runtime/config/config.cc
@@ -10,8 +10,9 @@ namespace spoor::runtime::config {
 using util::env::GetEnvOrDefault;
 
 auto Config::FromEnv(const util::env::GetEnv& get_env) -> Config {
-  return {.trace_file_path = GetEnvOrDefault(
-              kTraceFilePathKey.data(), kTraceFilePathDefaultValue, get_env),
+  return {.trace_file_path =
+              GetEnvOrDefault(kTraceFilePathKey.data(),
+                              std::string{kTraceFilePathDefaultValue}, get_env),
           .compression_strategy = GetEnvOrDefault(
               kCompressionStrategyKey.data(), kCompressionStrategyDefaultValue,
               kCompressionStrategyMap, true, get_env),

--- a/spoor/runtime/config/config.h
+++ b/spoor/runtime/config/config.h
@@ -9,24 +9,22 @@
 #include <random>
 #include <string>
 #include <string_view>
-#include <unordered_map>
 
 #include "spoor/runtime/buffer/circular_buffer.h"
 #include "spoor/runtime/trace/trace.h"
 #include "util/compression/compressor.h"
 #include "util/env/env.h"
+#include "util/flat_map/flat_map.h"
 
 namespace spoor::runtime::config {
 
 using CompressionStrategy = util::compression::Strategy;
 
 constexpr std::string_view kTraceFilePathKey{"SPOOR_RUNTIME_TRACE_FILE_PATH"};
-// NOLINTNEXTLINE(fuchsia-statically-constructed-objects)
-const std::string kTraceFilePathDefaultValue{"."};
+constexpr std::string_view kTraceFilePathDefaultValue{"."};
 constexpr std::string_view kCompressionStrategyKey{
     "SPOOR_RUNTIME_COMPRESSION_STRATEGY"};
-// NOLINTNEXTLINE(fuchsia-statically-constructed-objects)
-const std::unordered_map<std::string_view, CompressionStrategy>
+constexpr util::flat_map::FlatMap<std::string_view, CompressionStrategy, 2>
     kCompressionStrategyMap{{"none", CompressionStrategy::kNone},
                             {"snappy", CompressionStrategy::kSnappy}};
 constexpr auto kCompressionStrategyDefaultValue{CompressionStrategy::kSnappy};
@@ -76,9 +74,7 @@ constexpr bool kFlushAllEventsDefaultValue{true};
 struct Config {
   using SizeType = buffer::CircularBuffer<trace::Event>::SizeType;
 
-  static auto FromEnv(const util::env::GetEnv& get_env = [](const char* key) {
-    return std::getenv(key);
-  }) -> Config;
+  static auto FromEnv(const util::env::GetEnv& get_env = std::getenv) -> Config;
 
   std::filesystem::path trace_file_path;
   CompressionStrategy compression_strategy;

--- a/spoor/runtime/config/config_test.cc
+++ b/spoor/runtime/config/config_test.cc
@@ -5,10 +5,10 @@
 
 #include <limits>
 #include <string_view>
-#include <unordered_map>
 
 #include "gtest/gtest.h"
 #include "spoor/runtime/buffer/circular_buffer.h"
+#include "util/flat_map/flat_map.h"
 
 namespace {
 
@@ -31,20 +31,20 @@ using SizeType = spoor::runtime::buffer::CircularBuffer<
 
 TEST(Config, GetsUserProvidedValue) {  // NOLINT
   const auto get_env = [](const char* key) {
-    const std::unordered_map<std::string_view, std::string_view> environment{
-        {kTraceFilePathKey, "/path/to/file.extension"},
-        {kCompressionStrategyKey, "   SnApPy   "},
-        {kSessionIdKey, "42"},
-        {kThreadEventBufferCapacityKey, "42"},
-        {kMaxReservedEventBufferSliceCapacityKey, "42"},
-        {kMaxDynamicEventBufferSliceCapacityKey, "42"},
-        {kReservedEventPoolCapacityKey, "42"},
-        {kDynamicEventPoolCapacityKey, "42"},
-        {kDynamicEventSliceBorrowCasAttemptsKey, "42"},
-        {kEventBufferRetentionDurationNanosecondsKey, "42"},
-        {kMaxFlushBufferToFileAttemptsKey, "42"},
-        {kFlushAllEventsKey, "false"}};
-    return environment.at(key).data();
+    constexpr util::flat_map::FlatMap<std::string_view, std::string_view, 12>
+        environment{{kTraceFilePathKey, "/path/to/file.extension"},
+                    {kCompressionStrategyKey, "   SnApPy   "},
+                    {kSessionIdKey, "42"},
+                    {kThreadEventBufferCapacityKey, "42"},
+                    {kMaxReservedEventBufferSliceCapacityKey, "42"},
+                    {kMaxDynamicEventBufferSliceCapacityKey, "42"},
+                    {kReservedEventPoolCapacityKey, "42"},
+                    {kDynamicEventPoolCapacityKey, "42"},
+                    {kDynamicEventSliceBorrowCasAttemptsKey, "42"},
+                    {kEventBufferRetentionDurationNanosecondsKey, "42"},
+                    {kMaxFlushBufferToFileAttemptsKey, "42"},
+                    {kFlushAllEventsKey, "false"}};
+    return environment.At(key).value_or(nullptr).data();
   };
   const Config expected_options{
       .trace_file_path = "/path/to/file.extension",

--- a/util/env/BUILD
+++ b/util/env/BUILD
@@ -8,6 +8,7 @@ cc_library(
     copts = ["-Werror"],
     visibility = ["//visibility:public"],
     deps = [
+        "//util/flat_map",
         "@com_google_absl//absl/strings",
     ],
 )
@@ -21,6 +22,7 @@ cc_test(
     deps = [
         ":env",
         "//util:numeric",
+        "//util/flat_map",
         "@com_google_absl//absl/strings",
         "@com_google_googletest//:gtest_main",
     ],

--- a/util/env/env_test.cc
+++ b/util/env/env_test.cc
@@ -4,7 +4,6 @@
 #include "util/env/env.h"
 
 #include <string>
-#include <unordered_map>
 
 #include "absl/strings/ascii.h"
 #include "absl/strings/str_cat.h"
@@ -103,11 +102,8 @@ TEST(GetEnvOrDefault, Bool) {  // NOLINT
 
 TEST(GetEnvOrDefault, ValueMap) {  // NOLINT
   constexpr uint32 default_value{3};
-  const std::unordered_map<std::string_view, uint32> value_map{
-      {"zero", 0},
-      {"one", 1},
-      {"two", 2},
-  };
+  const util::flat_map::FlatMap<std::string_view, uint32, 3> value_map{
+      {"zero", 0}, {"one", 1}, {"two", 2}};
   for (const auto& [key_view, value] : value_map) {
     const std::string key{key_view};
     const auto messy_key =

--- a/util/flat_map/BUILD
+++ b/util/flat_map/BUILD
@@ -1,0 +1,25 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+
+cc_library(
+    name = "flat_map",
+    hdrs = ["flat_map.h"],
+    copts = ["-Werror"],
+    visibility = ["//visibility:public"],
+    deps = ["//util:result"],
+)
+
+cc_test(
+    name = "flat_map_test",
+    size = "small",
+    srcs = ["flat_map_test.cc"],
+    copts = ["-Werror"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":flat_map",
+        "//util:numeric",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/util/flat_map/flat_map.h
+++ b/util/flat_map/flat_map.h
@@ -1,0 +1,99 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <initializer_list>
+#include <optional>
+#include <utility>
+
+namespace util::flat_map {
+
+template <class Key, class Value, std::size_t Size>
+class FlatMap {
+ public:
+  using ValueType = std::pair<Key, Value>;
+  using Iterator = ValueType*;
+  using ConstIterator = const ValueType*;
+
+  constexpr FlatMap(std::initializer_list<ValueType> data);
+
+  [[nodiscard]] constexpr auto At(const Key& key) const -> std::optional<Value>;
+
+  // NOLINTNEXTLINE(readability-identifier-naming)
+  constexpr auto begin() const -> ConstIterator;
+  // NOLINTNEXTLINE(readability-identifier-naming)
+  constexpr auto begin() -> Iterator;
+  // NOLINTNEXTLINE(readability-identifier-naming)
+  constexpr auto cbegin() const -> ConstIterator;
+  // NOLINTNEXTLINE(readability-identifier-naming)
+  constexpr auto end() const -> ConstIterator;
+  // NOLINTNEXTLINE(readability-identifier-naming)
+  constexpr auto end() -> Iterator;
+  // NOLINTNEXTLINE(readability-identifier-naming)
+  constexpr auto cend() const -> ConstIterator;
+
+ private:
+  std::array<ValueType, Size> data_;
+
+  template <std::size_t... Indices>
+  constexpr FlatMap(std::initializer_list<ValueType>& data,
+                    std::index_sequence<Indices...> /*unused*/);
+};
+
+template <class Key, class Value, std::size_t Size>
+constexpr FlatMap<Key, Value, Size>::FlatMap(
+    std::initializer_list<ValueType> data)
+    : FlatMap{data, std::make_index_sequence<Size>()} {}
+
+template <class Key, class Value, std::size_t Size>
+template <std::size_t... Indices>
+constexpr FlatMap<Key, Value, Size>::FlatMap(
+    std::initializer_list<ValueType>& data,
+    std::index_sequence<Indices...> /*unused*/)
+    : data_{*(data.begin() + Indices)...} {}
+
+template <class Key, class Value, std::size_t Size>
+constexpr auto FlatMap<Key, Value, Size>::At(const Key& key) const
+    -> std::optional<Value> {
+  const auto iterator = std::find_if(
+      std::cbegin(data_), std::cend(data_),
+      [&key](const auto& key_value) { return key_value.first == key; });
+  if (iterator == std::cend(data_)) return {};
+  return iterator->second;
+}
+
+template <class Key, class Value, std::size_t Size>
+constexpr auto FlatMap<Key, Value, Size>::begin() const -> ConstIterator {
+  return data_.begin();
+}
+
+template <class Key, class Value, std::size_t Size>
+constexpr auto FlatMap<Key, Value, Size>::begin() -> Iterator {
+  return data_.begin();
+}
+
+template <class Key, class Value, std::size_t Size>
+constexpr auto FlatMap<Key, Value, Size>::cbegin() const -> ConstIterator {
+  return data_.cbegin();
+}
+
+template <class Key, class Value, std::size_t Size>
+constexpr auto FlatMap<Key, Value, Size>::end() const -> ConstIterator {
+  return data_.end();
+}
+
+template <class Key, class Value, std::size_t Size>
+constexpr auto FlatMap<Key, Value, Size>::end() -> Iterator {
+  return data_.end();
+}
+
+template <class Key, class Value, std::size_t Size>
+constexpr auto FlatMap<Key, Value, Size>::cend() const -> ConstIterator {
+  return data_.cend();
+}
+
+}  // namespace util::flat_map

--- a/util/flat_map/flat_map_test.cc
+++ b/util/flat_map/flat_map_test.cc
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "util/flat_map/flat_map.h"
+
+#include <array>
+#include <cstddef>
+#include <string_view>
+#include <utility>
+
+#include "gtest/gtest.h"
+#include "util/numeric.h"
+
+namespace {
+
+TEST(FlatMap, At) {  // NOLINT
+  using FlatMap = util::flat_map::FlatMap<std::string_view, int32, 3>;
+  constexpr FlatMap map{{"one", 1}, {"two", 2}, {"three", 3}};
+  for (const auto& [key, value] : map) {
+    const auto retrieved_value = map.At(key);
+    ASSERT_TRUE(retrieved_value.has_value());
+    ASSERT_EQ(retrieved_value.value(), value);
+  }
+  const auto retrieved_value = map.At("zero");
+  ASSERT_FALSE(retrieved_value.has_value());
+}
+
+}  // namespace


### PR DESCRIPTION
Although global variables within a translation unit are initialized in the order in which they are defined, the initialization order of globals between translation units is undefined behavior. This lead to a bug where `kCompressionStrategyMap` was empty (not yet initialized) when called so the runtime to always choose the default compression strategy and effectively ignored the user-defined value.

This PR implements `FlatMap`, a `constexpr` key-value lookup table to be used in place of `std::unordered_map`. This means that the map is initialized at compile time, thus eliminating the undefined behavior. There are runtime performance benefits using `FlatMap` over `std::unordered_map` as well (see below).

Also bundled in this PR is a patch that changes global `const std::string`s to `constexpr std::string_view`s.

#### Notes
* Lookup is O(n) (vs O(1) for `std::unordered_map`), however, we expect there to be a small number of key-value pairs. In fact, value lookup is _faster_ compared to `std::unordered_map` for small tables (our use case). One optimization could be to sort by key and binary search, however, we'd need to benchmark to see if this results in any real performance gains. We presently don't have a need for this. Reference: [C++ Weekly - Ep 233 - std::map vs constexpr map (huge perf difference!)
](https://www.youtube.com/watch?v=INn3xa4pMfg)
* In the case of duplicate keys, `FlatMap` returns the _first_ instance of the key. Checking for key uniqueness at compile-time is non-trivial (or is it?).