### PR TITLE
Safe pass exit

### DIFF
--- a/spoor/instrumentation/BUILD
+++ b/spoor/instrumentation/BUILD
@@ -46,6 +46,7 @@ SHARED_LIBRARY_DEPS = [
     "//spoor/instrumentation/inject_runtime",
     "//spoor/instrumentation/support",
     "//util/time:clock",
+    "@com_google_absl//absl/strings:str_format",
     "@llvm//12.0.0",
 ]
 

--- a/spoor/instrumentation/inject_runtime/BUILD
+++ b/spoor/instrumentation/inject_runtime/BUILD
@@ -14,6 +14,7 @@ cc_library(
         "//util:numeric",
         "//util/time:clock",
         "@com_apple_swift//:demangle",
+        "@com_google_absl//absl/strings:str_format",
         "@com_google_cityhash//:city_hash",
         "@com_microsoft_gsl//:gsl",
         "@llvm//12.0.0",

--- a/spoor/instrumentation/inject_runtime/inject_runtime_test.cc
+++ b/spoor/instrumentation/inject_runtime/inject_runtime_test.cc
@@ -760,11 +760,11 @@ TEST(InjectRuntime, ExitsOnOstreamError) {  // NOLINT
        .enable_runtime = false}};
   llvm::ModuleAnalysisManager module_analysis_manager{};
   const std::string pattern{
-      "error: Failed to open/create the instrumentation map output file "
-      "'.*'\\. Permission denied\\..*"};
-  ASSERT_EXIT(  // NOLINT
+      ".*Failed to open/create the instrumentation map output file '.*'\\. "
+      "Permission denied\\..*"};
+  ASSERT_DEATH(  // NOLINT
       inject_runtime.run(*parsed_module, module_analysis_manager),
-      testing::ExitedWithCode(EXIT_FAILURE), MatchesRegex(pattern));
+      MatchesRegex(pattern));
 }
 
 }  // namespace

--- a/spoor/instrumentation/register_pass.cc
+++ b/spoor/instrumentation/register_pass.cc
@@ -12,10 +12,12 @@
 #include <system_error>
 #include <unordered_set>
 
+#include "absl/strings/str_format.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/IR/PassManager.h"
 #include "llvm/Passes/PassBuilder.h"
 #include "llvm/Passes/PassPlugin.h"
+#include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/WithColor.h"
 #include "llvm/Support/raw_ostream.h"
 #include "spoor/instrumentation/config/env_config.h"
@@ -38,12 +40,10 @@ auto PluginInfo() -> llvm::PassPluginLibraryInfo {
           if (config.function_allow_list_file.has_value()) {
             std::ifstream file{config.function_allow_list_file.value()};
             if (!file.is_open()) {
-              llvm::WithColor::error();
-              llvm::errs() << "Failed to read the function allow list file '"
-                           << config.function_allow_list_file.value() << "'.\n";
-              // TODO(#118): Investigate error handling techniques and thread
-              // safety.
-              std::exit(EXIT_FAILURE);  // NOLINT(concurrency-mt-unsafe)
+              const auto message = absl::StrFormat(
+                  "Failed to read the function allow list file '%s'.",
+                  config.function_allow_list_file.value());
+              llvm::report_fatal_error(message, false);
             }
             function_allow_list = support::ReadLinesToSet(&file);
           }
@@ -52,12 +52,10 @@ auto PluginInfo() -> llvm::PassPluginLibraryInfo {
           if (config.function_blocklist_file.has_value()) {
             std::ifstream file{config.function_blocklist_file.value()};
             if (!file.is_open()) {
-              llvm::WithColor::error();
-              llvm::errs() << "Failed to read the function allow list file '"
-                           << config.function_blocklist_file.value() << "'.\n";
-              // TODO(#118): Investigate error handling techniques and thread
-              // safety.
-              std::exit(EXIT_FAILURE);  // NOLINT(concurrency-mt-unsafe)
+              const auto message = absl::StrFormat(
+                  "Failed to read the function blocklist file '%s'.",
+                  config.function_blocklist_file.value());
+              llvm::report_fatal_error(message, false);
             }
             function_blocklist = support::ReadLinesToSet(&file);
           }


### PR DESCRIPTION
Exit from a pass when an error occurs using `llvm::report_fatal_error` which is thread safe (unlike `std::exit`).

Resolves #118.