### PR TITLE
Spoor opt

### DIFF
--- a/spoor/instrumentation/BUILD
+++ b/spoor/instrumentation/BUILD
@@ -3,6 +3,29 @@
 
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_test")
 
+cc_binary(
+    name = "spoor_opt",
+    srcs = [
+        "instrumentation.h",
+        "spoor_opt.cc",
+    ],
+    copts = ["-Werror"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//spoor/instrumentation/config",
+        "//spoor/instrumentation/config:command_line_config",
+        "//spoor/instrumentation/inject_runtime",
+        "//spoor/instrumentation/support",
+        "//util/time:clock",
+        "@com_google_absl//absl/flags:config",
+        "@com_google_absl//absl/flags:flag",
+        "@com_google_absl//absl/flags:usage",
+        "@com_google_absl//absl/strings",
+        "@com_microsoft_gsl//:gsl",
+        "@llvm//11.0.0",
+    ],
+)
+
 # Hack to produce a shared library with the correct extension for each platform.
 
 SHARED_LIBRARY_NAME = "spoor_instrumentation"
@@ -19,8 +42,10 @@ SHARED_LIBRARY_LINKSHARED = True
 SHARED_LIBRARY_VISIBILITY = ["//visibility:public"]
 
 SHARED_LIBRARY_DEPS = [
-    "//spoor/instrumentation/config",
+    "//spoor/instrumentation/config:env_config",
     "//spoor/instrumentation/inject_runtime",
+    "//spoor/instrumentation/support",
+    "//util/time:clock",
     "@llvm//11.0.0",
 ]
 
@@ -40,6 +65,17 @@ cc_binary(
     linkshared = SHARED_LIBRARY_LINKSHARED,
     visibility = SHARED_LIBRARY_VISIBILITY,
     deps = SHARED_LIBRARY_DEPS,
+)
+
+sh_test(
+    name = "spoor_opt_test",
+    size = "small",
+    srcs = ["spoor_opt_test.sh"],
+    data = [
+        ":spoor_opt",
+        "//spoor/instrumentation/test_data",
+    ],
+    visibility = ["//visibility:private"],
 )
 
 sh_test(

--- a/spoor/instrumentation/config/BUILD
+++ b/spoor/instrumentation/config/BUILD
@@ -11,7 +11,39 @@ cc_library(
     visibility = ["//spoor/instrumentation:__pkg__"],
     deps = [
         "//util:numeric",
+        "//util/flags:optional",
+        "//util/flat_map",
+    ],
+)
+
+cc_library(
+    name = "env_config",
+    srcs = ["env_config.cc"],
+    hdrs = ["env_config.h"],
+    copts = ["-Werror"],
+    visibility = ["//spoor/instrumentation:__pkg__"],
+    deps = [
+        ":config",
+        "//util:numeric",
         "//util/env",
+    ],
+)
+
+cc_library(
+    name = "command_line_config",
+    srcs = ["command_line_config.cc"],
+    hdrs = ["command_line_config.h"],
+    copts = ["-Werror"],
+    visibility = ["//spoor/instrumentation:__pkg__"],
+    deps = [
+        ":config",
+        ":env_config",
+        "//util:numeric",
+        "//util/env",
+        "//util/flags:optional",
+        "@com_google_absl//absl/flags:flag",
+        "@com_google_absl//absl/flags:parse",
+        "@com_google_absl//absl/strings",
     ],
 )
 
@@ -23,8 +55,36 @@ cc_test(
     visibility = ["//visibility:private"],
     deps = [
         ":config",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "env_config_test",
+    size = "small",
+    srcs = ["env_config_test.cc"],
+    copts = ["-Werror"],
+    visibility = ["//visibility:private"],
+    deps = [
+        ":config",
+        ":env_config",
         "//util:numeric",
         "//util/flat_map",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "command_line_config_test",
+    size = "small",
+    srcs = ["command_line_config_test.cc"],
+    copts = ["-Werror"],
+    visibility = ["//visibility:private"],
+    deps = [
+        ":command_line_config",
+        ":config",
+        ":env_config",
+        "//util:numeric",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/spoor/instrumentation/config/command_line_config.cc
+++ b/spoor/instrumentation/config/command_line_config.cc
@@ -1,0 +1,138 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "spoor/instrumentation/config/command_line_config.h"
+
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "absl/flags/flag.h"
+#include "absl/flags/parse.h"
+#include "absl/strings/ascii.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_format.h"
+#include "absl/strings/str_join.h"
+#include "absl/strings/string_view.h"
+#include "spoor/instrumentation/config/config.h"
+#include "spoor/instrumentation/config/env_config.h"
+#include "util/env/env.h"
+#include "util/flags/optional.h"
+#include "util/numeric.h"
+
+ABSL_FLAG(  // NOLINT
+    bool, enable_runtime,
+    spoor::instrumentation::config::kEnableRuntimeDefaultValue,
+    spoor::instrumentation::config::kEnableRuntimeDoc);
+ABSL_FLAG(  // NOLINT
+    bool, force_binary_output,
+    spoor::instrumentation::config::kForceBinaryOutputDefaultValue,
+    spoor::instrumentation::config::kForceBinaryOutputDoc);
+ABSL_FLAG(  // NOLINT
+    util::flags::Optional<std::string>, function_allow_list_file,
+    util::flags::Optional<std::string>{
+        spoor::instrumentation::config::kFunctionAllowListFileDefaultValue},
+    spoor::instrumentation::config::kFunctionAllowListFileDoc);
+ABSL_FLAG(  // NOLINT
+    util::flags::Optional<std::string>, function_blocklist_file,
+    util::flags::Optional<std::string>{
+        spoor::instrumentation::config::kFunctionBlocklistFileDefaultValue},
+    spoor::instrumentation::config::kFunctionBlocklistFileDoc);
+ABSL_FLAG(  // NOLINT
+    bool, initialize_runtime,
+    spoor::instrumentation::config::kInitializeRuntimeDefaultValue,
+    spoor::instrumentation::config::kInitializeRuntimeDoc);
+ABSL_FLAG(  // NOLINT
+    bool, inject_instrumentation,
+    spoor::instrumentation::config::kInjectInstrumentationDefaultValue,
+    spoor::instrumentation::config::kInjectInstrumentationDoc);
+ABSL_FLAG(  // NOLINT
+    std::string, instrumentation_map_output_path,
+    std::string{spoor::instrumentation::config::
+                    kInstrumentedFunctionMapOutputPathDefaultValue},
+    spoor::instrumentation::config::kInstrumentedFunctionMapOutputPathDoc);
+ABSL_FLAG(  // NOLINT
+    uint32, min_instruction_threshold,
+    spoor::instrumentation::config::kMinInstructionThresholdDefaultValue,
+    spoor::instrumentation::config::kMinInstructionThresholdDoc);
+ABSL_FLAG(  // NOLINT
+    util::flags::Optional<std::string>, module_id,
+    util::flags::Optional<std::string>{
+        spoor::instrumentation::config::kModuleIdDefaultValue},
+    spoor::instrumentation::config::kModuleIdDoc);
+ABSL_FLAG(  // NOLINT
+    std::string, output_file,
+    std::string{spoor::instrumentation::config::kOutputFileDefaultValue},
+    spoor::instrumentation::config::kOutputFileDoc);
+ABSL_FLAG(  // NOLINT
+    spoor::instrumentation::config::OutputLanguage, output_language,
+    spoor::instrumentation::config::kOutputLanguageDefaultValue,
+    absl::StrFormat(
+        spoor::instrumentation::config::kOutputLanguageDoc,
+        absl::StrJoin(spoor::instrumentation::config::kOutputLanguages.Keys(),
+                      ", ")));
+
+namespace spoor::instrumentation::config {
+
+auto ConfigFromCommandLineOrEnv(const int argc, char** argv,
+                                const util::env::GetEnv& get_env)
+    -> std::pair<Config, std::vector<char*>> {
+  const auto env_config = ConfigFromEnv(get_env);
+  absl::SetFlag(&FLAGS_function_allow_list_file,
+                env_config.function_allow_list_file);
+  absl::SetFlag(&FLAGS_force_binary_output, env_config.force_binary_output);
+  absl::SetFlag(&FLAGS_function_blocklist_file,
+                env_config.function_blocklist_file);
+  absl::SetFlag(&FLAGS_enable_runtime, env_config.enable_runtime);
+  absl::SetFlag(&FLAGS_initialize_runtime, env_config.initialize_runtime);
+  absl::SetFlag(&FLAGS_inject_instrumentation,
+                env_config.inject_instrumentation);
+  absl::SetFlag(&FLAGS_instrumentation_map_output_path,
+                env_config.instrumented_function_map_output_path);
+  absl::SetFlag(&FLAGS_min_instruction_threshold,
+                env_config.min_instruction_threshold);
+  absl::SetFlag(&FLAGS_module_id, env_config.module_id);
+  absl::SetFlag(&FLAGS_output_file, env_config.output_file);
+  absl::SetFlag(&FLAGS_output_language, env_config.output_language);
+  auto positional_args = absl::ParseCommandLine(argc, argv);
+  Config config{
+      .enable_runtime = absl::GetFlag(FLAGS_enable_runtime),
+      .force_binary_output = absl::GetFlag(FLAGS_force_binary_output),
+      .function_allow_list_file =
+          absl::GetFlag(FLAGS_function_allow_list_file).StdOptional(),
+      .function_blocklist_file =
+          absl::GetFlag(FLAGS_function_blocklist_file).StdOptional(),
+      .initialize_runtime = absl::GetFlag(FLAGS_initialize_runtime),
+      .inject_instrumentation = absl::GetFlag(FLAGS_inject_instrumentation),
+      .instrumented_function_map_output_path =
+          absl::GetFlag(FLAGS_instrumentation_map_output_path),
+      .min_instruction_threshold =
+          absl::GetFlag(FLAGS_min_instruction_threshold),
+      .module_id = absl::GetFlag(FLAGS_module_id).StdOptional(),
+      .output_file = absl::GetFlag(FLAGS_output_file),
+      .output_language = absl::GetFlag(FLAGS_output_language)};
+  return std::make_pair(std::move(config), std::move(positional_args));
+}
+
+auto AbslParseFlag(const absl::string_view user_key, OutputLanguage* language,
+                   std::string* error) -> bool {
+  std::string key{user_key};
+  absl::AsciiStrToLower(&key);
+  const auto option = kOutputLanguages.FirstValueForKey(key);
+  if (option.has_value()) {
+    *language = option.value();
+    return true;
+  }
+  *error = absl::StrFormat("Unknown language '%s'. Options: %s.", user_key,
+                           absl::StrJoin(kOutputLanguages.Keys(), ", "));
+  return false;
+}
+
+auto AbslUnparseFlag(const OutputLanguage language) -> std::string {
+  const auto fallback = absl::StrCat(language);
+  const auto value =
+      kOutputLanguages.FirstKeyForValue(language).value_or(fallback);
+  return std::string{value};
+}
+
+}  // namespace spoor::instrumentation::config

--- a/spoor/instrumentation/config/command_line_config.h
+++ b/spoor/instrumentation/config/command_line_config.h
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <cstdlib>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "absl/flags/declare.h"
+#include "absl/flags/parse.h"
+#include "absl/strings/string_view.h"
+#include "spoor/instrumentation/config/config.h"
+#include "util/env/env.h"
+#include "util/flags/optional.h"
+#include "util/numeric.h"
+
+ABSL_DECLARE_FLAG(bool, enable_runtime);       // NOLINT
+ABSL_DECLARE_FLAG(bool, force_binary_output);  // NOLINT
+ABSL_DECLARE_FLAG(                             // NOLINT
+    util::flags::Optional<std::string>, function_allow_list_file);
+ABSL_DECLARE_FLAG(  // NOLINT
+    util::flags::Optional<std::string>, function_blocklist_file);
+ABSL_DECLARE_FLAG(bool, initialize_runtime);                       // NOLINT
+ABSL_DECLARE_FLAG(bool, inject_instrumentation);                   // NOLINT
+ABSL_DECLARE_FLAG(std::string, instrumentation_map_output_path);   // NOLINT
+ABSL_DECLARE_FLAG(uint32, min_instruction_threshold);              // NOLINT
+ABSL_DECLARE_FLAG(util::flags::Optional<std::string>, module_id);  // NOLINT
+ABSL_DECLARE_FLAG(std::string, output_file);                       // NOLINT
+ABSL_DECLARE_FLAG(                                                 // NOLINT
+    spoor::instrumentation::config::OutputLanguage, output_language);
+
+namespace spoor::instrumentation::config {
+auto ConfigFromCommandLineOrEnv(int argc, char** argv,
+                                const util::env::GetEnv& get_env = std::getenv)
+    -> std::pair<Config, std::vector<char*>>;
+
+auto AbslParseFlag(absl::string_view user_key, OutputLanguage* language,
+                   std::string* error) -> bool;
+auto AbslUnparseFlag(OutputLanguage language) -> std::string;
+
+}  // namespace spoor::instrumentation::config

--- a/spoor/instrumentation/config/command_line_config_test.cc
+++ b/spoor/instrumentation/config/command_line_config_test.cc
@@ -1,0 +1,246 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "command_line_config.h"
+
+#include <algorithm>
+#include <cstddef>
+#include <iterator>
+#include <string_view>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "spoor/instrumentation/config/config.h"
+#include "spoor/instrumentation/config/env_config.h"
+#include "util/flat_map/flat_map.h"
+
+namespace {
+
+using spoor::instrumentation::config::Config;
+using spoor::instrumentation::config::ConfigFromCommandLineOrEnv;
+using spoor::instrumentation::config::kEnableRuntimeKey;
+using spoor::instrumentation::config::kForceBinaryOutputKey;
+using spoor::instrumentation::config::kFunctionAllowListFileKey;
+using spoor::instrumentation::config::kFunctionBlocklistFileKey;
+using spoor::instrumentation::config::kInitializeRuntimeKey;
+using spoor::instrumentation::config::kInjectInstrumentationKey;
+using spoor::instrumentation::config::kInstrumentedFunctionMapOutputPathKey;
+using spoor::instrumentation::config::kMinInstructionThresholdKey;
+using spoor::instrumentation::config::kModuleIdKey;
+using spoor::instrumentation::config::kOutputFileKey;
+using spoor::instrumentation::config::kOutputLanguageKey;
+using spoor::instrumentation::config::kOutputLanguages;
+using spoor::instrumentation::config::OutputLanguage;
+
+auto MakeArgv(const std::vector<std::string_view>& args) -> std::vector<char*> {
+  std::vector<char*> argv{};
+  argv.reserve(args.size());
+  std::transform(
+      std::begin(args), std::end(args), std::back_inserter(argv),
+      // `absl::ParseCommandLine` requires a (non-const) char** as an argument.
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+      [](auto string_view) { return const_cast<char*>(string_view.data()); });
+  return argv;
+}
+
+TEST(CommandLineConfig, ParsesCommandLine) {  // NOLINT
+  const auto get_env = [](const char* /*unused*/) -> const char* {
+    return nullptr;
+  };
+  const Config expected_config{
+      .enable_runtime = false,
+      .force_binary_output = true,
+      .function_allow_list_file = "/path/to/allow_list.txt",
+      .function_blocklist_file = "/path/to/blocklist.txt",
+      .initialize_runtime = false,
+      .inject_instrumentation = false,
+      .instrumented_function_map_output_path = "/path/to/output/",
+      .min_instruction_threshold = 42,
+      .module_id = "ModuleId",
+      .output_file = "/path/to/output_file.ll",
+      .output_language = OutputLanguage::kIr};
+  auto argv = MakeArgv(
+      {"spoor_opt", "--enable_runtime=false",
+       "--function_allow_list_file=/path/to/allow_list.txt",
+       "--function_blocklist_file=/path/to/blocklist.txt",
+       "--initialize_runtime=false", "--inject_instrumentation=false",
+       "--instrumentation_map_output_path=/path/to/output/",
+       "--min_instruction_threshold=42", "--module_id=ModuleId",
+       "--output_file=/path/to/output_file.ll", "--output_language=ir"});
+  const auto expected_positional_args = MakeArgv({argv.front()});
+  const auto [config, positional_args] =
+      ConfigFromCommandLineOrEnv(argv.size(), argv.data(), get_env);
+  ASSERT_EQ(config, expected_config);
+  ASSERT_EQ(positional_args, expected_positional_args);
+}
+
+TEST(CommandLineConfig, UsesDefaultValueWhenNotSpecified) {  // NOLINT
+  const auto get_env = [](const char* /*unused*/) -> const char* {
+    return nullptr;
+  };
+  const Config expected_config{.enable_runtime = true,
+                               .force_binary_output = false,
+                               .function_allow_list_file = {},
+                               .function_blocklist_file = {},
+                               .initialize_runtime = true,
+                               .inject_instrumentation = true,
+                               .instrumented_function_map_output_path = ".",
+                               .min_instruction_threshold = 0,
+                               .module_id = {},
+                               .output_file = "-",
+                               .output_language = OutputLanguage::kBitcode};
+  auto argv = MakeArgv({"spoor_opt"});
+  const auto [config, positional_args] =
+      ConfigFromCommandLineOrEnv(argv.size(), argv.data(), get_env);
+  ASSERT_EQ(config, expected_config);
+  ASSERT_EQ(positional_args, argv);
+}
+
+TEST(CommandLineConfig, UsesEnvironmentValueWhenNotSpecified) {  // NOLINT
+  const auto get_env = [](const char* key) {
+    constexpr util::flat_map::FlatMap<std::string_view, std::string_view, 11>
+        environment{{kEnableRuntimeKey, "false"},
+                    {kForceBinaryOutputKey, "true"},
+                    {kFunctionAllowListFileKey, "/path/to/allow_list.txt"},
+                    {kFunctionBlocklistFileKey, "/path/to/blocklist.txt"},
+                    {kInitializeRuntimeKey, "false"},
+                    {kInjectInstrumentationKey, "false"},
+                    {kInstrumentedFunctionMapOutputPathKey, "/path/to/output/"},
+                    {kMinInstructionThresholdKey, "42"},
+                    {kModuleIdKey, "ModuleId"},
+                    {kOutputFileKey, "/path/to/output_file.ll"},
+                    {kOutputLanguageKey, "ir"}};
+    return environment.FirstValueForKey(key).value_or(nullptr).data();
+  };
+  const Config expected_config{
+      .enable_runtime = false,
+      .force_binary_output = true,
+      .function_allow_list_file = "/path/to/allow_list.txt",
+      .function_blocklist_file = "/path/to/blocklist.txt",
+      .initialize_runtime = false,
+      .inject_instrumentation = false,
+      .instrumented_function_map_output_path = "/path/to/output/",
+      .min_instruction_threshold = 42,
+      .module_id = "ModuleId",
+      .output_file = "/path/to/output_file.ll",
+      .output_language = OutputLanguage::kIr};
+  auto argv = MakeArgv({"spoor_opt"});
+  const auto [config, positional_args] =
+      ConfigFromCommandLineOrEnv(argv.size(), argv.data(), get_env);
+  ASSERT_EQ(config, expected_config);
+  ASSERT_EQ(positional_args, argv);
+}
+
+TEST(CommandLineConfig, OverridesEnvironment) {  // NOLINT
+  const auto get_env = [](const char* key) -> const char* {
+    constexpr util::flat_map::FlatMap<std::string_view, std::string_view, 11>
+        environment{
+            {kEnableRuntimeKey, "true"},
+            {kForceBinaryOutputKey, "false"},
+            {kFunctionAllowListFileKey, "/path/to/other/allow_list.txt"},
+            {kFunctionBlocklistFileKey, "/path/to/other/blocklist.txt"},
+            {kInitializeRuntimeKey, "true"},
+            {kInjectInstrumentationKey, "true"},
+            {kInstrumentedFunctionMapOutputPathKey, "/path/to/other/output/"},
+            {kMinInstructionThresholdKey, "43"},
+            {kModuleIdKey, "OtherModuleId"},
+            {kOutputFileKey, "/path/to/other/output_file.ll"},
+            {kOutputLanguageKey, "bitcode"}};
+    return environment.FirstValueForKey(key).value_or(nullptr).data();
+  };
+  const Config expected_config{
+      .enable_runtime = false,
+      .force_binary_output = false,
+      .function_allow_list_file = "/path/to/allow_list.txt",
+      .function_blocklist_file = "/path/to/blocklist.txt",
+      .initialize_runtime = false,
+      .inject_instrumentation = false,
+      .instrumented_function_map_output_path = "/path/to/output/",
+      .min_instruction_threshold = 42,
+      .module_id = "ModuleId",
+      .output_file = "/path/to/output_file.ll",
+      .output_language = OutputLanguage::kIr};
+  auto argv = MakeArgv(
+      {"spoor_opt", "--enable_runtime=false",
+       "--function_allow_list_file=/path/to/allow_list.txt",
+       "--function_blocklist_file=/path/to/blocklist.txt",
+       "--initialize_runtime=false", "--inject_instrumentation=false",
+       "--instrumentation_map_output_path=/path/to/output/",
+       "--min_instruction_threshold=42", "--module_id=ModuleId",
+       "--output_file=/path/to/output_file.ll", "--output_language=ir"});
+  const auto expected_positional_args = MakeArgv({argv.front()});
+  const auto [config, positional_args] =
+      ConfigFromCommandLineOrEnv(argv.size(), argv.data(), get_env);
+  ASSERT_EQ(config, expected_config);
+  ASSERT_EQ(positional_args, expected_positional_args);
+}
+
+TEST(CommandLineConfig, PositionalArguments) {  // NOLINT
+  const auto get_env = [](const char* /*unused*/) -> const char* {
+    return nullptr;
+  };
+  auto argv = MakeArgv({"spoor_opt", "--output_language=ir", "-", "--",
+                        "--enable_runtime=true"});
+  auto expected_positional_args =
+      MakeArgv({"spoor_opt", "-", "--enable_runtime=true"});
+  const auto [_, positional_args] =
+      ConfigFromCommandLineOrEnv(argv.size(), argv.data(), get_env);
+  ASSERT_EQ(positional_args, expected_positional_args);
+}
+
+TEST(CommandLineConfig, Version) {  // NOLINT
+  const auto get_env = [](const char* /*unused*/) -> const char* {
+    return nullptr;
+  };
+  auto argv = MakeArgv({"spoor_opt", "--version"});
+  EXPECT_EXIT(  // NOLINT
+      ConfigFromCommandLineOrEnv(argv.size(), argv.data(), get_env),
+      testing::ExitedWithCode(0), "");
+}
+
+TEST(CommandLineConfig, Help) {  // NOLINT
+  const auto get_env = [](const char* /*unused*/) -> const char* {
+    return nullptr;
+  };
+  auto argv = MakeArgv({"spoor_opt", "--help"});
+  EXPECT_DEATH(  // NOLINT
+      ConfigFromCommandLineOrEnv(argv.size(), argv.data(), get_env), "");
+}
+
+TEST(CommandLineConfig, UnknownFlag) {  // NOLINT
+  const auto get_env = [](const char* /*unused*/) -> const char* {
+    return nullptr;
+  };
+  auto argv = MakeArgv({"spoor_opt", "--unknown_flag"});
+  EXPECT_DEATH(  // NOLINT
+      ConfigFromCommandLineOrEnv(argv.size(), argv.data(), get_env),
+      "Unknown command line flag 'unknown_flag'");
+}
+
+TEST(CommandLineconfig, AbslParseFlag) {  // NOLINT
+  for (const auto& [key, value] : kOutputLanguages) {
+    OutputLanguage language{};
+    std::string error{};
+    const auto success = AbslParseFlag(key, &language, &error);
+    ASSERT_TRUE(success);
+    ASSERT_TRUE(error.empty());
+    ASSERT_EQ(language, value);
+  }
+
+  OutputLanguage language{};
+  std::string error{};
+  const auto success = AbslParseFlag("invalid", &language, &error);
+  ASSERT_FALSE(success);
+  ASSERT_EQ(error, "Unknown language 'invalid'. Options: bitcode, ir.");
+}
+
+TEST(CommandLineconfig, AbslUnparseFlag) {  // NOLINT
+  for (const auto& [key, value] : kOutputLanguages) {
+    const auto result = AbslUnparseFlag(value);
+    ASSERT_EQ(result, key);
+  }
+  const auto result = AbslUnparseFlag(static_cast<OutputLanguage>(100));
+  ASSERT_EQ(result, "100");
+}
+
+}  // namespace

--- a/spoor/instrumentation/config/config.cc
+++ b/spoor/instrumentation/config/config.cc
@@ -3,44 +3,30 @@
 
 #include "spoor/instrumentation/config/config.h"
 
-#include "util/env/env.h"
-
 namespace spoor::instrumentation::config {
 
-using util::env::GetEnvOrDefault;
-
-auto Config::FromEnv(const util::env::GetEnv& get_env) -> Config {
-  return {
-      .instrumented_function_map_output_path = GetEnvOrDefault(
-          kInstrumentedFunctionMapOutputPathKey.data(),
-          std::string{kInstrumentedFunctionMapOutputPathDefaultValue}, get_env),
-      .initialize_runtime =
-          GetEnvOrDefault(kInitializeRuntimeKey.data(),
-                          kInitializeRuntimeDefaultValue, get_env),
-      .enable_runtime = GetEnvOrDefault(kEnableRuntimeKey.data(),
-                                        kEnableRuntimeDefaultValue, get_env),
-      .min_instruction_threshold =
-          GetEnvOrDefault(kMinInstructionThresholdKey.data(),
-                          kMinInstructionThresholdDefaultValue, get_env),
-      .module_id = GetEnvOrDefault(kModuleIdKey.data(), kModuleIdDefaultValue,
-                                   true, get_env),
-      .function_allow_list_file =
-          GetEnvOrDefault(kFunctionAllowListFileKey.data(),
-                          kFunctionAllowListFileDefaultValue, true, get_env),
-      .function_blocklist_file =
-          GetEnvOrDefault(kFunctionBlocklistFileKey.data(),
-                          kFunctionBlocklistFileDefaultValue, true, get_env)};
+auto operator==(const Config& lhs, const Config& rhs) -> bool {
+  return lhs.function_allow_list_file == rhs.function_allow_list_file &&
+         lhs.function_blocklist_file == rhs.function_blocklist_file &&
+         lhs.enable_runtime == rhs.enable_runtime &&
+         lhs.initialize_runtime == rhs.initialize_runtime &&
+         lhs.inject_instrumentation == rhs.inject_instrumentation &&
+         lhs.instrumented_function_map_output_path ==
+             rhs.instrumented_function_map_output_path &&
+         lhs.min_instruction_threshold == rhs.min_instruction_threshold &&
+         lhs.module_id == rhs.module_id && lhs.output_file == rhs.output_file &&
+         lhs.output_language == rhs.output_language;
 }
 
-auto operator==(const Config& lhs, const Config& rhs) -> bool {
-  return lhs.instrumented_function_map_output_path ==
-             rhs.instrumented_function_map_output_path &&
-         lhs.initialize_runtime == rhs.initialize_runtime &&
-         lhs.enable_runtime == rhs.enable_runtime &&
-         lhs.min_instruction_threshold == rhs.min_instruction_threshold &&
-         lhs.module_id == rhs.module_id &&
-         lhs.function_allow_list_file == rhs.function_allow_list_file &&
-         lhs.function_blocklist_file == rhs.function_blocklist_file;
+auto BinaryOutput(const OutputLanguage output_language) -> bool {
+  switch (output_language) {
+    case OutputLanguage::kBitcode: {
+      return true;
+    }
+    case OutputLanguage::kIr: {
+      return false;
+    }
+  }
 }
 
 }  // namespace spoor::instrumentation::config

--- a/spoor/instrumentation/config/config.h
+++ b/spoor/instrumentation/config/config.h
@@ -3,51 +3,95 @@
 
 #pragma once
 
-#include <cstdlib>
 #include <optional>
 #include <string>
 #include <string_view>
 
-#include "util/env/env.h"
+#include "util/flat_map/flat_map.h"
 #include "util/numeric.h"
 
 namespace spoor::instrumentation::config {
 
-constexpr std::string_view kInstrumentedFunctionMapOutputPathKey{
-    "SPOOR_INSTRUMENTATION_INSTRUMENTED_FUNCTION_MAP_OUTPUT_PATH"};
-constexpr std::string_view kInstrumentedFunctionMapOutputPathDefaultValue{"."};
-constexpr std::string_view kInitializeRuntimeKey{
-    "SPOOR_INSTRUMENTATION_RUNTIME_INITIALIZE_RUNTIME"};
-constexpr bool kInitializeRuntimeDefaultValue{true};
-constexpr std::string_view kEnableRuntimeKey{
-    "SPOOR_INSTRUMENTATION_RUNTIME_ENABLE_RUNTIME"};
+enum class OutputLanguage {
+  kBitcode,
+  kIr,
+};
+
+struct Config {
+  // Alphabetized to match the order printed in --help.
+  bool enable_runtime;
+  bool force_binary_output;
+  std::optional<std::string> function_allow_list_file;
+  std::optional<std::string> function_blocklist_file;
+  bool initialize_runtime;
+  bool inject_instrumentation;
+  std::string instrumented_function_map_output_path;
+  uint32 min_instruction_threshold;
+  std::optional<std::string> module_id;
+  std::string output_file;
+  OutputLanguage output_language;
+};
+
+constexpr util::flat_map::FlatMap<std::string_view, OutputLanguage, 2>
+    kOutputLanguages{{"bitcode", OutputLanguage::kBitcode},
+                     {"ir", OutputLanguage::kIr}};
+
+constexpr std::string_view kEnableRuntimeDoc{
+    "Automatically enable Spoor's runtime."};
 constexpr bool kEnableRuntimeDefaultValue{true};
-constexpr std::string_view kMinInstructionThresholdKey{
-    "SPOOR_INSTRUMENTATION_MIN_INSTRUCTION_THRESHOLD"};
-constexpr uint32 kMinInstructionThresholdDefaultValue{0};
-constexpr std::string_view kModuleIdKey{"SPOOR_INSTRUMENTATION_MODULE_ID"};
-// NOLINTNEXTLINE(fuchsia-statically-constructed-objects)
-const std::optional<std::string> kModuleIdDefaultValue{};
-constexpr std::string_view kFunctionAllowListFileKey{
-    "SPOOR_INSTRUMENTATION_FUNCTION_ALLOW_LIST_FILE"};
+
+constexpr std::string_view kForceBinaryOutputDoc{
+    "Force printing binary data to the console."};
+constexpr bool kForceBinaryOutputDefaultValue{false};
+
+constexpr std::string_view kFunctionAllowListFileDoc{
+    "File path to the function allow list."};
+// This statically-constructed object is safe because its value is the type's
+// default.
 // NOLINTNEXTLINE(fuchsia-statically-constructed-objects)
 const std::optional<std::string> kFunctionAllowListFileDefaultValue{};
-constexpr std::string_view kFunctionBlocklistFileKey{
-    "SPOOR_INSTRUMENTATION_FUNCTION_BLOCKLIST_FILE"};
+
+constexpr std::string_view kFunctionBlocklistFileDoc{
+    "File path to the function blocklist."};
+// This statically-constructed object is safe because its value is the type's
+// default.
 // NOLINTNEXTLINE(fuchsia-statically-constructed-objects)
 const std::optional<std::string> kFunctionBlocklistFileDefaultValue{};
 
-struct Config {
-  static auto FromEnv(const util::env::GetEnv& get_env = std::getenv) -> Config;
+constexpr std::string_view kInitializeRuntimeDoc{
+    "Automatically initialize Spoor's runtime."};
+constexpr bool kInitializeRuntimeDefaultValue{true};
 
-  std::string instrumented_function_map_output_path;
-  bool initialize_runtime;
-  bool enable_runtime;
-  uint32 min_instruction_threshold;
-  std::optional<std::string> module_id;
-  std::optional<std::string> function_allow_list_file;
-  std::optional<std::string> function_blocklist_file;
-};
+constexpr std::string_view kInjectInstrumentationDoc{
+    "Inject Spoor instrumentation."};
+constexpr auto kInjectInstrumentationDefaultValue{true};
+
+constexpr std::string_view kInstrumentedFunctionMapOutputPathDoc{
+    "Spoor function map output file."};
+constexpr std::string_view kInstrumentedFunctionMapOutputPathDefaultValue{"."};
+
+constexpr std::string_view kMinInstructionThresholdDoc{
+    "Minimum number of LLVM IR instructions required to instrument a "
+    "function."};
+constexpr uint32 kMinInstructionThresholdDefaultValue{0};
+
+constexpr std::string_view kModuleIdDoc{"Override the LLVM module's ID."};
+// This statically-constructed object is safe because its value is the type's
+// default.
+// NOLINTNEXTLINE(fuchsia-statically-constructed-objects)
+const std::optional<std::string> kModuleIdDefaultValue{};
+
+constexpr std::string_view kOutputFileDoc{"Output file."};
+// This statically-constructed object is safe because its value is the type's
+// default.
+// NOLINTNEXTLINE(fuchsia-statically-constructed-objects)
+const std::string_view kOutputFileDefaultValue{"-"};
+
+constexpr std::string_view kOutputLanguageDoc{
+    "Language in which to output the transformed code. Options: %s."};
+constexpr auto kOutputLanguageDefaultValue{OutputLanguage::kBitcode};
+
+auto BinaryOutput(OutputLanguage output_language) -> bool;
 
 auto operator==(const Config& lhs, const Config& rhs) -> bool;
 

--- a/spoor/instrumentation/config/config_test.cc
+++ b/spoor/instrumentation/config/config_test.cc
@@ -3,80 +3,57 @@
 
 #include "spoor/instrumentation/config/config.h"
 
-#include <limits>
-
 #include "gtest/gtest.h"
-#include "util/flat_map/flat_map.h"
-#include "util/numeric.h"
 
 namespace {
 
 using spoor::instrumentation::config::Config;
-using spoor::instrumentation::config::kEnableRuntimeKey;
-using spoor::instrumentation::config::kFunctionAllowListFileKey;
-using spoor::instrumentation::config::kFunctionBlocklistFileKey;
-using spoor::instrumentation::config::kInitializeRuntimeKey;
-using spoor::instrumentation::config::kInstrumentedFunctionMapOutputPathKey;
-using spoor::instrumentation::config::kMinInstructionThresholdKey;
-using spoor::instrumentation::config::kModuleIdKey;
+using spoor::instrumentation::config::OutputLanguage;
 
-TEST(Config, GetsUserProvidedValue) {  // NOLINT
-  const auto get_env = [](const char* key) {
-    constexpr util::flat_map::FlatMap<std::string_view, std::string_view, 7>
-        environment{{kInstrumentedFunctionMapOutputPathKey, "/path/to/output/"},
-                    {kInitializeRuntimeKey, "false"},
-                    {kEnableRuntimeKey, "false"},
-                    {kMinInstructionThresholdKey, "42"},
-                    {kModuleIdKey, "ModuleId"},
-                    {kFunctionAllowListFileKey, "/path/to/allow_list.txt"},
-                    {kFunctionBlocklistFileKey, "/path/to/blocklist.txt"}};
-    return environment.FirstValueForKey(key).value_or(nullptr).data();
-  };
-  const Config expected_options{
-      .instrumented_function_map_output_path = "/path/to/output/",
-      .initialize_runtime = false,
+TEST(Config, ConfigEquality) {  // NOLINT
+  const Config config_a{
       .enable_runtime = false,
+      .force_binary_output = true,
+      .function_allow_list_file = "/path/to/allow_list.txt",
+      .function_blocklist_file = "/path/to/blocklist.txt",
+      .initialize_runtime = false,
+      .inject_instrumentation = false,
+      .instrumented_function_map_output_path = "/path/to/output/",
       .min_instruction_threshold = 42,
       .module_id = "ModuleId",
+      .output_file = "/path/to/output_file.ll",
+      .output_language = OutputLanguage::kIr};
+  const Config config_b{
+      .enable_runtime = false,
+      .force_binary_output = true,
       .function_allow_list_file = "/path/to/allow_list.txt",
-      .function_blocklist_file = "/path/to/blocklist.txt"};
-  ASSERT_EQ(Config::FromEnv(get_env), expected_options);
+      .function_blocklist_file = "/path/to/blocklist.txt",
+      .initialize_runtime = false,
+      .inject_instrumentation = false,
+      .instrumented_function_map_output_path = "/path/to/output/",
+      .min_instruction_threshold = 42,
+      .module_id = "ModuleId",
+      .output_file = "/path/to/output_file.ll",
+      .output_language = OutputLanguage::kIr};
+  const Config config_c{.enable_runtime = true,
+                        .force_binary_output = false,
+                        .function_allow_list_file = "",
+                        .function_blocklist_file = "",
+                        .initialize_runtime = true,
+                        .inject_instrumentation = true,
+                        .instrumented_function_map_output_path = "",
+                        .min_instruction_threshold = 0,
+                        .module_id = "",
+                        .output_file = "",
+                        .output_language = OutputLanguage::kBitcode};
+  ASSERT_EQ(config_a, config_b);
+  ASSERT_NE(config_a, config_c);
+  ASSERT_NE(config_b, config_c);
 }
 
-TEST(Config, UsesDefaultValueWhenNotSpecified) {  // NOLINT
-  const auto get_env = [](const char* /*unused*/) -> const char* {
-    return nullptr;
-  };
-  const Config expected_options{.instrumented_function_map_output_path = ".",
-                                .initialize_runtime = true,
-                                .enable_runtime = true,
-                                .min_instruction_threshold = 0,
-                                .module_id = {},
-                                .function_allow_list_file = {},
-                                .function_blocklist_file = {}};
-  ASSERT_EQ(Config::FromEnv(get_env), expected_options);
-}
-
-TEST(Config, UsesDefaultValueForEmptyStringValues) {  // NOLINT
-  const auto get_env = [](const char* key) {
-    constexpr util::flat_map::FlatMap<std::string_view, std::string_view, 7>
-        environment{{kInstrumentedFunctionMapOutputPathKey, ""},
-                    {kInitializeRuntimeKey, ""},
-                    {kEnableRuntimeKey, ""},
-                    {kMinInstructionThresholdKey, ""},
-                    {kModuleIdKey, ""},
-                    {kFunctionAllowListFileKey, ""},
-                    {kFunctionBlocklistFileKey, ""}};
-    return environment.FirstValueForKey(key).value_or(nullptr).data();
-  };
-  const Config expected_options{.instrumented_function_map_output_path = "",
-                                .initialize_runtime = true,
-                                .enable_runtime = true,
-                                .min_instruction_threshold = 0,
-                                .module_id = {},
-                                .function_allow_list_file = {},
-                                .function_blocklist_file = {}};
-  ASSERT_EQ(Config::FromEnv(get_env), expected_options);
+TEST(Config, OutputLanguageBinaryOutput) {  // NOLINT
+  ASSERT_TRUE(BinaryOutput(OutputLanguage::kBitcode));
+  ASSERT_FALSE(BinaryOutput(OutputLanguage::kIr));
 }
 
 }  // namespace

--- a/spoor/instrumentation/config/env_config.cc
+++ b/spoor/instrumentation/config/env_config.cc
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "spoor/instrumentation/config/env_config.h"
+
+#include <string>
+
+#include "spoor/instrumentation/config/config.h"
+#include "util/env/env.h"
+
+namespace spoor::instrumentation::config {
+
+using util::env::GetEnvOrDefault;
+
+auto ConfigFromEnv(const util::env::GetEnv& get_env) -> Config {
+  return {
+      .enable_runtime = GetEnvOrDefault(kEnableRuntimeKey.data(),
+                                        kEnableRuntimeDefaultValue, get_env),
+      .force_binary_output =
+          GetEnvOrDefault(kForceBinaryOutputKey.data(),
+                          kForceBinaryOutputDefaultValue, get_env),
+      .function_allow_list_file =
+          GetEnvOrDefault(kFunctionAllowListFileKey.data(),
+                          kFunctionAllowListFileDefaultValue, true, get_env),
+      .function_blocklist_file =
+          GetEnvOrDefault(kFunctionBlocklistFileKey.data(),
+                          kFunctionBlocklistFileDefaultValue, true, get_env),
+      .initialize_runtime =
+          GetEnvOrDefault(kInitializeRuntimeKey.data(),
+                          kInitializeRuntimeDefaultValue, get_env),
+      .inject_instrumentation =
+          GetEnvOrDefault(kInjectInstrumentationKey.data(),
+                          kInjectInstrumentationDefaultValue, get_env),
+      .instrumented_function_map_output_path = GetEnvOrDefault(
+          kInstrumentedFunctionMapOutputPathKey.data(),
+          std::string{kInstrumentedFunctionMapOutputPathDefaultValue}, get_env),
+      .min_instruction_threshold =
+          GetEnvOrDefault(kMinInstructionThresholdKey.data(),
+                          kMinInstructionThresholdDefaultValue, get_env),
+      .module_id = GetEnvOrDefault(kModuleIdKey.data(), kModuleIdDefaultValue,
+                                   true, get_env),
+      .output_file = GetEnvOrDefault(
+          kOutputFileKey.data(), std::string{kOutputFileDefaultValue}, get_env),
+      .output_language = GetEnvOrDefault(kOutputLanguageKey.data(),
+                                         kOutputLanguageDefaultValue,
+                                         kOutputLanguages, true, get_env)};
+}
+
+}  // namespace spoor::instrumentation::config

--- a/spoor/instrumentation/config/env_config.h
+++ b/spoor/instrumentation/config/env_config.h
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <cstdlib>
+
+#include "spoor/instrumentation/config/config.h"
+#include "util/env/env.h"
+
+namespace spoor::instrumentation::config {
+
+constexpr std::string_view kEnableRuntimeKey{
+    "SPOOR_INSTRUMENTATION_RUNTIME_ENABLE_RUNTIME"};
+constexpr std::string_view kForceBinaryOutputKey{
+    "SPOOR_INSTRUMENTATION_FORCE_BINARY_OUTPUT"};
+constexpr std::string_view kFunctionAllowListFileKey{
+    "SPOOR_INSTRUMENTATION_FUNCTION_ALLOW_LIST_FILE"};
+constexpr std::string_view kFunctionBlocklistFileKey{
+    "SPOOR_INSTRUMENTATION_FUNCTION_BLOCKLIST_FILE"};
+constexpr std::string_view kInitializeRuntimeKey{
+    "SPOOR_INSTRUMENTATION_RUNTIME_INITIALIZE_RUNTIME"};
+constexpr std::string_view kInjectInstrumentationKey{
+    "SPOOR_INSTRUMENTATION_INJECT_INSTRUMENTATION"};
+constexpr std::string_view kInstrumentedFunctionMapOutputPathKey{
+    "SPOOR_INSTRUMENTATION_INSTRUMENTED_FUNCTION_MAP_OUTPUT_PATH"};
+constexpr std::string_view kMinInstructionThresholdKey{
+    "SPOOR_INSTRUMENTATION_MIN_INSTRUCTION_THRESHOLD"};
+constexpr std::string_view kModuleIdKey{"SPOOR_INSTRUMENTATION_MODULE_ID"};
+constexpr std::string_view kOutputFileKey{"SPOOR_INSTRUMENTATION_OUTPUT_FILE"};
+constexpr std::string_view kOutputLanguageKey{
+    "SPOOR_INSTRUMENTATION_OUTPUT_LANGUAGE"};
+
+auto ConfigFromEnv(const util::env::GetEnv& get_env = std::getenv) -> Config;
+
+}  // namespace spoor::instrumentation::config

--- a/spoor/instrumentation/config/env_config_test.cc
+++ b/spoor/instrumentation/config/env_config_test.cc
@@ -1,0 +1,109 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "spoor/instrumentation/config/env_config.h"
+
+#include <string_view>
+
+#include "gtest/gtest.h"
+#include "spoor/instrumentation/config/config.h"
+#include "util/flat_map/flat_map.h"
+#include "util/numeric.h"
+
+namespace {
+
+using spoor::instrumentation::config::Config;
+using spoor::instrumentation::config::ConfigFromEnv;
+using spoor::instrumentation::config::kEnableRuntimeKey;
+using spoor::instrumentation::config::kForceBinaryOutputKey;
+using spoor::instrumentation::config::kFunctionAllowListFileKey;
+using spoor::instrumentation::config::kFunctionBlocklistFileKey;
+using spoor::instrumentation::config::kInitializeRuntimeKey;
+using spoor::instrumentation::config::kInjectInstrumentationKey;
+using spoor::instrumentation::config::kInstrumentedFunctionMapOutputPathKey;
+using spoor::instrumentation::config::kMinInstructionThresholdKey;
+using spoor::instrumentation::config::kModuleIdKey;
+using spoor::instrumentation::config::kOutputFileKey;
+using spoor::instrumentation::config::kOutputLanguageKey;
+using spoor::instrumentation::config::OutputLanguage;
+
+TEST(EnvConfig, GetsUserProvidedValue) {  // NOLINT
+  const auto get_env = [](const char* key) {
+    constexpr util::flat_map::FlatMap<std::string_view, std::string_view, 11>
+        environment{{kEnableRuntimeKey, "false"},
+                    {kForceBinaryOutputKey, "true"},
+                    {kFunctionAllowListFileKey, "/path/to/allow_list.txt"},
+                    {kFunctionBlocklistFileKey, "/path/to/blocklist.txt"},
+                    {kInitializeRuntimeKey, "false"},
+                    {kInjectInstrumentationKey, "false"},
+                    {kInstrumentedFunctionMapOutputPathKey, "/path/to/output/"},
+                    {kMinInstructionThresholdKey, "42"},
+                    {kModuleIdKey, "ModuleId"},
+                    {kOutputFileKey, "/path/to/output_file.ll"},
+                    {kOutputLanguageKey, "      iR     "}};
+    return environment.FirstValueForKey(key).value_or(nullptr).data();
+  };
+  const Config expected_config{
+      .enable_runtime = false,
+      .force_binary_output = true,
+      .function_allow_list_file = "/path/to/allow_list.txt",
+      .function_blocklist_file = "/path/to/blocklist.txt",
+      .initialize_runtime = false,
+      .inject_instrumentation = false,
+      .instrumented_function_map_output_path = "/path/to/output/",
+      .min_instruction_threshold = 42,
+      .module_id = "ModuleId",
+      .output_file = "/path/to/output_file.ll",
+      .output_language = OutputLanguage::kIr};
+  ASSERT_EQ(ConfigFromEnv(get_env), expected_config);
+}
+
+TEST(EnvConfig, UsesDefaultValueWhenNotSpecified) {  // NOLINT
+  const auto get_env = [](const char* /*unused*/) -> const char* {
+    return nullptr;
+  };
+  const Config expected_config{.enable_runtime = true,
+                               .force_binary_output = false,
+                               .function_allow_list_file = {},
+                               .function_blocklist_file = {},
+                               .initialize_runtime = true,
+                               .inject_instrumentation = true,
+                               .instrumented_function_map_output_path = ".",
+                               .min_instruction_threshold = 0,
+                               .module_id = {},
+                               .output_file = "-",
+                               .output_language = OutputLanguage::kBitcode};
+  ASSERT_EQ(ConfigFromEnv(get_env), expected_config);
+}
+
+TEST(EnvConfig, UsesDefaultValueForEmptyStringValues) {  // NOLINT
+  const auto get_env = [](const char* key) {
+    constexpr util::flat_map::FlatMap<std::string_view, std::string_view, 11>
+        environment{{kEnableRuntimeKey, ""},
+                    {kForceBinaryOutputKey, ""},
+                    {kFunctionAllowListFileKey, ""},
+                    {kFunctionBlocklistFileKey, ""},
+                    {kInitializeRuntimeKey, ""},
+                    {kInjectInstrumentationKey, ""},
+                    {kInstrumentedFunctionMapOutputPathKey, ""},
+                    {kMinInstructionThresholdKey, ""},
+                    {kModuleIdKey, ""},
+                    {kOutputFileKey, ""},
+                    {kOutputLanguageKey, ""}};
+    return environment.FirstValueForKey(key).value_or(nullptr).data();
+  };
+  const Config expected_config{.enable_runtime = true,
+                               .force_binary_output = false,
+                               .function_allow_list_file = {},
+                               .function_blocklist_file = {},
+                               .initialize_runtime = true,
+                               .inject_instrumentation = true,
+                               .instrumented_function_map_output_path = "",
+                               .min_instruction_threshold = 0,
+                               .module_id = {},
+                               .output_file = "",
+                               .output_language = OutputLanguage::kBitcode};
+  ASSERT_EQ(ConfigFromEnv(get_env), expected_config);
+}
+
+}  // namespace

--- a/spoor/instrumentation/inject_runtime/inject_runtime.cc
+++ b/spoor/instrumentation/inject_runtime/inject_runtime.cc
@@ -55,6 +55,8 @@ InjectRuntime::InjectRuntime(Options&& options)
 
 auto InjectRuntime::run(llvm::Module& llvm_module, llvm::ModuleAnalysisManager&
                         /*unused*/) -> llvm::PreservedAnalyses {
+  if (!options_.inject_instrumentation) return llvm::PreservedAnalyses::all();
+
   auto [instrumented_function_map, modified] = InstrumentModule(&llvm_module);
 
   const auto now = [&] {

--- a/spoor/instrumentation/inject_runtime/inject_runtime.h
+++ b/spoor/instrumentation/inject_runtime/inject_runtime.h
@@ -32,6 +32,7 @@ constexpr std::string_view kInstrumentedFunctionMapFileExtension{
 class InjectRuntime : public llvm::PassInfoMixin<InjectRuntime> {
  public:
   struct Options {
+    bool inject_instrumentation;
     std::filesystem::path instrumented_function_map_output_path;
     std::function<std::unique_ptr<llvm::raw_ostream>(
         llvm::StringRef /*file_path*/,
@@ -54,6 +55,7 @@ class InjectRuntime : public llvm::PassInfoMixin<InjectRuntime> {
   auto operator=(InjectRuntime&&) noexcept -> InjectRuntime& = default;
   ~InjectRuntime() = default;
 
+  // LLVM's pass interface require deviating from Spoor's naming convention.
   // NOLINTNEXTLINE(google-runtime-references, readability-identifier-naming)
   auto run(llvm::Module& llvm_module,
            // NOLINTNEXTLINE(google-runtime-references)

--- a/spoor/instrumentation/instrumentation.h
+++ b/spoor/instrumentation/instrumentation.h
@@ -8,6 +8,6 @@
 namespace spoor::instrumentation {
 
 constexpr std::string_view kPluginName{"inject-spoor-instrumentation"};
-constexpr std::string_view kPluginVersion{"0.0.0"};
+constexpr std::string_view kVersion{"0.0.0"};
 
 }  // namespace spoor::instrumentation

--- a/spoor/instrumentation/spoor_opt.cc
+++ b/spoor/instrumentation/spoor_opt.cc
@@ -1,0 +1,188 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include <array>
+#include <filesystem>
+#include <fstream>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <unordered_set>
+
+#include "absl/flags/flag.h"
+#include "absl/flags/usage.h"
+#include "absl/flags/usage_config.h"
+#include "absl/strings/ascii.h"
+#include "absl/strings/match.h"
+#include "absl/strings/str_format.h"
+#include "absl/strings/string_view.h"
+#include "gsl/gsl"
+#include "llvm/Bitcode/BitcodeWriter.h"
+#include "llvm/IR/IRPrintingPasses.h"
+#include "llvm/IR/LLVMContext.h"
+#include "llvm/IR/PassManager.h"
+#include "llvm/IRReader/IRReader.h"
+#include "llvm/Support/SourceMgr.h"
+#include "llvm/Support/WithColor.h"
+#include "llvm/Support/raw_ostream.h"
+#include "spoor/instrumentation/config/command_line_config.h"
+#include "spoor/instrumentation/config/config.h"
+#include "spoor/instrumentation/inject_runtime/inject_runtime.h"
+#include "spoor/instrumentation/instrumentation.h"
+#include "spoor/instrumentation/support/support.h"
+#include "util/time/clock.h"
+
+namespace {
+
+using spoor::instrumentation::config::ConfigFromCommandLineOrEnv;
+using spoor::instrumentation::config::OutputLanguage;
+using spoor::instrumentation::support::ReadLinesToSet;
+
+constexpr std::string_view kStdinFileName{"-"};
+constexpr std::string_view kUsage{
+    "Transform LLVM Bitcode/IR by injecting Spoor instrumentation.\n\n"
+    "USAGE: %1$s [options] [input_file]\n\n"
+    "EXAMPLES\n"
+    "$ %1$s source.bc --output_file=instrumented_source.bc\n"
+    "$ clang++ source.cc -c -emit-llvm -o - | %1$s | "
+    "clang++ -x ir - -lspoor_runtime\n\n"
+    "Reads from stdin if an input file is not provided.\n"
+    "Prints to stdout if an output file is not provided."};
+
+}  // namespace
+
+auto main(int argc, char** argv) -> int {
+  const auto short_program_invocation_name = [argc, argv] {
+    const gsl::span<char*> args{argv,
+                                static_cast<gsl::span<char*>::size_type>(argc)};
+    const auto program_invocation_name = std::filesystem::path{args.front()};
+    return program_invocation_name.filename();
+  }();
+  const auto show_help = [](const absl::string_view source) {
+    std::string string{source};
+    absl::AsciiStrToLower(&string);
+    return absl::StrContains(string, "spoor") ||
+           absl::StrContains(string, "usage");
+  };
+  absl::SetFlagsUsageConfig({
+      .contains_helpshort_flags = show_help,
+      .contains_help_flags = show_help,
+      .version_string =
+          [] {
+            return absl::StrFormat("v%s\n", spoor::instrumentation::kVersion);
+          },
+  });
+  absl::SetProgramUsageMessage(
+      absl::StrFormat(kUsage, short_program_invocation_name));
+
+  const auto [config, positional_args] = ConfigFromCommandLineOrEnv(argc, argv);
+  if (2 < positional_args.size()) {
+    llvm::WithColor::error();
+    llvm::errs() << "Expected at most one positional argument.\n\n"
+                 << absl::ProgramUsageMessage() << "\n\n"
+                 << "Try --help to list available flags.\n";
+    return EXIT_FAILURE;
+  }
+  const auto* const input_file = [positional_args = positional_args] {
+    if (positional_args.size() == 1) return kStdinFileName.data();
+    return static_cast<const char*>(positional_args.back());
+  }();
+
+  llvm::SMDiagnostic parse_ir_file_diagnostic{};
+  llvm::LLVMContext context{};
+  const auto llvm_module =
+      llvm::parseIRFile(input_file, parse_ir_file_diagnostic, context);
+  if (llvm_module == nullptr) {
+    parse_ir_file_diagnostic.print(short_program_invocation_name.c_str(),
+                                   llvm::errs());
+    return EXIT_FAILURE;
+  }
+
+  auto instrumented_function_map_output_stream =
+      [](const llvm::StringRef file_path,
+         gsl::not_null<std::error_code*> error) {
+        return std::make_unique<llvm::raw_fd_ostream>(file_path, *error);
+      };
+
+  auto system_clock = std::make_unique<util::time::SystemClock>();
+
+  std::unordered_set<std::string> function_allow_list{};
+  if (config.function_allow_list_file.has_value()) {
+    std::ifstream file{config.function_allow_list_file.value()};
+    if (!file.is_open()) {
+      llvm::WithColor::error();
+      llvm::errs() << "Failed to read the function allow list file '"
+                   << config.function_allow_list_file.value() << "'.\n";
+      return EXIT_FAILURE;
+    }
+    function_allow_list = ReadLinesToSet(&file);
+  }
+
+  std::unordered_set<std::string> function_blocklist{};
+  if (config.function_blocklist_file.has_value()) {
+    std::ifstream file{config.function_blocklist_file.value()};
+    if (!file.is_open()) {
+      llvm::WithColor::error();
+      llvm::errs() << "Failed to read the function allow list file '"
+                   << config.function_blocklist_file.value() << "'.\n";
+      return EXIT_FAILURE;
+    }
+    function_blocklist = ReadLinesToSet(&file);
+  }
+
+  spoor::instrumentation::inject_runtime::InjectRuntime inject_runtime{{
+      .inject_instrumentation = config.inject_instrumentation,
+      .instrumented_function_map_output_path =
+          config.instrumented_function_map_output_path,
+      .instrumented_function_map_output_stream =
+          std::move(instrumented_function_map_output_stream),
+      .system_clock = std::move(system_clock),
+      .function_allow_list = std::move(function_allow_list),
+      .function_blocklist = std::move(function_blocklist),
+      .module_id = config.module_id,
+      .min_instruction_count_to_instrument = config.min_instruction_threshold,
+      .initialize_runtime = config.initialize_runtime,
+      .enable_runtime = config.enable_runtime,
+  }};
+  llvm::ModuleAnalysisManager module_analysis_manager{};
+  inject_runtime.run(*llvm_module, module_analysis_manager);
+
+  std::error_code create_ostream_error{};
+  llvm::raw_fd_ostream ostream{config.output_file, create_ostream_error};
+  if (create_ostream_error) {
+    llvm::WithColor::error();
+    llvm::errs() << create_ostream_error.message();
+    return EXIT_FAILURE;
+  }
+  const auto binary_output = BinaryOutput(config.output_language);
+  if (ostream.is_displayed() && binary_output && !config.force_binary_output) {
+    const auto force_binary_output_flag = absl::StrFormat(
+        "--%s",
+        absl::GetFlagReflectionHandle(FLAGS_force_binary_output).Name());
+    const auto output_language_flag_suggestion = absl::StrFormat(
+        "--%s=%s", absl::GetFlagReflectionHandle(FLAGS_output_language).Name(),
+        AbslUnparseFlag(OutputLanguage::kIr));
+    llvm::WithColor::warning();
+    llvm::errs() << "Attempting to print binary data to the console. This "
+                    "might cause display problems. Pass "
+                 << force_binary_output_flag
+                 << " to suppress this warning or try "
+                 << output_language_flag_suggestion
+                 << " for a textual output.\n";
+    return EXIT_FAILURE;
+  }
+  switch (config.output_language) {
+    case OutputLanguage::kBitcode: {
+      llvm::WriteBitcodeToFile(*llvm_module, ostream);
+      break;
+    }
+    case OutputLanguage::kIr: {
+      llvm::PrintModulePass print_module_pass{ostream};
+      print_module_pass.run(*llvm_module, module_analysis_manager);
+      break;
+    }
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/spoor/instrumentation/spoor_opt_test.sh
+++ b/spoor/instrumentation/spoor_opt_test.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+set -e
+
+BASE_PATH="spoor/instrumentation"
+SPOOR_OPT="$BASE_PATH/spoor_opt"
+OUTPUT_IR_FILE="instrumented.ll"
+
+"$SPOOR_OPT" "$BASE_PATH/test_data/fib.ll" \
+  --output_language=ir \
+  --output_file="$OUTPUT_IR_FILE"
+
+FUNCTION_MAP_FILE=$(find . -type f -name "*.spoor_function_map")
+
+if ! [[ -s "$FUNCTION_MAP_FILE" ]]; then
+  echo "The function map file '$FUNCTION_MAP_FILE' is empty."
+  exit 1
+fi
+
+grep _spoor_runtime_LogFunctionEntry "$OUTPUT_IR_FILE" > /dev/null
+grep _spoor_runtime_LogFunctionExit "$OUTPUT_IR_FILE" > /dev/null

--- a/spoor/instrumentation/support/BUILD
+++ b/spoor/instrumentation/support/BUILD
@@ -1,0 +1,25 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+
+cc_library(
+    name = "support",
+    srcs = ["support.cc"],
+    hdrs = ["support.h"],
+    visibility = ["//spoor/instrumentation:__pkg__"],
+    deps = [
+        "@com_microsoft_gsl//:gsl",
+    ],
+)
+
+cc_test(
+    name = "support_test",
+    size = "small",
+    srcs = ["support_test.cc"],
+    visibility = ["//visibility:private"],
+    deps = [
+        ":support",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/spoor/instrumentation/support/support.cc
+++ b/spoor/instrumentation/support/support.cc
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "spoor/instrumentation/support/support.h"
+
+#include <algorithm>
+#include <istream>
+#include <unordered_set>
+
+#include "gsl/gsl"
+
+namespace spoor::instrumentation::support {
+
+auto ReadLinesToSet(gsl::not_null<std::istream*> istream)
+    -> std::unordered_set<std::string> {
+  std::unordered_set<std::string> file_lines{};
+  std::copy(std::istream_iterator<std::string>(*istream),
+            std::istream_iterator<std::string>(),
+            std::inserter(file_lines, std::begin(file_lines)));
+  return file_lines;
+}
+
+}  // namespace spoor::instrumentation::support

--- a/spoor/instrumentation/support/support.h
+++ b/spoor/instrumentation/support/support.h
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <istream>
+#include <unordered_set>
+
+#include "gsl/gsl"
+
+namespace spoor::instrumentation::support {
+
+auto ReadLinesToSet(gsl::not_null<std::istream*> istream)
+    -> std::unordered_set<std::string>;
+
+}  // namespace spoor::instrumentation::support

--- a/spoor/instrumentation/support/support_test.cc
+++ b/spoor/instrumentation/support/support_test.cc
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "spoor/instrumentation/support/support.h"
+
+#include <sstream>
+#include <unordered_set>
+
+#include "gtest/gtest.h"
+
+namespace {
+
+using spoor::instrumentation::support::ReadLinesToSet;
+
+TEST(Support, ReadLinesToSet) {  // NOLINT
+  std::stringstream stream{"bar\nbaz\nfoo\nbar"};
+  ASSERT_FALSE(stream.eof());
+  std::unordered_set<std::string> expected_unique_lines{"foo", "bar", "baz"};
+  const auto unique_lines = ReadLinesToSet(&stream);
+  ASSERT_EQ(unique_lines, expected_unique_lines);
+  ASSERT_TRUE(stream.eof());
+
+  std::stringstream empty_stream{};
+  const auto empty_lines = ReadLinesToSet(&stream);
+  ASSERT_TRUE(empty_lines.empty());
+}
+
+}  // namespace

--- a/spoor/runtime/config/config.cc
+++ b/spoor/runtime/config/config.cc
@@ -15,7 +15,7 @@ auto Config::FromEnv(const util::env::GetEnv& get_env) -> Config {
                               std::string{kTraceFilePathDefaultValue}, get_env),
           .compression_strategy = GetEnvOrDefault(
               kCompressionStrategyKey.data(), kCompressionStrategyDefaultValue,
-              kCompressionStrategyMap, true, get_env),
+              kCompressionStrategies, true, get_env),
           .session_id = GetEnvOrDefault(kSessionIdKey.data(),
                                         kSessionIdDefaultValue(), get_env),
           .thread_event_buffer_capacity =

--- a/spoor/runtime/config/config.h
+++ b/spoor/runtime/config/config.h
@@ -25,8 +25,8 @@ constexpr std::string_view kTraceFilePathDefaultValue{"."};
 constexpr std::string_view kCompressionStrategyKey{
     "SPOOR_RUNTIME_COMPRESSION_STRATEGY"};
 constexpr util::flat_map::FlatMap<std::string_view, CompressionStrategy, 2>
-    kCompressionStrategyMap{{"none", CompressionStrategy::kNone},
-                            {"snappy", CompressionStrategy::kSnappy}};
+    kCompressionStrategies{{"none", CompressionStrategy::kNone},
+                           {"snappy", CompressionStrategy::kSnappy}};
 constexpr auto kCompressionStrategyDefaultValue{CompressionStrategy::kSnappy};
 constexpr std::string_view kSessionIdKey{"SPOOR_RUNTIME_SESSION_ID"};
 // NOLINTNEXTLINE(fuchsia-statically-constructed-objects)

--- a/util/env/env.cc
+++ b/util/env/env.cc
@@ -8,6 +8,7 @@
 #include <optional>
 #include <string>
 
+#include "absl/strings/ascii.h"
 #include "absl/strings/numbers.h"
 
 namespace util::env {
@@ -16,7 +17,7 @@ auto GetEnvOrDefault(const char* key, std::string default_value,
                      const GetEnv& get_env) -> std::string {
   const auto* user_value = get_env(key);
   if (user_value == nullptr) return default_value;
-  return std::string{user_value};
+  return user_value;
 }
 
 auto GetEnvOrDefault(const char* key, std::optional<std::string> default_value,
@@ -24,9 +25,9 @@ auto GetEnvOrDefault(const char* key, std::optional<std::string> default_value,
     -> std::optional<std::string> {
   const auto* user_value = get_env(key);
   if (user_value == nullptr) return default_value;
-  auto user_value_string = std::string{user_value};
+  std::string user_value_string{user_value};
   if (user_value_string.empty() && empty_string_is_nullopt) return {};
-  return std::move(user_value_string);
+  return user_value_string;
 }
 
 auto GetEnvOrDefault(const char* key, const bool default_value,
@@ -34,6 +35,7 @@ auto GetEnvOrDefault(const char* key, const bool default_value,
   const auto* user_value = get_env(key);
   if (user_value == nullptr) return default_value;
   std::string value{user_value};
+  absl::StripAsciiWhitespace(&value);
   absl::AsciiStrToLower(&value);
   bool result{};
   const auto success = absl::SimpleAtob(value, &result);

--- a/util/env/env.h
+++ b/util/env/env.h
@@ -53,14 +53,14 @@ auto GetEnvOrDefault(
     const char* key, const T& default_value,
     const util::flat_map::FlatMap<std::string_view, T, Size>& value_map,
     const bool normalize, const GetEnv& get_env) -> T {
-  const auto* user_value = get_env(key);
-  if (user_value == nullptr) return default_value;
-  auto value = std::string{user_value};
+  const auto* user_key = get_env(key);
+  if (user_key == nullptr) return default_value;
+  auto normalized_key = std::string{user_key};
   if (normalize) {
-    absl::StripAsciiWhitespace(&value);
-    absl::AsciiStrToLower(&value);
+    absl::StripAsciiWhitespace(&normalized_key);
+    absl::AsciiStrToLower(&normalized_key);
   }
-  return value_map.FirstValueForKey(value).value_or(default_value);
+  return value_map.FirstValueForKey(normalized_key).value_or(default_value);
 }
 
 }  // namespace util::env

--- a/util/env/env_test.cc
+++ b/util/env/env_test.cc
@@ -4,6 +4,7 @@
 #include "util/env/env.h"
 
 #include <string>
+#include <string_view>
 
 #include "absl/strings/ascii.h"
 #include "absl/strings/str_cat.h"
@@ -104,14 +105,14 @@ TEST(GetEnvOrDefault, ValueMap) {  // NOLINT
   constexpr uint32 default_value{3};
   const util::flat_map::FlatMap<std::string_view, uint32, 3> value_map{
       {"zero", 0}, {"one", 1}, {"two", 2}};
-  for (const auto& [key_view, value] : value_map) {
-    const std::string key{key_view};
+  for (const auto& [raw_key, raw_value] : value_map) {
+    const std::string key{raw_key};
     const auto messy_key =
         absl::StrCat("   ", absl::AsciiStrToUpper(key), "    ");
     const auto retrieved_env_value =
         GetEnvOrDefault("KEY", default_value, value_map, false,
                         [key](const char* /*unused*/) { return key.data(); });
-    ASSERT_EQ(retrieved_env_value, value);
+    ASSERT_EQ(retrieved_env_value, raw_value);
     const auto retrieved_env_value_not_normalized = GetEnvOrDefault(
         "KEY", default_value, value_map, false,
         [messy_key](const char* /*unused*/) { return messy_key.data(); });
@@ -119,7 +120,7 @@ TEST(GetEnvOrDefault, ValueMap) {  // NOLINT
     const auto retrieved_env_value_normalized = GetEnvOrDefault(
         "KEY", default_value, value_map, true,
         [messy_key](const char* /*unused*/) { return messy_key.data(); });
-    ASSERT_EQ(retrieved_env_value_normalized, value);
+    ASSERT_EQ(retrieved_env_value_normalized, raw_value);
   }
   const auto retrieved_env_value_nullptr =
       GetEnvOrDefault("KEY", default_value, value_map, true,

--- a/util/flags/BUILD
+++ b/util/flags/BUILD
@@ -1,0 +1,28 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+
+cc_library(
+    name = "optional",
+    srcs = ["optional.cc"],
+    hdrs = ["optional.h"],
+    copts = ["-Werror"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_google_absl//absl/strings",
+    ],
+)
+
+cc_test(
+    name = "optional_test",
+    size = "small",
+    srcs = ["optional_test.cc"],
+    copts = ["-Werror"],
+    visibility = ["//visibility:private"],
+    deps = [
+        ":optional",
+        "//util:numeric",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/util/flags/optional.cc
+++ b/util/flags/optional.cc
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "util/flags/optional.h"
+
+#include <string>
+
+#include "absl/strings/string_view.h"
+
+namespace util::flags {
+
+template <>
+constexpr Optional<std::string>::Optional(const std::string& item)
+    : item_{[&item]() -> std::optional<std::string> {
+        if (item.empty()) return {};
+        return item;
+      }()} {}
+
+template <>
+constexpr Optional<std::string>::Optional(std::string&& item)
+    : item_{[&item]() -> std::optional<std::string> {
+        if (item.empty()) return {};
+        return std::move(item);
+      }()} {}
+
+template <>
+auto AbslParseFlag(const absl::string_view user_value,
+                   Optional<std::string>* optional, std::string*
+                   /*error*/) -> bool {
+  if (user_value.empty()) {
+    *optional = {};
+  } else {
+    *optional = std::string{user_value};
+  }
+  return true;
+}
+
+}  // namespace util::flags

--- a/util/flags/optional.h
+++ b/util/flags/optional.h
@@ -1,0 +1,108 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <optional>
+#include <utility>
+
+#include "absl/strings/string_view.h"
+
+namespace util::flags {
+
+// `std::optional<T>` and `absl::optional<T>` do not work with `absl::Flags`
+// because their constructors are ambiguous with absl::string_view.
+
+template <class T>
+class Optional {
+ public:
+  constexpr Optional() = default;
+  constexpr Optional(const T& item);  // NOLINT(google-explicit-constructor)
+  constexpr Optional(T&& item);       // NOLINT(google-explicit-constructor)
+  // NOLINTNEXTLINE(google-explicit-constructor)
+  constexpr Optional(const std::optional<T>& optional);
+  // NOLINTNEXTLINE(google-explicit-constructor)
+  constexpr Optional(std::optional<T>&& optional);
+
+  [[nodiscard]] constexpr auto HasValue() const -> bool;
+  [[nodiscard]] constexpr auto Value() const& -> const T&;
+  [[nodiscard]] constexpr auto Value() & -> T&;
+  [[nodiscard]] constexpr auto Value() const&& -> const T&&;
+  [[nodiscard]] constexpr auto Value() && -> T&&;
+  [[nodiscard]] constexpr auto ValueOr(T&& other) const& -> T;
+  [[nodiscard]] constexpr auto ValueOr(T&& other) && -> T;
+  [[nodiscard]] constexpr auto StdOptional() const -> std::optional<T>;
+
+ private:
+  std::optional<T> item_;
+};
+
+template <class T>
+auto AbslParseFlag(absl::string_view user_value, Optional<T>* optional,
+                   std::string* error) -> bool;
+
+template <class T>
+auto AbslUnparseFlag(const Optional<T>& optional_value) -> std::string;
+
+template <class T>
+constexpr Optional<T>::Optional(const T& item) : item_{item} {}
+
+template <class T>
+constexpr Optional<T>::Optional(T&& item) : item_{std::move(item)} {}
+
+template <class T>
+constexpr Optional<T>::Optional(const std::optional<T>& optional)
+    : item_{optional} {}
+
+template <class T>
+constexpr Optional<T>::Optional(std::optional<T>&& optional)
+    : item_{optional} {}
+
+template <class T>
+constexpr auto Optional<T>::HasValue() const -> bool {
+  return item_.has_value();
+}
+
+template <class T>
+constexpr auto Optional<T>::Value() const& -> const T& {
+  return item_.value();
+}
+
+template <class T>
+constexpr auto Optional<T>::Value() & -> T& {
+  return item_.value();
+}
+
+template <class T>
+constexpr auto Optional<T>::Value() const&& -> const T&& {
+  return std::move(item_.value());
+}
+
+template <class T>
+constexpr auto Optional<T>::Value() && -> T&& {
+  return std::move(item_.value());
+}
+
+template <class T>
+constexpr auto Optional<T>::ValueOr(T&& other) const& -> T {
+  return item_.value_or(other);
+}
+
+template <class T>
+constexpr auto Optional<T>::ValueOr(T&& other) && -> T {
+  return item_.value_or(other);
+}
+
+template <class T>
+constexpr auto Optional<T>::StdOptional() const -> std::optional<T> {
+  if (item_.has_value()) return item_.value();
+  return {};
+}
+
+template <class T>
+auto AbslUnparseFlag(const Optional<T>& optional_value) -> std::string {
+  if (optional_value.HasValue()) return std::string{optional_value.Value()};
+  return "none";
+}
+
+}  // namespace util::flags

--- a/util/flags/optional_test.cc
+++ b/util/flags/optional_test.cc
@@ -1,0 +1,140 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "util/flags/optional.h"
+
+#include <optional>
+
+#include "gtest/gtest.h"
+#include "util/numeric.h"
+
+namespace {
+
+using Optional = util::flags::Optional<int64>;
+
+TEST(Optional, DefaultConstructor) {  // NOLINT
+  constexpr Optional optional{};
+  ASSERT_FALSE(optional.HasValue());
+}
+
+TEST(Optional, LvalueConstructor) {  // NOLINT
+  constexpr int64 x{42};
+  constexpr Optional optional{x};
+  ASSERT_TRUE(optional.HasValue());
+  ASSERT_EQ(optional.Value(), x);
+}
+
+TEST(Optional, RvalueConstructor) {  // NOLINT
+  constexpr Optional optional{42};
+  ASSERT_TRUE(optional.HasValue());
+  ASSERT_EQ(optional.Value(), 42);
+}
+
+TEST(Optional, StdOptionalLvalueConstructor) {  // NOLINT
+  {
+    constexpr std::optional<int64> std_optional{42};
+    constexpr Optional optional{std_optional};
+    ASSERT_TRUE(optional.HasValue());
+    ASSERT_EQ(optional.Value(), std_optional);
+  }
+  {
+    constexpr std::optional<int64> std_optional{};
+    constexpr Optional optional{std_optional};
+    ASSERT_FALSE(optional.HasValue());
+  }
+}
+
+TEST(Optional, StdOptionalRvalueConstructor) {  // NOLINT
+  {
+    constexpr Optional optional{std::optional<int64>{42}};
+    ASSERT_TRUE(optional.HasValue());
+    ASSERT_EQ(optional.Value(), std::optional<int64>{42});
+  }
+  {
+    constexpr Optional optional{std::optional<int64>{}};
+    ASSERT_FALSE(optional.HasValue());
+  }
+}
+
+TEST(Optional, HasValue) {  // NOLINT
+  {
+    constexpr Optional optional{42};
+    ASSERT_TRUE(optional.HasValue());
+  }
+  {
+    constexpr Optional optional{};
+    ASSERT_FALSE(optional.HasValue());
+  }
+}
+
+TEST(Optional, ValueConstLvalue) {  // NOLINT
+  constexpr int64 x{42};
+  constexpr Optional optional{x};
+  ASSERT_EQ(optional.Value(), x);
+}
+
+TEST(Optional, ValueLvalue) {  // NOLINT
+  constexpr int64 x{42};
+  Optional optional{x};
+  ASSERT_EQ(optional.Value(), x);
+  optional.Value() += 1;
+  ASSERT_EQ(optional.Value(), x + 1);
+}
+
+TEST(Optional, ValueConstRvalue) {  // NOLINT
+  constexpr int64 x{42};
+  constexpr Optional optional{x};
+  // NOLINTNEXTLINE(performance-move-const-arg)
+  ASSERT_EQ(std::move(optional).Value(), x);
+}
+
+TEST(Optional, ValueRvalue) {  // NOLINT
+  constexpr int64 x{42};
+  Optional optional{x};
+  // NOLINTNEXTLINE(performance-move-const-arg)
+  ASSERT_EQ(std::move(optional).Value(), x);
+}
+
+TEST(Optional, ValueOrLvalue) {  // NOLINT
+  {
+    constexpr Optional optional{};
+    const auto value = optional.ValueOr(42);
+    ASSERT_EQ(value, 42);
+  }
+  {
+    constexpr Optional optional{123};
+    const auto value = optional.ValueOr(42);
+    ASSERT_EQ(value, 123);
+  }
+}
+
+TEST(Optional, ValueOrRvalue) {  // NOLINT
+  {
+    constexpr Optional optional{};
+    // NOLINTNEXTLINE(performance-move-const-arg)
+    const auto value = std::move(optional).ValueOr(42);
+    ASSERT_EQ(value, 42);
+  }
+  {
+    constexpr Optional optional{123};
+    // NOLINTNEXTLINE(performance-move-const-arg)
+    const auto value = std::move(optional).ValueOr(42);
+    ASSERT_EQ(value, 123);
+  }
+}
+
+TEST(Optional, StdOptional) {  // NOLINT
+  {
+    constexpr Optional optional{};
+    const auto std_optional = optional.StdOptional();
+    ASSERT_EQ(std_optional, std::optional<int64>{});
+  }
+  {
+    constexpr int64 x{42};
+    constexpr Optional optional{x};
+    const auto std_optional = optional.StdOptional();
+    ASSERT_EQ(std_optional, std::optional<int64>{x});
+  }
+}
+
+}  // namespace


### PR DESCRIPTION
Implements `spoor_opt`, an executable to inject Spoor instrumentation into LLVM IR.

The tool is similar to LLVM's `opt` which we were using previously. Note that it's not a drop-in replacement.

Creating our own tool has several advantages:

#### No LLVM dependency

Most significantly, `spoor_opt` eliminates the toolchain's dependency on LLVM.

* Spoorers* no longer need to `brew install llvm` to instrument their code. This is one less headache during installation and has significant space savings. On macOS, the LLVM 11.1.0 toolchain is 1.3 GB (it's easiest to install the whole thing) whereas `spoor_opt` is 17 MB (98% smaller).
* There's no need to add `/usr/local/opt/llvm/bin` (or equivalent on other platforms) to your PATH. This is one less headache during installation, is an easy step to miss (not done automatically by Homebrew), saves you from changing your system's default `clang`, and avoids name conflicts with other tools. Additionally, `spoor_opt` eliminates naming conflicts with other tools. As it turns out, there's also a C# tool called `opt` whose name conflicts with LLVM's `opt` and breaks the wrapper script if it's the default. The solution before `spoor_opt` to get the toolchain working was (yet another) environment variable config.
* Note that LLVM will still be a dev dependency.

\* Not sure if this will catch on 🙃


#### Ergonomics

`spoor_opt` is a bit more ergonomic than `opt`. There's no need to remember the `opt` incantation to import the custom pass and Spoor's instrumentation can now be configured via command line arguments.

Of course, we'll still support `opt` by shipping the `libspoor_instrumentation.[so|dylib]` pass plugin, and you can still configure the instrumentation via environment variables.
```
$ opt file.bc -load-pass-plugin=libspoor_instrumentation.so -passes="inject-spoor-instrumentation"
```


#### Binary publishing

We can bundle `spoor_opt` with our custom Xcode toolchain whereas it would be non-trivial to bundle LLVM's `opt` with toolchain since it's a third-party binary. Installation will now be as simple as dragging and dropping (or symlinking) Spoor.xctoolchain into ~/Library/Developer/Toolchains. No other installations!


#### Piping

An upcoming feature will allow you to configure running optimizations before or after injecting instrumentation. Before, we'd need to chain together five executables to instrument a file: `frontend | opt | opt | opt | clang`. Now it's just three: `frontend | spoor_opt | clang`.

----------------

```
$ spoor_opt --help
spoor_opt: Transform LLVM Bitcode/IR by injecting Spoor instrumentation.

USAGE: spoor_opt [options] [input_file]

EXAMPLES
$ spoor_opt source.bc --output_file=instrumented_source.bc
$ clang++ source.cc -c -emit-llvm -o - | spoor_opt | clang++ -x ir - -lspoor_runtime

Reads from stdin if an input file is not provided.
Prints to stdout if an output file is not provided.

  Flags from external/com_google_absl/absl/flags/internal/usage.cc:
    --help (show help on important flags for this binary [tip: all flags can
      have two dashes]); default: false; currently: true;
    --helpfull (show help on all flags); default: false;
    --helpmatch (show help on modules whose name contains the specified substr);
      default: "";
    --helpon (show help on the modules named by this flag value); default: "";
    --helppackage (show help on all modules in the main package);
      default: false;
    --helpshort (show help on only the main module for this program);
      default: false;
    --only_check_args (exit after checking all flags); default: false;
    --version (show version and build info and exit); default: false;


  Flags from spoor/instrumentation/config/command_line_config.cc:
    --enable_runtime (Automatically enable Spoor's runtime.); default: true;
    --force_binary_output (Force printing binary data to the console.);
      default: false;
    --function_allow_list_file (File path to the function allow list.);
      default: none;
    --function_blocklist_file (File path to the function blocklist.);
      default: none;
    --initialize_runtime (Automatically initialize Spoor's runtime.);
      default: true;
    --inject_instrumentation (Inject Spoor instrumentation.); default: true;
    --instrumentation_map_output_path (Spoor function map output file.);
      default: ".";
    --min_instruction_threshold (Minimum number of LLVM IR instructions required
      to instrument a function.); default: 0;
    --module_id (Override the LLVM module's ID.); default: none;
    --output_file (Output file.); default: "-";
    --output_language (Language in which to output the transformed code.
      Options: bitcode, ir.); default: bitcode;

Try --helpfull to get a list of all flags.
```