### PR TITLE
Flat Map updates

### DIFF
--- a/spoor/instrumentation/config/config_test.cc
+++ b/spoor/instrumentation/config/config_test.cc
@@ -30,7 +30,7 @@ TEST(Config, GetsUserProvidedValue) {  // NOLINT
                     {kModuleIdKey, "ModuleId"},
                     {kFunctionAllowListFileKey, "/path/to/allow_list.txt"},
                     {kFunctionBlocklistFileKey, "/path/to/blocklist.txt"}};
-    return environment.At(key).value_or(nullptr).data();
+    return environment.FirstValueForKey(key).value_or(nullptr).data();
   };
   const Config expected_options{
       .instrumented_function_map_output_path = "/path/to/output/",
@@ -67,7 +67,7 @@ TEST(Config, UsesDefaultValueForEmptyStringValues) {  // NOLINT
                     {kModuleIdKey, ""},
                     {kFunctionAllowListFileKey, ""},
                     {kFunctionBlocklistFileKey, ""}};
-    return environment.At(key).value_or(nullptr).data();
+    return environment.FirstValueForKey(key).value_or(nullptr).data();
   };
   const Config expected_options{.instrumented_function_map_output_path = "",
                                 .initialize_runtime = true,

--- a/spoor/runtime/config/config_test.cc
+++ b/spoor/runtime/config/config_test.cc
@@ -44,7 +44,7 @@ TEST(Config, GetsUserProvidedValue) {  // NOLINT
                     {kEventBufferRetentionDurationNanosecondsKey, "42"},
                     {kMaxFlushBufferToFileAttemptsKey, "42"},
                     {kFlushAllEventsKey, "false"}};
-    return environment.At(key).value_or(nullptr).data();
+    return environment.FirstValueForKey(key).value_or(nullptr).data();
   };
   const Config expected_options{
       .trace_file_path = "/path/to/file.extension",

--- a/util/env/env.h
+++ b/util/env/env.h
@@ -60,7 +60,7 @@ auto GetEnvOrDefault(
     absl::StripAsciiWhitespace(&value);
     absl::AsciiStrToLower(&value);
   }
-  return value_map.At(value).value_or(default_value);
+  return value_map.FirstValueForKey(value).value_or(default_value);
 }
 
 }  // namespace util::env

--- a/util/flat_map/flat_map.h
+++ b/util/flat_map/flat_map.h
@@ -21,8 +21,15 @@ class FlatMap {
 
   constexpr FlatMap(std::initializer_list<ValueType> data);
 
-  [[nodiscard]] constexpr auto At(const Key& key) const -> std::optional<Value>;
+  [[nodiscard]] constexpr auto FirstValueForKey(const Key& key) const
+      -> std::optional<Value>;
+  [[nodiscard]] constexpr auto FirstKeyForValue(const Value& value) const
+      -> std::optional<Key>;
+  [[nodiscard]] constexpr auto Keys() const -> std::array<Key, Size>;
+  [[nodiscard]] constexpr auto Values() const -> std::array<Value, Size>;
 
+  // NOLINTNEXTLINE(readability-identifier-naming)
+  [[nodiscard]] constexpr auto size() const -> decltype(Size);
   // NOLINTNEXTLINE(readability-identifier-naming)
   constexpr auto begin() const -> ConstIterator;
   // NOLINTNEXTLINE(readability-identifier-naming)
@@ -57,13 +64,46 @@ constexpr FlatMap<Key, Value, Size>::FlatMap(
     : data_{*(data.begin() + Indices)...} {}
 
 template <class Key, class Value, std::size_t Size>
-constexpr auto FlatMap<Key, Value, Size>::At(const Key& key) const
+constexpr auto FlatMap<Key, Value, Size>::FirstValueForKey(const Key& key) const
     -> std::optional<Value> {
   const auto iterator = std::find_if(
       std::cbegin(data_), std::cend(data_),
       [&key](const auto& key_value) { return key_value.first == key; });
   if (iterator == std::cend(data_)) return {};
   return iterator->second;
+}
+
+template <class Key, class Value, std::size_t Size>
+constexpr auto FlatMap<Key, Value, Size>::FirstKeyForValue(
+    const Value& value) const -> std::optional<Key> {
+  const auto iterator = std::find_if(
+      std::cbegin(data_), std::cend(data_),
+      [&value](const auto& key_value) { return key_value.second == value; });
+  if (iterator == std::cend(data_)) return {};
+  return iterator->first;
+}
+
+template <class Key, class Value, std::size_t Size>
+constexpr auto FlatMap<Key, Value, Size>::Keys() const
+    -> std::array<Key, Size> {
+  std::array<Key, Size> keys{};
+  std::transform(std::cbegin(data_), std::cend(data_), std::begin(keys),
+                 [](const auto& key_value) { return key_value.first; });
+  return keys;
+}
+
+template <class Key, class Value, std::size_t Size>
+constexpr auto FlatMap<Key, Value, Size>::Values() const
+    -> std::array<Value, Size> {
+  std::array<Value, Size> values{};
+  std::transform(std::cbegin(data_), std::cend(data_), std::begin(values),
+                 [](const auto& key_value) { return key_value.second; });
+  return values;
+}
+
+template <class Key, class Value, std::size_t Size>
+constexpr auto FlatMap<Key, Value, Size>::size() const -> decltype(Size) {
+  return Size;
 }
 
 template <class Key, class Value, std::size_t Size>

--- a/util/flat_map/flat_map_test.cc
+++ b/util/flat_map/flat_map_test.cc
@@ -13,16 +13,41 @@
 
 namespace {
 
-TEST(FlatMap, At) {  // NOLINT
+TEST(FlatMap, KeyValueLookup) {  // NOLINT
   using FlatMap = util::flat_map::FlatMap<std::string_view, int32, 3>;
   constexpr FlatMap map{{"one", 1}, {"two", 2}, {"three", 3}};
   for (const auto& [key, value] : map) {
-    const auto retrieved_value = map.At(key);
+    const auto retrieved_value = map.FirstValueForKey(key);
     ASSERT_TRUE(retrieved_value.has_value());
     ASSERT_EQ(retrieved_value.value(), value);
+    const auto retrieved_key = map.FirstKeyForValue(value);
+    ASSERT_TRUE(retrieved_key.has_value());
+    ASSERT_EQ(retrieved_key.value(), key);
   }
-  const auto retrieved_value = map.At("zero");
+  const auto retrieved_value = map.FirstValueForKey("zero");
   ASSERT_FALSE(retrieved_value.has_value());
+  const auto retrieved_key = map.FirstKeyForValue(0);
+  ASSERT_FALSE(retrieved_key.has_value());
+}
+
+TEST(FlatMap, GetKeysValues) {  // NOLINT
+  using FlatMap = util::flat_map::FlatMap<std::string_view, int32, 3>;
+  constexpr FlatMap map{{"one", 1}, {"two", 2}, {"three", 3}};
+  constexpr std::array<std::string_view, 3> expected_keys{
+      {"one", "two", "three"}};
+  constexpr std::array<int32, 3> expected_values{{1, 2, 3}};
+  ASSERT_EQ(map.Keys(), expected_keys);
+  ASSERT_EQ(map.Values(), expected_values);
+}
+
+TEST(FlatMap, Size) {  // NOLINT
+  constexpr util::flat_map::FlatMap<std::string_view, int32, 0> zero{};
+  constexpr util::flat_map::FlatMap<std::string_view, int32, 1> one{{"one", 1}};
+  constexpr util::flat_map::FlatMap<std::string_view, int32, 2> two{{"one", 1},
+                                                                    {"two", 2}};
+  ASSERT_EQ(zero.size(), 0);
+  ASSERT_EQ(one.size(), 1);
+  ASSERT_EQ(two.size(), 2);
 }
 
 }  // namespace


### PR DESCRIPTION
Builds on #109 with extra features to be used in an upcoming PR.

* Support value-key lookup.
* Retrieve all keys or values from the map.
* Adds a `size()` method.
* Renames At to First* which is more descriptive of the method's behavior.