### PR TITLE
Gardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,10 @@
 # Getting Started
 
 ## Requirements
-* Compiler instrumentation and runtime library
-  * A C++ compiler that supports [C++20][c++20-compiler] such as Clang 12.
-  * [Bazel][bazel].
-  * [Clang Format][clang-format] and [Clang Tidy][clang-tidy] to style and lint
-    code.
+* A C++ compiler that supports [C++20][c++20-compiler] such as Clang 12.
+* [Bazel][bazel].
+* [Clang Format][clang-format] and [Clang Tidy][clang-tidy] to style and lint
+  code.
 
 ## Build
 ```

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -10,7 +10,7 @@ http_archive(
     build_file = "//toolchain:gsl.BUILD",
     sha256 = "ca3f015ea80a8d9163714dbf6b377a424e196bd5c8b254fdb5e5770ea3f84a55",
     strip_prefix = "GSL-ec6cd75d57f68b6566e1d406de20e59636a881e7",
-    urls = ["https://github.com/microsoft/GSL/archive/ec6cd75d57f68b6566e1d406de20e59636a881e7.tar.gz"],
+    url = "https://github.com/microsoft/GSL/archive/ec6cd75d57f68b6566e1d406de20e59636a881e7.tar.gz",
 )
 
 # TODO(#54): Migrate to the original repository when the fork's changes with
@@ -19,7 +19,7 @@ http_archive(
     name = "llvm",
     sha256 = "99181c717ca0d659c1b2a934642f7987ad93b17c2d7a211b773b627e35f90ab2",
     strip_prefix = "bazel_llvm-lelandjansen-llvm-12",
-    urls = ["https://github.com/lelandjansen/bazel_llvm/archive/lelandjansen/llvm-12.tar.gz"],
+    url = "https://github.com/lelandjansen/bazel_llvm/archive/lelandjansen/llvm-12.tar.gz",
 )
 
 load("@llvm//tools/bzl:deps.bzl", "llvm_deps")
@@ -43,21 +43,21 @@ http_archive(
     ],
     sha256 = "421dafdb0dd4c55cdfed4d8736e965b42a0d97f690bb13528947f9cc3f7ddca9",
     strip_prefix = "swift-swift-5.4-RELEASE",
-    urls = ["https://github.com/apple/swift/archive/swift-5.4-RELEASE.tar.gz"],
+    url = "https://github.com/apple/swift/archive/swift-5.4-RELEASE.tar.gz",
 )
 
 http_archive(
     name = "com_google_absl",
     sha256 = "441db7c09a0565376ecacf0085b2d4c2bbedde6115d7773551bc116212c2a8d6",
     strip_prefix = "abseil-cpp-20210324.1",
-    urls = ["https://github.com/abseil/abseil-cpp/archive/20210324.1.tar.gz"],
+    url = "https://github.com/abseil/abseil-cpp/archive/20210324.1.tar.gz",
 )
 
 http_archive(
     name = "com_google_protobuf",
     sha256 = "9b57647b898e45253c98fae35146f6a5e9e788817d29019f9280270c951a0038",
     strip_prefix = "protobuf-3.15.8",
-    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v3.15.8/protobuf-cpp-3.15.8.tar.gz"],
+    url = "https://github.com/protocolbuffers/protobuf/releases/download/v3.15.8/protobuf-cpp-3.15.8.tar.gz",
 )
 
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
@@ -69,7 +69,7 @@ http_archive(
     build_file = "//toolchain:snappy.BUILD",
     sha256 = "16b677f07832a612b0836178db7f374e414f94657c138e6993cbfc5dcc58651f",
     strip_prefix = "snappy-1.1.8",
-    urls = ["https://github.com/google/snappy/archive/1.1.8.tar.gz"],
+    url = "https://github.com/google/snappy/archive/1.1.8.tar.gz",
 )
 
 http_archive(
@@ -77,42 +77,42 @@ http_archive(
     build_file = "//toolchain:city_hash.BUILD",
     sha256 = "f70368facd15735dffc77fe2b27ab505bfdd05be5e9166d94149a8744c212f49",
     strip_prefix = "cityhash-8af9b8c2b889d80c22d6bc26ba0df1afb79a30db",
-    urls = ["https://github.com/google/cityhash/archive/8af9b8c2b889d80c22d6bc26ba0df1afb79a30db.tar.gz"],
+    url = "https://github.com/google/cityhash/archive/8af9b8c2b889d80c22d6bc26ba0df1afb79a30db.tar.gz",
 )
 
 http_archive(
     name = "com_google_googletest",
     sha256 = "9dc9157a9a1551ec7a7e43daea9a694a0bb5fb8bec81235d8a1e6ef64c716dcb",
     strip_prefix = "googletest-release-1.10.0",
-    urls = ["https://github.com/google/googletest/archive/release-1.10.0.tar.gz"],
+    url = "https://github.com/google/googletest/archive/release-1.10.0.tar.gz",
 )
 
 http_archive(
     name = "com_google_benchmark",
     sha256 = "dccbdab796baa1043f04982147e67bb6e118fe610da2c65f88912d73987e700c",
     strip_prefix = "benchmark-1.5.2",
-    urls = ["https://github.com/google/benchmark/archive/v1.5.2.tar.gz"],
+    url = "https://github.com/google/benchmark/archive/v1.5.2.tar.gz",
 )
 
 http_archive(
     name = "com_bazelbuild_bazel",
     sha256 = "2b9999d06466815ab1f2eb9c6fc6fceb6061efc715b4086fa99eac041976fb4f",
     strip_prefix = "bazel-4.0.0",
-    urls = ["https://github.com/bazelbuild/bazel/archive/4.0.0.tar.gz"],
+    url = "https://github.com/bazelbuild/bazel/archive/4.0.0.tar.gz",
 )
 
 http_archive(
     # Dependencies require deviating from the naming convention.
     name = "io_bazel_rules_go",
     sha256 = "52d0a57ea12139d727883c2fef03597970b89f2cc2a05722c42d1d7d41ec065b",
-    urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.24.13/rules_go-v0.24.13.tar.gz"],
+    url = "https://github.com/bazelbuild/rules_go/releases/download/v0.24.13/rules_go-v0.24.13.tar.gz",
 )
 
 http_archive(
     # Dependencies require deviating from the naming convention.
     name = "bazel_gazelle",
     sha256 = "222e49f034ca7a1d1231422cdb67066b885819885c356673cb1f72f748a3c9d4",
-    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.22.3/bazel-gazelle-v0.22.3.tar.gz"],
+    url = "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.22.3/bazel-gazelle-v0.22.3.tar.gz",
 )
 
 load(

--- a/spoor/instrumentation/BUILD
+++ b/spoor/instrumentation/BUILD
@@ -14,7 +14,7 @@ cc_binary(
     deps = [
         "//spoor/instrumentation/config",
         "//spoor/instrumentation/config:command_line_config",
-        "//spoor/instrumentation/inject_runtime",
+        "//spoor/instrumentation/inject_instrumentation",
         "//spoor/instrumentation/support",
         "//util/time:clock",
         "@com_google_absl//absl/flags:config",
@@ -32,7 +32,7 @@ SHARED_LIBRARY_NAME = "spoor_instrumentation"
 
 SHARED_LIBRARY_SRCS = [
     "instrumentation.h",
-    "register_pass.cc",
+    "spoor_instrumentation_pass.cc",
 ]
 
 SHARED_LIBRARY_COPTS = ["-Werror"]
@@ -43,7 +43,7 @@ SHARED_LIBRARY_VISIBILITY = ["//visibility:public"]
 
 SHARED_LIBRARY_DEPS = [
     "//spoor/instrumentation/config:env_config",
-    "//spoor/instrumentation/inject_runtime",
+    "//spoor/instrumentation/inject_instrumentation",
     "//spoor/instrumentation/support",
     "//util/time:clock",
     "@com_google_absl//absl/strings:str_format",

--- a/spoor/instrumentation/inject_instrumentation/BUILD
+++ b/spoor/instrumentation/inject_instrumentation/BUILD
@@ -4,9 +4,9 @@
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 
 cc_library(
-    name = "inject_runtime",
-    srcs = ["inject_runtime.cc"],
-    hdrs = ["inject_runtime.h"],
+    name = "inject_instrumentation",
+    srcs = ["inject_instrumentation.cc"],
+    hdrs = ["inject_instrumentation.h"],
     copts = ["-Werror"],
     visibility = ["//spoor/instrumentation:__pkg__"],
     deps = [
@@ -22,14 +22,14 @@ cc_library(
 )
 
 cc_test(
-    name = "inject_runtime_test",
+    name = "inject_instrumentation_test",
     size = "small",
-    srcs = ["inject_runtime_test.cc"],
+    srcs = ["inject_instrumentation_test.cc"],
     copts = ["-Werror"],
     data = ["//spoor/instrumentation/test_data"],
     visibility = ["//visibility:private"],
     deps = [
-        ":inject_runtime",
+        ":inject_instrumentation",
         "//spoor/proto:spoor_cc_proto",
         "//util:numeric",
         "//util/time:clock",

--- a/spoor/instrumentation/inject_instrumentation/inject_instrumentation.cc
+++ b/spoor/instrumentation/inject_instrumentation/inject_instrumentation.cc
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#include "spoor/instrumentation/inject_runtime/inject_runtime.h"
+#include "spoor/instrumentation/inject_instrumentation/inject_instrumentation.h"
 
 #include <algorithm>
 #include <cctype>
@@ -37,7 +37,7 @@
 #include "swift/Demangling/Demangler.h"
 #include "util/time/clock.h"
 
-namespace spoor::instrumentation::inject_runtime {
+namespace spoor::instrumentation::inject_instrumentation {
 
 using google::protobuf::util::TimeUtil;
 
@@ -53,11 +53,12 @@ constexpr std::string_view kLogFunctionEntryFunctionName{
 constexpr std::string_view kLogFunctionExitFunctionName{
     "_spoor_runtime_LogFunctionExit"};
 
-InjectRuntime::InjectRuntime(Options&& options)
+InjectInstrumentation::InjectInstrumentation(Options&& options)
     : options_{std::move(options)} {}
 
-auto InjectRuntime::run(llvm::Module& llvm_module, llvm::ModuleAnalysisManager&
-                        /*unused*/) -> llvm::PreservedAnalyses {
+auto InjectInstrumentation::run(llvm::Module& llvm_module,
+                                llvm::ModuleAnalysisManager&
+                                /*unused*/) -> llvm::PreservedAnalyses {
   if (!options_.inject_instrumentation) return llvm::PreservedAnalyses::all();
 
   auto [instrumented_function_map, modified] = InstrumentModule(&llvm_module);
@@ -106,8 +107,9 @@ auto InjectRuntime::run(llvm::Module& llvm_module, llvm::ModuleAnalysisManager&
 }
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
-auto InjectRuntime::InstrumentModule(gsl::not_null<llvm::Module*> llvm_module)
-    const -> std::pair<InstrumentedFunctionMap, bool> {
+auto InjectInstrumentation::InstrumentModule(
+    gsl::not_null<llvm::Module*> llvm_module) const
+    -> std::pair<InstrumentedFunctionMap, bool> {
   const auto& module_id = llvm_module->getModuleIdentifier();
   InstrumentedFunctionMap instrumented_function_map{};
   instrumented_function_map.set_module_id(module_id);
@@ -214,4 +216,4 @@ auto InjectRuntime::InstrumentModule(gsl::not_null<llvm::Module*> llvm_module)
   return {instrumented_function_map, modified};
 }
 
-}  // namespace spoor::instrumentation::inject_runtime
+}  // namespace spoor::instrumentation::inject_instrumentation

--- a/spoor/instrumentation/inject_instrumentation/inject_instrumentation.h
+++ b/spoor/instrumentation/inject_instrumentation/inject_instrumentation.h
@@ -24,12 +24,13 @@
 #include "util/numeric.h"
 #include "util/time/clock.h"
 
-namespace spoor::instrumentation::inject_runtime {
+namespace spoor::instrumentation::inject_instrumentation {
 
 constexpr std::string_view kInstrumentedFunctionMapFileExtension{
     "spoor_function_map"};
 
-class InjectRuntime : public llvm::PassInfoMixin<InjectRuntime> {
+class InjectInstrumentation
+    : public llvm::PassInfoMixin<InjectInstrumentation> {
  public:
   struct alignas(128) Options {
     bool inject_instrumentation;
@@ -47,13 +48,15 @@ class InjectRuntime : public llvm::PassInfoMixin<InjectRuntime> {
     bool enable_runtime;
   };
 
-  InjectRuntime() = delete;
-  explicit InjectRuntime(Options&& options);
-  InjectRuntime(const InjectRuntime&) = delete;
-  InjectRuntime(InjectRuntime&&) noexcept = default;
-  auto operator=(const InjectRuntime&) -> InjectRuntime& = delete;
-  auto operator=(InjectRuntime&&) noexcept -> InjectRuntime& = default;
-  ~InjectRuntime() = default;
+  InjectInstrumentation() = delete;
+  explicit InjectInstrumentation(Options&& options);
+  InjectInstrumentation(const InjectInstrumentation&) = delete;
+  InjectInstrumentation(InjectInstrumentation&&) noexcept = default;
+  auto operator=(const InjectInstrumentation&)
+      -> InjectInstrumentation& = delete;
+  auto operator=(InjectInstrumentation&&) noexcept
+      -> InjectInstrumentation& = default;
+  ~InjectInstrumentation() = default;
 
   // LLVM's pass interface require deviating from Spoor's naming convention.
   // NOLINTNEXTLINE(google-runtime-references, readability-identifier-naming)
@@ -69,4 +72,4 @@ class InjectRuntime : public llvm::PassInfoMixin<InjectRuntime> {
   Options options_;
 };
 
-}  // namespace spoor::instrumentation::inject_runtime
+}  // namespace spoor::instrumentation::inject_instrumentation

--- a/spoor/instrumentation/spoor_instrumentation_pass.cc
+++ b/spoor/instrumentation/spoor_instrumentation_pass.cc
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-// Register `InjectRuntime` with LLVM's pass manager.
+// Register `InjectInstrumentation` with LLVM's pass manager.
 
 #include <algorithm>
 #include <cstdlib>
@@ -21,7 +21,7 @@
 #include "llvm/Support/WithColor.h"
 #include "llvm/Support/raw_ostream.h"
 #include "spoor/instrumentation/config/env_config.h"
-#include "spoor/instrumentation/inject_runtime/inject_runtime.h"
+#include "spoor/instrumentation/inject_instrumentation/inject_instrumentation.h"
 #include "spoor/instrumentation/instrumentation.h"
 #include "spoor/instrumentation/support/support.h"
 #include "util/time/clock.h"
@@ -67,7 +67,7 @@ auto PluginInfo() -> llvm::PassPluginLibraryInfo {
                                                               *error);
               };
           auto system_clock = std::make_unique<util::time::SystemClock>();
-          pass_manager.addPass(inject_runtime::InjectRuntime{{
+          pass_manager.addPass(inject_instrumentation::InjectInstrumentation{{
               .inject_instrumentation = config.inject_instrumentation,
               .instrumented_function_map_output_path =
                   config.instrumented_function_map_output_path,

--- a/spoor/instrumentation/spoor_opt.cc
+++ b/spoor/instrumentation/spoor_opt.cc
@@ -28,7 +28,7 @@
 #include "llvm/Support/raw_ostream.h"
 #include "spoor/instrumentation/config/command_line_config.h"
 #include "spoor/instrumentation/config/config.h"
-#include "spoor/instrumentation/inject_runtime/inject_runtime.h"
+#include "spoor/instrumentation/inject_instrumentation/inject_instrumentation.h"
 #include "spoor/instrumentation/instrumentation.h"
 #include "spoor/instrumentation/support/support.h"
 #include "util/time/clock.h"
@@ -131,22 +131,24 @@ auto main(int argc, char** argv) -> int {
     function_blocklist = ReadLinesToSet(&file);
   }
 
-  spoor::instrumentation::inject_runtime::InjectRuntime inject_runtime{{
-      .inject_instrumentation = config.inject_instrumentation,
-      .instrumented_function_map_output_path =
-          config.instrumented_function_map_output_path,
-      .instrumented_function_map_output_stream =
-          std::move(instrumented_function_map_output_stream),
-      .system_clock = std::move(system_clock),
-      .function_allow_list = std::move(function_allow_list),
-      .function_blocklist = std::move(function_blocklist),
-      .module_id = config.module_id,
-      .min_instruction_count_to_instrument = config.min_instruction_threshold,
-      .initialize_runtime = config.initialize_runtime,
-      .enable_runtime = config.enable_runtime,
-  }};
+  spoor::instrumentation::inject_instrumentation::InjectInstrumentation
+      inject_instrumentation{{
+          .inject_instrumentation = config.inject_instrumentation,
+          .instrumented_function_map_output_path =
+              config.instrumented_function_map_output_path,
+          .instrumented_function_map_output_stream =
+              std::move(instrumented_function_map_output_stream),
+          .system_clock = std::move(system_clock),
+          .function_allow_list = std::move(function_allow_list),
+          .function_blocklist = std::move(function_blocklist),
+          .module_id = config.module_id,
+          .min_instruction_count_to_instrument =
+              config.min_instruction_threshold,
+          .initialize_runtime = config.initialize_runtime,
+          .enable_runtime = config.enable_runtime,
+      }};
   llvm::ModuleAnalysisManager module_analysis_manager{};
-  inject_runtime.run(*llvm_module, module_analysis_manager);
+  inject_instrumentation.run(*llvm_module, module_analysis_manager);
 
   std::error_code create_ostream_error{};
   llvm::raw_fd_ostream ostream{config.output_file, create_ostream_error};

--- a/toolchain/style/clang_tidy.sh
+++ b/toolchain/style/clang_tidy.sh
@@ -2,8 +2,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-# TODO
-# set -e
+set -e
 
 WORKSPACE="$(bazel info workspace)"
 

--- a/util/compression/compressor_test.cc
+++ b/util/compression/compressor_test.cc
@@ -47,7 +47,7 @@ TEST(Compressor, CompressorFactory) {  // NOLINT
 
 TEST(Compressor, CompressesAndUncompressesData) {  // NOLINT
   for (auto& compressor : MakeCompressors(0)) {
-    for (const auto original_data : kTestData) {
+    for (const auto& original_data : kTestData) {
       const gsl::span<const char> original_span{original_data.data(),
                                                 original_data.size()};
       auto const compress_result =
@@ -67,7 +67,7 @@ TEST(Compressor, CompressesAndUncompressesData) {  // NOLINT
 
 TEST(NoneCompressor, CompressedIsUncompressed) {  // NOLINT
   NoneCompressor compressor{};
-  for (const auto original_data : kTestData) {
+  for (const auto& original_data : kTestData) {
     const gsl::span<const char> original_span{original_data.data(),
                                               original_data.size()};
     const auto compressed_result =
@@ -84,7 +84,7 @@ TEST(SnappyCompressor, CompressesData) {  // NOLINT
   constexpr std::string_view abc{"abcabcabcabcabcabcabcabcabcabcabcabc"};
   constexpr std::string_view x{"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"};
   SnappyCompressor compressor{0};
-  for (const auto original_data : {abc, x}) {
+  for (const auto& original_data : {abc, x}) {
     const auto compressed_result =
         compressor.Compress({original_data.data(), original_data.size()});
     ASSERT_TRUE(compressed_result.IsOk());


### PR DESCRIPTION
* Changes `urls` to `url` in the WORKSPACE for `http_archive`s with only one URL.
* Fixes some loop iterations to use which improves efficiency.
* Renames "inject runtime" to "inject instrumentation" which is more accurate.
* README.md documentation update.
* Fixes `clang_tidy.sh` by returning it to a failable state.