### PR TITLE
C++ runtime API

### DIFF
--- a/spoor/runtime/BUILD
+++ b/spoor/runtime/BUILD
@@ -73,6 +73,8 @@ cc_test(
     visibility = ["//visibility:private"],
     deps = [
         ":runtime_stub",
+        "@com_google_absl//absl/synchronization",
+        "@com_google_absl//absl/time",
         "@com_google_googletest//:gtest_main",
         "@com_microsoft_gsl//:gsl",
     ],

--- a/spoor/runtime/runtime.cc
+++ b/spoor/runtime/runtime.cc
@@ -10,6 +10,7 @@
 #include <cstddef>
 #include <filesystem>
 #include <system_error>
+#include <thread>
 #include <type_traits>
 #include <utility>
 
@@ -27,18 +28,31 @@
 #include "util/numeric.h"
 #include "util/time/clock.h"
 
+namespace spoor::runtime {
+
+static_assert(std::is_same_v<DurationNanoseconds, trace::DurationNanoseconds>);
+static_assert(std::is_same_v<EventType, trace::EventType>);
+static_assert(std::is_same_v<FunctionId, trace::FunctionId>);
+static_assert(std::is_same_v<SessionId, trace::SessionId>);
+static_assert(
+    std::is_same_v<TimestampNanoseconds, trace::TimestampNanoseconds>);
+
+static_assert(
+    std::is_same_v<DurationNanoseconds, _spoor_runtime_DurationNanoseconds>);
+static_assert(std::is_same_v<EventType, _spoor_runtime_EventType>);
+static_assert(std::is_same_v<FunctionId, _spoor_runtime_FunctionId>);
+static_assert(std::is_same_v<SessionId, _spoor_runtime_SessionId>);
+static_assert(std::is_same_v<SizeType, _spoor_runtime_SessionId>);
+static_assert(std::is_same_v<SystemTimestampSeconds,
+                             _spoor_runtime_SystemTimestampSeconds>);
+static_assert(
+    std::is_same_v<TimestampNanoseconds, _spoor_runtime_TimestampNanoseconds>);
+
+}  // namespace spoor::runtime
+
 namespace {
 
 using spoor::runtime::runtime_manager::RuntimeManager;
-
-static_assert(
-    std::is_same_v<_spoor_runtime_EventType, spoor::runtime::trace::EventType>);
-static_assert(std::is_same_v<_spoor_runtime_FunctionId,
-                             spoor::runtime::trace::FunctionId>);
-static_assert(
-    std::is_same_v<_spoor_runtime_SessionId, spoor::runtime::trace::SessionId>);
-static_assert(std::is_same_v<_spoor_runtime_TimestampNanoseconds,
-                             spoor::runtime::trace::TimestampNanoseconds>);
 
 // NOLINTNEXTLINE(fuchsia-statically-constructed-objects)
 const auto kConfig = spoor::runtime::config::Config::FromEnv();
@@ -89,19 +103,126 @@ RuntimeManager runtime_{
 
 }  // namespace
 
-auto _spoor_runtime_InitializeRuntime() -> void { runtime_.Initialize(); }
+namespace spoor::runtime {
 
-auto _spoor_runtime_DeinitializeRuntime() -> void { runtime_.Deinitialize(); }
+auto Initialize() -> void { runtime_.Initialize(); }
 
-auto _spoor_runtime_RuntimeInitialized() -> bool {
-  return runtime_.Initialized();
+auto Deinitialize() -> void { runtime_.Deinitialize(); }
+
+auto Initialized() -> bool { return runtime_.Initialized(); }
+
+auto Enable() -> void { runtime_.Enable(); }
+
+auto Disable() -> void { runtime_.Disable(); }
+
+auto Enabled() -> bool { return runtime_.Enabled(); }
+
+auto LogEvent(const EventType event,
+              const TimestampNanoseconds steady_clock_timestamp,
+              const uint64_t payload_1, const uint64_t payload_2) -> void {
+  runtime_.LogEvent(event, steady_clock_timestamp, payload_1, payload_2);
 }
 
-auto _spoor_runtime_EnableRuntime() -> void { runtime_.Enable(); }
+auto LogEvent(const EventType event, const uint64_t payload_1,
+              const uint64_t payload_2) -> void {
+  runtime_.LogEvent(event, payload_1, payload_2);
+}
 
-auto _spoor_runtime_DisableRuntime() -> void { runtime_.Disable(); }
+auto LogFunctionEntry(const FunctionId function_id) -> void {
+  runtime_.LogFunctionEntry(function_id);
+}
 
-auto _spoor_runtime_RuntimeEnabled() -> bool { return runtime_.Enabled(); }
+auto LogFunctionExit(const FunctionId function_id) -> void {
+  runtime_.LogFunctionExit(function_id);
+}
+
+auto FlushTraceEvents(std::function<void()> callback) -> void {
+  runtime_.Flush(std::move(callback));
+}
+
+auto ClearTraceEvents() -> void { runtime_.Clear(); }
+
+auto FlushedTraceFiles(
+    std::function<void(std::vector<std::filesystem::path>)> callback) -> void {
+  std::error_code error{};
+  const std::filesystem::directory_iterator directory{kConfig.trace_file_path,
+                                                      error};
+  if (error) {
+    if (callback != nullptr) {
+      std::thread{std::move(callback), std::vector<std::filesystem::path>{}}
+          .detach();
+    }
+    return;
+  }
+  RuntimeManager::FlushedTraceFiles(std::filesystem::begin(directory),
+                                    std::filesystem::end(directory),
+                                    &trace_reader_, std::move(callback));
+}
+
+auto DeleteFlushedTraceFilesOlderThan(
+    const SystemTimestampSeconds system_timestamp_seconds,
+    std::function<void(DeletedFilesInfo)> callback) -> void {
+  auto callback_adapter =
+      [callback{std::move(callback)}](
+          const RuntimeManager::DeletedFilesInfo deleted_files_info) {
+        if (callback == nullptr) return;
+        callback({.deleted_files = deleted_files_info.deleted_files,
+                  .deleted_bytes = deleted_files_info.deleted_bytes});
+      };
+
+  std::error_code error{};
+  const std::filesystem::directory_iterator directory{kConfig.trace_file_path,
+                                                      error};
+  if (error) {
+    std::thread{std::move(callback_adapter),
+                RuntimeManager::DeletedFilesInfo{.deleted_files = 0,
+                                                 .deleted_bytes = 0}}
+        .detach();
+    return;
+  }
+  const auto system_timestamp =
+      std::chrono::time_point<std::chrono::system_clock>{
+          std::chrono::seconds{system_timestamp_seconds}};
+  RuntimeManager::DeleteFlushedTraceFilesOlderThan(
+      system_timestamp, std::filesystem::begin(directory),
+      std::filesystem::end(directory), &file_system_, &trace_reader_,
+      std::move(callback_adapter));
+}
+
+auto GetConfig() -> Config {
+  return {.trace_file_path = kConfig.trace_file_path,
+          .session_id = kConfig.session_id,
+          .thread_event_buffer_capacity = kConfig.thread_event_buffer_capacity,
+          .max_reserved_event_buffer_slice_capacity =
+              kConfig.max_reserved_event_buffer_slice_capacity,
+          .max_dynamic_event_buffer_slice_capacity =
+              kConfig.max_dynamic_event_buffer_slice_capacity,
+          .reserved_event_pool_capacity = kConfig.reserved_event_pool_capacity,
+          .dynamic_event_pool_capacity = kConfig.dynamic_event_pool_capacity,
+          .dynamic_event_slice_borrow_cas_attempts =
+              kConfig.dynamic_event_slice_borrow_cas_attempts,
+          .event_buffer_retention_duration_nanoseconds =
+              kConfig.event_buffer_retention_duration_nanoseconds,
+          .max_flush_buffer_to_file_attempts =
+              kConfig.max_flush_buffer_to_file_attempts,
+          .flush_all_events = kConfig.flush_all_events};
+}
+
+auto StubImplementation() -> bool { return false; }
+
+}  // namespace spoor::runtime
+
+auto _spoor_runtime_Initialize() -> void { runtime_.Initialize(); }
+
+auto _spoor_runtime_Deinitialize() -> void { runtime_.Deinitialize(); }
+
+auto _spoor_runtime_Initialized() -> bool { return runtime_.Initialized(); }
+
+auto _spoor_runtime_Enable() -> void { runtime_.Enable(); }
+
+auto _spoor_runtime_Disable() -> void { runtime_.Disable(); }
+
+auto _spoor_runtime_Enabled() -> bool { return runtime_.Enabled(); }
 
 auto _spoor_runtime_LogEventWithTimestamp(
     const _spoor_runtime_EventType event,
@@ -135,7 +256,7 @@ auto _spoor_runtime_ClearTraceEvents() -> void { runtime_.Clear(); }
 
 auto _spoor_runtime_FlushedTraceFiles(
     const _spoor_runtime_FlushedTraceFilesCallback callback) -> void {
-  const auto callback_adapter =
+  auto callback_adapter =
       [callback](const std::vector<std::filesystem::path>& trace_file_paths) {
         if (callback == nullptr) return;
         gsl::span<char*> file_paths{
@@ -168,31 +289,35 @@ auto _spoor_runtime_FlushedTraceFiles(
   const std::filesystem::directory_iterator directory{kConfig.trace_file_path,
                                                       error};
   if (error) {
-    callback_adapter({});
+    std::thread{std::move(callback_adapter),
+                std::vector<std::filesystem::path>{}}
+        .detach();
     return;
   }
-  RuntimeManager::FlushedTraceFiles(std::filesystem::begin(directory),
-                                    std::filesystem::end(directory),
-                                    &trace_reader_, callback_adapter);
+  RuntimeManager::FlushedTraceFiles(
+      std::filesystem::begin(directory), std::filesystem::end(directory),
+      &trace_reader_, std::move(callback_adapter));
 }
 
 auto _spoor_runtime_DeleteFlushedTraceFilesOlderThan(
     const _spoor_runtime_SystemTimestampSeconds system_timestamp_seconds,
     const _spoor_runtime_DeleteFlushedTraceFilesCallback callback) -> void {
-  const auto callback_adapter =
-      [callback](const RuntimeManager::DeletedFilesInfo deleted_files_info) {
+  auto callback_adapter =
+      [callback](const RuntimeManager::DeletedFilesInfo& deleted_files_info) {
         if (callback == nullptr) return;
         callback(_spoor_runtime_DeletedFilesInfo{
             .deleted_files = deleted_files_info.deleted_files,
             .deleted_bytes = deleted_files_info.deleted_bytes});
       };
 
-  std::error_code error_code{};
+  std::error_code error{};
   const std::filesystem::directory_iterator directory{kConfig.trace_file_path,
-                                                      error_code};
-  const auto error = static_cast<bool>(error_code);
+                                                      error};
   if (error) {
-    callback_adapter({.deleted_bytes = 0, .deleted_files = 0});
+    std::thread{std::move(callback_adapter),
+                RuntimeManager::DeletedFilesInfo{.deleted_files = 0,
+                                                 .deleted_bytes = 0}}
+        .detach();
     return;
   }
   const auto system_timestamp =
@@ -201,7 +326,7 @@ auto _spoor_runtime_DeleteFlushedTraceFilesOlderThan(
   RuntimeManager::DeleteFlushedTraceFilesOlderThan(
       system_timestamp, std::filesystem::begin(directory),
       std::filesystem::end(directory), &file_system_, &trace_reader_,
-      callback_adapter);
+      std::move(callback_adapter));
 }
 
 auto _spoor_runtime_GetConfig() -> _spoor_runtime_Config {

--- a/spoor/runtime/runtime.h
+++ b/spoor/runtime/runtime.h
@@ -1,14 +1,126 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#ifndef SPOOR_RUNTIME
-#define SPOOR_RUNTIME
+// This header provides C++ and C APIs to interface with Spoor's runtime engine.
+
+#ifndef SPOOR_RUNTIME_RUNTIME_H_
+#define SPOOR_RUNTIME_RUNTIME_H_
 
 #ifdef __cplusplus
 #include <cstdint>
-extern "C" {
+#include <filesystem>
+#include <functional>
+#include <vector>
 #else
 #include <stdint.h>
+#endif
+
+// C++ API
+
+#ifdef __cplusplus
+namespace spoor::runtime {
+
+using DurationNanoseconds = int64_t;
+using EventType = uint32_t;
+using FunctionId = uint64_t;
+using SessionId = uint64_t;
+using SizeType = uint64_t;
+using SystemTimestampSeconds = int64_t;
+using TimestampNanoseconds = int64_t;
+
+struct DeletedFilesInfo {
+  int32_t deleted_files;
+  int64_t deleted_bytes;
+};
+
+struct Config {
+  std::filesystem::path trace_file_path;
+  SessionId session_id;
+  SizeType thread_event_buffer_capacity;
+  SizeType max_reserved_event_buffer_slice_capacity;
+  SizeType max_dynamic_event_buffer_slice_capacity;
+  SizeType reserved_event_pool_capacity;
+  SizeType dynamic_event_pool_capacity;
+  SizeType dynamic_event_slice_borrow_cas_attempts;
+  DurationNanoseconds event_buffer_retention_duration_nanoseconds;
+  int32_t max_flush_buffer_to_file_attempts;
+  bool flush_all_events;
+};
+
+// Initialize the event tracing runtime. A call to this function is inserted at
+// the start of `main` by the compile-time instrumentation unless configured
+// otherwise.
+auto Initialize() -> void;
+
+// Deinitialize the event tracing runtime. A call to this function is inserted
+// at the  end of `main` by the compile-time instrumentation.
+auto Deinitialize() -> void;
+
+// Check if the runtime engine is initialized.
+auto Initialized() -> bool;
+
+// Enable runtime logging.
+auto Enable() -> void;
+
+// Disable runtime logging.
+auto Disable() -> void;
+
+// Check if runtime logging is enabled.
+auto Enabled() -> bool;
+
+// Log that the program generated an event. The function internally checks if
+// the runtime is enabled before logging the event.
+auto LogEvent(EventType event, TimestampNanoseconds steady_clock_timestamp,
+              uint64_t payload_1, uint64_t payload_2) -> void;
+
+// Log that the program generated an event. The function internally checks if
+// the runtime is enabled before collecting the current timestamp and logging
+// the event.
+auto LogEvent(EventType event, uint64_t payload_1, uint64_t payload_2) -> void;
+
+// Log that the program entered a function. The function internally checks if
+// the runtime is enabled before collecting the current timestamp and logging
+// the event. A call to this function is inserted at the start of every function
+// by the compile-time instrumentation.
+auto LogFunctionEntry(FunctionId function_id) -> void;
+
+// Log that the program exited a function. The function internally checks if the
+// runtime is enabled before collecting the current timestamp and logging the
+// event. A call to this function is inserted at the end of every function by
+// the compile-time instrumentation.
+auto LogFunctionExit(FunctionId function_id) -> void;
+
+// Flush in-memory trace events to disk. The callback is invoked on a background
+// thread.
+auto FlushTraceEvents(std::function<void()> callback) -> void;
+
+// Clear the trace events from memory without flushing them to disk.
+auto ClearTraceEvents() -> void;
+
+// Retrieve an array of all trace files on disk. The callback is invoked on a
+// background thread.
+auto FlushedTraceFiles(
+    std::function<void(std::vector<std::filesystem::path>)> callback) -> void;
+
+// Delete all trace files older than a given timestamp. The callback is invoked
+// on a background thread.
+auto DeleteFlushedTraceFilesOlderThan(
+    SystemTimestampSeconds system_timestamp,
+    std::function<void(DeletedFilesInfo)> callback) -> void;
+
+// Retrieve Spoor's configuration.
+auto GetConfig() -> Config;
+
+// Check if the runtime contains stub implementations.
+auto StubImplementation() -> bool;
+
+}  // namespace spoor::runtime
+#endif  // __cplusplus
+
+// C API
+
+#ifdef __cplusplus
+extern "C" {
 #endif
 
 typedef int64_t _spoor_runtime_DurationNanoseconds;
@@ -58,23 +170,23 @@ typedef void (*_spoor_runtime_DeleteFlushedTraceFilesCallback)(
 // Initialize the event tracing runtime. A call to this function is inserted at
 // the start of `main` by the compile-time instrumentation unless configured
 // otherwise.
-void _spoor_runtime_InitializeRuntime();
+void _spoor_runtime_Initialize();
 
 // Deinitialize the event tracing runtime. A call to this function is inserted
 // at the  end of `main` by the compile-time instrumentation.
-void _spoor_runtime_DeinitializeRuntime();
+void _spoor_runtime_Deinitialize();
 
-// Check if the event tracing runtime is initialized.
-bool _spoor_runtime_RuntimeInitialized();
+// Check if the runtime engine is initialized.
+bool _spoor_runtime_Initialized();
 
 // Enable runtime logging.
-void _spoor_runtime_EnableRuntime();
+void _spoor_runtime_Enable();
 
 // Disable runtime logging.
-void _spoor_runtime_DisableRuntime();
+void _spoor_runtime_Disable();
 
 // Check if runtime logging is enabled.
-bool _spoor_runtime_RuntimeEnabled();
+bool _spoor_runtime_Enabled();
 
 // Log that the program generated an event. The function internally checks if
 // the runtime is enabled before logging the event.
@@ -101,18 +213,22 @@ void _spoor_runtime_LogFunctionEntry(_spoor_runtime_FunctionId function_id);
 // the compile-time instrumentation.
 void _spoor_runtime_LogFunctionExit(_spoor_runtime_FunctionId function_id);
 
-// Flush in-memory trace events to disk.
+// Flush in-memory trace events to disk. The callback is invoked on a background
+// thread.
 void _spoor_runtime_FlushTraceEvents(
     _spoor_runtime_FlushTraceEventsCallback callback);
 
-// Clear the trace events from memory without flushing them to disk.
+// Clear the trace events from memory without flushing them to disk. The
+// callback is invoked on a background thread;
 void _spoor_runtime_ClearTraceEvents();
 
-// Retrieve an array of all trace files on disk.
+// Retrieve an array of all trace files on disk. The callback is invoked on a
+// background thread.
 void _spoor_runtime_FlushedTraceFiles(
     _spoor_runtime_FlushedTraceFilesCallback callback);
 
-// Delete all trace files older than a given timestamp.
+// Delete all trace files older than a given timestamp. The callback is invoked
+// on a background thread;
 void _spoor_runtime_DeleteFlushedTraceFilesOlderThan(
     _spoor_runtime_SystemTimestampSeconds system_timestamp,
     _spoor_runtime_DeleteFlushedTraceFilesCallback callback);
@@ -129,7 +245,7 @@ bool _spoor_runtime_StubImplementation();
 void _spoor_runtime_ReleaseTraceFilePaths(
     _spoor_runtime_TraceFiles* trace_files);
 
-// Struct equality.
+// Equality.
 // Implemented in the stub.
 bool _spoor_runtime_DeletedFilesInfoEqual(
     const _spoor_runtime_DeletedFilesInfo* lhs,
@@ -138,11 +254,21 @@ bool _spoor_runtime_TraceFilesEqual(const _spoor_runtime_TraceFiles* lhs,
                                     const _spoor_runtime_TraceFiles* rhs);
 bool _spoor_runtime_ConfigEqual(const _spoor_runtime_Config* lhs,
                                 const _spoor_runtime_Config* rhs);
-
 #ifdef __cplusplus
-}
+}  // extern "C"
+#endif
 
+// Equality.
 // Implemented in the stub.
+#ifdef __cplusplus
+namespace spoor::runtime {
+
+auto operator==(const DeletedFilesInfo& lhs, const DeletedFilesInfo& rhs)
+    -> bool;
+auto operator==(const Config& lhs, const Config& rhs) -> bool;
+
+}  // namespace spoor::runtime
+
 auto operator==(const _spoor_runtime_DeletedFilesInfo& lhs,
                 const _spoor_runtime_DeletedFilesInfo& rhs) -> bool;
 auto operator==(const _spoor_runtime_TraceFiles& lhs,
@@ -151,4 +277,4 @@ auto operator==(const _spoor_runtime_Config& lhs,
                 const _spoor_runtime_Config& rhs) -> bool;
 #endif
 
-#endif
+#endif  // SPOOR_RUNTIME_RUNTIME_H_

--- a/spoor/runtime/runtime_common.cc
+++ b/spoor/runtime/runtime_common.cc
@@ -89,6 +89,35 @@ auto _spoor_runtime_ConfigEqual(const _spoor_runtime_Config* lhs,
          lhs->flush_all_events == rhs->flush_all_events;
 }
 
+namespace spoor::runtime {
+
+auto operator==(const DeletedFilesInfo& lhs, const DeletedFilesInfo& rhs)
+    -> bool {
+  return lhs.deleted_files == rhs.deleted_files &&
+         lhs.deleted_bytes == rhs.deleted_bytes;
+}
+
+auto operator==(const Config& lhs, const Config& rhs) -> bool {
+  return lhs.trace_file_path == rhs.trace_file_path &&
+         lhs.session_id == rhs.session_id &&
+         lhs.thread_event_buffer_capacity == rhs.thread_event_buffer_capacity &&
+         lhs.max_reserved_event_buffer_slice_capacity ==
+             rhs.max_reserved_event_buffer_slice_capacity &&
+         lhs.max_dynamic_event_buffer_slice_capacity ==
+             rhs.max_dynamic_event_buffer_slice_capacity &&
+         lhs.reserved_event_pool_capacity == rhs.reserved_event_pool_capacity &&
+         lhs.dynamic_event_pool_capacity == rhs.dynamic_event_pool_capacity &&
+         lhs.dynamic_event_slice_borrow_cas_attempts ==
+             rhs.dynamic_event_slice_borrow_cas_attempts &&
+         lhs.event_buffer_retention_duration_nanoseconds ==
+             rhs.event_buffer_retention_duration_nanoseconds &&
+         lhs.max_flush_buffer_to_file_attempts ==
+             rhs.max_flush_buffer_to_file_attempts &&
+         lhs.flush_all_events == rhs.flush_all_events;
+}
+
+}  // namespace spoor::runtime
+
 auto operator==(const _spoor_runtime_DeletedFilesInfo& lhs,
                 const _spoor_runtime_DeletedFilesInfo& rhs) -> bool {
   return _spoor_runtime_DeletedFilesInfoEqual(&lhs, &rhs);

--- a/spoor/runtime/runtime_common_test.cc
+++ b/spoor/runtime/runtime_common_test.cc
@@ -110,10 +110,25 @@ TEST(Runtime, DeletedFilesInfoEquality) {  // NOLINT
   ASSERT_EQ(info_a, info_a);
   ASSERT_EQ(info_a, info_b);
   ASSERT_NE(info_a, info_c);
+
+  constexpr spoor::runtime::DeletedFilesInfo info_1{.deleted_files = 1,
+                                                    .deleted_bytes = 2};
+  constexpr spoor::runtime::DeletedFilesInfo info_2{.deleted_files = 1,
+                                                    .deleted_bytes = 2};
+  constexpr spoor::runtime::DeletedFilesInfo info_3{.deleted_files = 0,
+                                                    .deleted_bytes = 0};
+  ASSERT_EQ(info_1, info_1);
+  ASSERT_EQ(info_1, info_2);
+  ASSERT_NE(info_1, info_3);
 }
 
 TEST(Runtime, ConfigEquality) {  // NOLINT
   constexpr std::string_view path_a{"/path/to/file"};
+  constexpr std::string_view path_c{"/path/to/file"};
+  constexpr std::string_view path_d{"xxxxxxxxxxxxx"};
+  ASSERT_EQ(path_a, path_c);
+  ASSERT_EQ(path_a.size(), path_d.size());
+
   constexpr _spoor_runtime_Config config_a{
       .trace_file_path_size = path_a.size(),
       .trace_file_path = path_a.data(),
@@ -140,8 +155,6 @@ TEST(Runtime, ConfigEquality) {  // NOLINT
       .event_buffer_retention_duration_nanoseconds = 8,
       .max_flush_buffer_to_file_attempts = 9,
       .flush_all_events = true};
-  constexpr std::string_view path_c{"/path/to/file"};
-  ASSERT_EQ(path_a, path_c);
   constexpr _spoor_runtime_Config config_c{
       .trace_file_path_size = path_c.size(),
       .trace_file_path = path_c.data(),
@@ -155,8 +168,6 @@ TEST(Runtime, ConfigEquality) {  // NOLINT
       .event_buffer_retention_duration_nanoseconds = 8,
       .max_flush_buffer_to_file_attempts = 9,
       .flush_all_events = true};
-  constexpr std::string_view path_d{"xxxxxxxxxxxxx"};
-  ASSERT_EQ(path_a.size(), path_d.size());
   constexpr _spoor_runtime_Config config_d{
       .trace_file_path_size = path_d.size(),
       .trace_file_path = path_d.data(),
@@ -219,6 +230,72 @@ TEST(Runtime, ConfigEquality) {  // NOLINT
   ASSERT_NE(config_a, config_e);
   ASSERT_NE(config_a, malformed_config_f);
   ASSERT_NE(config_a, malformed_config_g);
+
+  const spoor::runtime::Config config_1{
+      .trace_file_path = path_a,
+      .session_id = 1,
+      .thread_event_buffer_capacity = 2,
+      .max_reserved_event_buffer_slice_capacity = 3,
+      .max_dynamic_event_buffer_slice_capacity = 4,
+      .reserved_event_pool_capacity = 5,
+      .dynamic_event_pool_capacity = 6,
+      .dynamic_event_slice_borrow_cas_attempts = 7,
+      .event_buffer_retention_duration_nanoseconds = 8,
+      .max_flush_buffer_to_file_attempts = 9,
+      .flush_all_events = true};
+  const spoor::runtime::Config config_2{
+      .trace_file_path = path_a,
+      .session_id = 1,
+      .thread_event_buffer_capacity = 2,
+      .max_reserved_event_buffer_slice_capacity = 3,
+      .max_dynamic_event_buffer_slice_capacity = 4,
+      .reserved_event_pool_capacity = 5,
+      .dynamic_event_pool_capacity = 6,
+      .dynamic_event_slice_borrow_cas_attempts = 7,
+      .event_buffer_retention_duration_nanoseconds = 8,
+      .max_flush_buffer_to_file_attempts = 9,
+      .flush_all_events = true};
+  const spoor::runtime::Config config_3{
+      .trace_file_path = path_c,
+      .session_id = 1,
+      .thread_event_buffer_capacity = 2,
+      .max_reserved_event_buffer_slice_capacity = 3,
+      .max_dynamic_event_buffer_slice_capacity = 4,
+      .reserved_event_pool_capacity = 5,
+      .dynamic_event_pool_capacity = 6,
+      .dynamic_event_slice_borrow_cas_attempts = 7,
+      .event_buffer_retention_duration_nanoseconds = 8,
+      .max_flush_buffer_to_file_attempts = 9,
+      .flush_all_events = true};
+  const spoor::runtime::Config config_4{
+      .trace_file_path = path_d,
+      .session_id = 1,
+      .thread_event_buffer_capacity = 2,
+      .max_reserved_event_buffer_slice_capacity = 3,
+      .max_dynamic_event_buffer_slice_capacity = 4,
+      .reserved_event_pool_capacity = 5,
+      .dynamic_event_pool_capacity = 6,
+      .dynamic_event_slice_borrow_cas_attempts = 7,
+      .event_buffer_retention_duration_nanoseconds = 8,
+      .max_flush_buffer_to_file_attempts = 9,
+      .flush_all_events = true};
+  const spoor::runtime::Config config_5{
+      .trace_file_path = path_a,
+      .session_id = 0,
+      .thread_event_buffer_capacity = 0,
+      .max_reserved_event_buffer_slice_capacity = 0,
+      .max_dynamic_event_buffer_slice_capacity = 0,
+      .reserved_event_pool_capacity = 0,
+      .dynamic_event_pool_capacity = 0,
+      .dynamic_event_slice_borrow_cas_attempts = 0,
+      .event_buffer_retention_duration_nanoseconds = 0,
+      .max_flush_buffer_to_file_attempts = 0,
+      .flush_all_events = false};
+  ASSERT_EQ(config_1, config_1);
+  ASSERT_EQ(config_1, config_2);
+  ASSERT_EQ(config_1, config_3);
+  ASSERT_NE(config_1, config_4);
+  ASSERT_NE(config_1, config_5);
 }
 
 }  // namespace

--- a/spoor/runtime/runtime_manager/runtime_manager.cc
+++ b/spoor/runtime/runtime_manager/runtime_manager.cc
@@ -133,14 +133,14 @@ auto RuntimeManager::LogFunctionExit(const trace::FunctionId function_id)
            function_id, 0);
 }
 
-auto RuntimeManager::Flush(const std::function<void()>& completion) -> void {
+auto RuntimeManager::Flush(std::function<void()> completion) -> void {
   {
     std::unique_lock lock{lock_};
     for (auto* event_logger : event_loggers_) {
       event_logger->Flush();
     }
   }
-  options_.flush_queue->Flush(completion);
+  options_.flush_queue->Flush(std::move(completion));
 }
 
 auto RuntimeManager::Clear() -> void {

--- a/spoor/runtime/runtime_manager/runtime_manager.h
+++ b/spoor/runtime/runtime_manager/runtime_manager.h
@@ -42,8 +42,8 @@ class RuntimeManager final : public event_logger::EventLoggerNotifier {
   };
 
   struct alignas(16) DeletedFilesInfo {
-    int64 deleted_bytes;
     int32 deleted_files;
+    int64 deleted_bytes;
   };
 
   RuntimeManager() = delete;
@@ -72,7 +72,7 @@ class RuntimeManager final : public event_logger::EventLoggerNotifier {
   auto LogFunctionEntry(trace::FunctionId function_id) -> void;
   auto LogFunctionExit(trace::FunctionId function_id) -> void;
 
-  auto Flush(const std::function<void()>& completion) -> void;
+  auto Flush(std::function<void()> completion) -> void;
   auto Clear() -> void;
 
   [[nodiscard]] auto Initialized() const -> bool;
@@ -129,7 +129,7 @@ auto RuntimeManager::DeleteFlushedTraceFilesOlderThan(
     std::function<void(DeletedFilesInfo)> completion) -> void {
   std::thread{[directory_begin, directory_end, file_system, trace_reader,
                timestamp, completion{std::move(completion)}] {
-    DeletedFilesInfo deleted_files_info{.deleted_bytes = 0, .deleted_files = 0};
+    DeletedFilesInfo deleted_files_info{.deleted_files = 0, .deleted_bytes = 0};
     for (auto file{directory_begin}; file != directory_end; ++file) {
       if (!trace_reader->MatchesTraceFileConvention(file->path())) {
         continue;

--- a/spoor/runtime/runtime_manager/runtime_manager_test.cc
+++ b/spoor/runtime/runtime_manager/runtime_manager_test.cc
@@ -322,14 +322,13 @@ TEST(RuntimeManager, DeleteFlushedTraceFilesOlderThan) {  // NOLINT
     const auto timestamp = make_timestamp(i) - 1'000;
 
     RuntimeManager::DeletedFilesInfo expected_deleted_files_info{
-        .deleted_bytes =
-            [&] {
-              // 2^0 + 2^1 + ... + 2^(n - 1) == 2^n - 1
-              const auto shift{static_cast<uint64>(
-                  std::min(std::max(i, 0), trace_files_size))};
-              return gsl::narrow_cast<int64>((1ULL << shift) - 1);
-            }(),
-        .deleted_files = std::max(0, std::min(i, trace_files_size))};
+        .deleted_files = std::max(0, std::min(i, trace_files_size)),
+        .deleted_bytes = [&] {
+          // 2^0 + 2^1 + ... + 2^(n - 1) == 2^n - 1
+          const auto shift{
+              static_cast<uint64>(std::min(std::max(i, 0), trace_files_size))};
+          return gsl::narrow_cast<int64>((1ULL << shift) - 1);
+        }()};
 
     MockFunction<void(RuntimeManager::DeletedFilesInfo)> callback{};
     absl::Notification done{};
@@ -346,12 +345,12 @@ TEST(RuntimeManager, DeleteFlushedTraceFilesOlderThan) {  // NOLINT
 }
 
 TEST(RuntimeManagerDeletedFilesInfo, Equality) {  // NOLINT
-  RuntimeManager::DeletedFilesInfo info_a{.deleted_bytes = 2,
-                                          .deleted_files = 1};
-  RuntimeManager::DeletedFilesInfo info_b{.deleted_bytes = 2,
-                                          .deleted_files = 1};
-  RuntimeManager::DeletedFilesInfo info_c{.deleted_bytes = 1,
-                                          .deleted_files = 2};
+  RuntimeManager::DeletedFilesInfo info_a{.deleted_files = 1,
+                                          .deleted_bytes = 2};
+  RuntimeManager::DeletedFilesInfo info_b{.deleted_files = 1,
+                                          .deleted_bytes = 2};
+  RuntimeManager::DeletedFilesInfo info_c{.deleted_files = 2,
+                                          .deleted_bytes = 1};
   ASSERT_EQ(info_a, info_b);
   ASSERT_NE(info_b, info_c);
 }

--- a/spoor/runtime/runtime_stub.cc
+++ b/spoor/runtime/runtime_stub.cc
@@ -1,28 +1,99 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#include <cstdint>
+#include <filesystem>
+#include <functional>
+#include <thread>
+#include <vector>
+
 #include "spoor/runtime/runtime.h"
 
-auto _spoor_runtime_InitializeRuntime() -> void {}
+namespace spoor::runtime {
 
-auto _spoor_runtime_DeinitializeRuntime() -> void {}
+auto Initialize() -> void {}
 
-auto _spoor_runtime_RuntimeInitialized() -> bool { return false; }
+auto Deinitialize() -> void {}
 
-auto _spoor_runtime_EnableRuntime() -> void {}
+auto Initialized() -> bool { return false; }
 
-auto _spoor_runtime_DisableRuntime() -> void {}
+auto Enable() -> void {}
 
-auto _spoor_runtime_RuntimeEnabled() -> bool { return false; }
+auto Disable() -> void {}
+
+auto Enabled() -> bool { return false; }
+
+auto LogEvent(const EventType /*unused*/, const TimestampNanoseconds /*unused*/,
+              const uint64_t /*unused*/, const uint64_t /*unused*/) -> void {}
+
+auto LogEvent(const EventType /*unused*/, const uint64_t /*unused*/,
+              const uint64_t /*unused*/) -> void {}
+
+auto LogFunctionEntry(const FunctionId /*unused*/) -> void {}
+
+auto LogFunctionExit(const FunctionId /*unused*/) -> void {}
+
+auto FlushTraceEvents(std::function<void()> callback) -> void {
+  if (callback == nullptr) return;
+  std::thread{std::move(callback)}.detach();
+}
+
+auto ClearTraceEvents() -> void {}
+
+auto FlushedTraceFiles(
+    std::function<void(std::vector<std::filesystem::path>)> callback) -> void {
+  if (callback == nullptr) return;
+  std::thread{std::move(callback), std::vector<std::filesystem::path>{}}
+      .detach();
+}
+
+auto DeleteFlushedTraceFilesOlderThan(
+    const SystemTimestampSeconds /*unused*/,
+    std::function<void(DeletedFilesInfo)> callback) -> void {
+  if (callback == nullptr) return;
+  std::thread{std::move(callback),
+              DeletedFilesInfo{.deleted_files = 0, .deleted_bytes = 0}}
+      .detach();
+}
+
+auto GetConfig() -> Config {
+  return {.trace_file_path = {},
+          .session_id = 0,
+          .thread_event_buffer_capacity = 0,
+          .max_reserved_event_buffer_slice_capacity = 0,
+          .max_dynamic_event_buffer_slice_capacity = 0,
+          .reserved_event_pool_capacity = 0,
+          .dynamic_event_pool_capacity = 0,
+          .dynamic_event_slice_borrow_cas_attempts = 0,
+          .event_buffer_retention_duration_nanoseconds = 0,
+          .max_flush_buffer_to_file_attempts = 0,
+          .flush_all_events = false};
+}
+
+auto StubImplementation() -> bool { return true; }
+
+}  // namespace spoor::runtime
+
+auto _spoor_runtime_Initialize() -> void {}
+
+auto _spoor_runtime_Deinitialize() -> void {}
+
+auto _spoor_runtime_Initialized() -> bool { return false; }
+
+auto _spoor_runtime_Enable() -> void {}
+
+auto _spoor_runtime_Disable() -> void {}
+
+auto _spoor_runtime_Enabled() -> bool { return false; }
 
 auto _spoor_runtime_LogEventWithTimestamp(
-    _spoor_runtime_EventType /*unused*/,
-    _spoor_runtime_TimestampNanoseconds /*unused*/, uint64_t /*unused*/,
-    uint32_t /*unused*/) -> void {}
+    const _spoor_runtime_EventType /*unused*/,
+    const _spoor_runtime_TimestampNanoseconds /*unused*/,
+    const uint64_t /*unused*/, const uint32_t /*unused*/) -> void {}
 
-auto _spoor_runtime_LogEvent(_spoor_runtime_EventType /*unused*/,
-                             uint64_t /*unused*/, uint32_t /*unused*/) -> void {
-}
+auto _spoor_runtime_LogEvent(const _spoor_runtime_EventType /*unused*/,
+                             const uint64_t /*unused*/,
+                             const uint32_t /*unused*/) -> void {}
 
 auto _spoor_runtime_LogFunctionEntry(const _spoor_runtime_FunctionId /*unused*/)
     -> void {}
@@ -32,25 +103,34 @@ auto _spoor_runtime_LogFunctionExit(const _spoor_runtime_FunctionId /*unused*/)
 
 auto _spoor_runtime_FlushTraceEvents(
     const _spoor_runtime_FlushTraceEventsCallback callback) -> void {
-  if (callback == nullptr) return;
-  callback();
+  auto callback_adapter = [callback]() {
+    if (callback == nullptr) return;
+    callback();
+  };
+  std::thread{std::move(callback_adapter)}.detach();
 }
 
 auto _spoor_runtime_ClearTraceEvents() -> void {}
 
 auto _spoor_runtime_FlushedTraceFiles(
     const _spoor_runtime_FlushedTraceFilesCallback callback) -> void {
-  if (callback == nullptr) return;
-  callback({.file_paths_size = 0,
-            .file_path_sizes = nullptr,
-            .file_paths = nullptr});
+  auto callback_adapter = [callback]() {
+    if (callback == nullptr) return;
+    callback({.file_paths_size = 0,
+              .file_path_sizes = nullptr,
+              .file_paths = nullptr});
+  };
+  std::thread{std::move(callback_adapter)}.detach();
 }
 
 auto _spoor_runtime_DeleteFlushedTraceFilesOlderThan(
     const _spoor_runtime_SystemTimestampSeconds /*unused*/,
     const _spoor_runtime_DeleteFlushedTraceFilesCallback callback) -> void {
-  if (callback == nullptr) return;
-  callback({.deleted_files = 0, .deleted_bytes = 0});
+  auto callback_adapter = [callback]() {
+    if (callback == nullptr) return;
+    callback({.deleted_files = 0, .deleted_bytes = 0});
+  };
+  std::thread{std::move(callback_adapter)}.detach();
 }
 
 auto _spoor_runtime_GetConfig() -> _spoor_runtime_Config {

--- a/spoor/runtime/runtime_stub_test.cc
+++ b/spoor/runtime/runtime_stub_test.cc
@@ -3,6 +3,8 @@
 
 #include <limits>
 
+#include "absl/synchronization/notification.h"
+#include "absl/time/time.h"
 #include "gmock/gmock.h"
 #include "gsl/gsl"
 #include "gtest/gtest.h"
@@ -12,20 +14,38 @@ namespace {
 
 using testing::MockFunction;
 
+constexpr absl::Duration kNotificationTimeout{absl::Milliseconds(1'000)};
+
+ACTION_P(Notify, notification) {  // NOLINT
+  notification->Notify();
+}
+
 TEST(Runtime, Initialize) {  // NOLINT
-  ASSERT_FALSE(_spoor_runtime_RuntimeInitialized());
-  _spoor_runtime_InitializeRuntime();
-  ASSERT_FALSE(_spoor_runtime_RuntimeInitialized());
-  _spoor_runtime_DeinitializeRuntime();
-  ASSERT_FALSE(_spoor_runtime_RuntimeInitialized());
+  ASSERT_FALSE(_spoor_runtime_Initialized());
+  _spoor_runtime_Initialize();
+  ASSERT_FALSE(_spoor_runtime_Initialized());
+  _spoor_runtime_Deinitialize();
+  ASSERT_FALSE(_spoor_runtime_Initialized());
+
+  ASSERT_FALSE(spoor::runtime::Initialized());
+  spoor::runtime::Initialize();
+  ASSERT_FALSE(spoor::runtime::Initialized());
+  spoor::runtime::Deinitialize();
+  ASSERT_FALSE(spoor::runtime::Initialized());
 }
 
 TEST(Runtime, Enable) {  // NOLINT
-  ASSERT_FALSE(_spoor_runtime_RuntimeEnabled());
-  _spoor_runtime_EnableRuntime();
-  ASSERT_FALSE(_spoor_runtime_RuntimeEnabled());
-  _spoor_runtime_DisableRuntime();
-  ASSERT_FALSE(_spoor_runtime_RuntimeEnabled());
+  ASSERT_FALSE(_spoor_runtime_Enabled());
+  _spoor_runtime_Enable();
+  ASSERT_FALSE(_spoor_runtime_Enabled());
+  _spoor_runtime_Disable();
+  ASSERT_FALSE(_spoor_runtime_Enabled());
+
+  ASSERT_FALSE(spoor::runtime::Enabled());
+  spoor::runtime::Enable();
+  ASSERT_FALSE(spoor::runtime::Enabled());
+  spoor::runtime::Disable();
+  ASSERT_FALSE(spoor::runtime::Enabled());
 }
 
 TEST(Runtime, LogEvent) {  // NOLINT
@@ -33,6 +53,11 @@ TEST(Runtime, LogEvent) {  // NOLINT
   _spoor_runtime_LogEvent(1, 2, 3);
   _spoor_runtime_LogFunctionEntry(1);
   _spoor_runtime_LogFunctionExit(1);
+
+  spoor::runtime::LogEvent(1, 2, 3, 4);
+  spoor::runtime::LogEvent(1, 2, 3);
+  spoor::runtime::LogFunctionEntry(1);
+  spoor::runtime::LogFunctionExit(1);
 }
 
 namespace flush_trace_events_test {
@@ -42,17 +67,35 @@ std::function<void()> callback_{};
 
 TEST(Runtime, FlushTraceEvents) {  // NOLINT
   _spoor_runtime_FlushTraceEvents({});
+  spoor::runtime::FlushTraceEvents({});
 
-  MockFunction<void()> callback{};
-  callback_ = callback.AsStdFunction();
-  EXPECT_CALL(callback, Call());
-  _spoor_runtime_FlushTraceEvents([] { callback_(); });
+  {
+    MockFunction<void()> callback{};
+    absl::Notification done{};
+    callback_ = callback.AsStdFunction();
+    EXPECT_CALL(callback, Call()).WillOnce(Notify(&done));
+    _spoor_runtime_FlushTraceEvents([] { callback_(); });
+    const auto success =
+        done.WaitForNotificationWithTimeout(kNotificationTimeout);
+    ASSERT_TRUE(success);
+  }
+  {
+    MockFunction<void()> callback{};
+    absl::Notification done{};
+    EXPECT_CALL(callback, Call()).WillOnce(Notify(&done));
+    spoor::runtime::FlushTraceEvents(callback.AsStdFunction());
+    const auto success =
+        done.WaitForNotificationWithTimeout(kNotificationTimeout);
+    ASSERT_TRUE(success);
+  }
 }
 
 }  // namespace flush_trace_events_test
 
 TEST(Runtime, ClearTraceEvents) {  // NOLINT
   _spoor_runtime_ClearTraceEvents();
+
+  spoor::runtime::ClearTraceEvents();
 }
 
 namespace flushed_trace_files_test {
@@ -62,14 +105,33 @@ std::function<void(_spoor_runtime_TraceFiles)> callback_{};
 
 TEST(Runtime, FlushedTraceFiles) {  // NOLINT
   _spoor_runtime_FlushedTraceFiles({});
+  spoor::runtime::FlushedTraceFiles({});
 
-  constexpr _spoor_runtime_TraceFiles expected_trace_files{
-      .file_paths_size = 0, .file_path_sizes = nullptr, .file_paths = nullptr};
-  MockFunction<void(_spoor_runtime_TraceFiles)> callback{};
-  callback_ = callback.AsStdFunction();
-  EXPECT_CALL(callback, Call(expected_trace_files));
-  _spoor_runtime_FlushedTraceFiles(
-      [](auto trace_files) { callback_(trace_files); });
+  {
+    MockFunction<void(_spoor_runtime_TraceFiles)> callback{};
+    absl::Notification done{};
+    constexpr _spoor_runtime_TraceFiles expected_trace_files{
+        .file_paths_size = 0,
+        .file_path_sizes = nullptr,
+        .file_paths = nullptr};
+    callback_ = callback.AsStdFunction();
+    EXPECT_CALL(callback, Call(expected_trace_files)).WillOnce(Notify(&done));
+    _spoor_runtime_FlushedTraceFiles(
+        [](auto trace_files) { callback_(trace_files); });
+    const auto success =
+        done.WaitForNotificationWithTimeout(kNotificationTimeout);
+    ASSERT_TRUE(success);
+  }
+  {
+    MockFunction<void(std::vector<std::filesystem::path>)> callback{};
+    absl::Notification done{};
+    const std::vector<std::filesystem::path> expected_trace_files{};
+    EXPECT_CALL(callback, Call(expected_trace_files)).WillOnce(Notify(&done));
+    spoor::runtime::FlushedTraceFiles(callback.AsStdFunction());
+    const auto success =
+        done.WaitForNotificationWithTimeout(kNotificationTimeout);
+    ASSERT_TRUE(success);
+  }
 }
 
 }  // namespace flushed_trace_files_test
@@ -82,38 +144,81 @@ std::function<void(_spoor_runtime_DeletedFilesInfo)> callback_{};
 TEST(Runtime, DeleteFlushedTraceFilesOlderThan) {  // NOLINT
   _spoor_runtime_DeleteFlushedTraceFilesOlderThan(
       std::numeric_limits<_spoor_runtime_SystemTimestampSeconds>::min(), {});
+  spoor::runtime::DeleteFlushedTraceFilesOlderThan(
+      std::numeric_limits<_spoor_runtime_SystemTimestampSeconds>::min(), {});
 
-  constexpr _spoor_runtime_DeletedFilesInfo expected_deleted_files_info{
-      .deleted_files = 0, .deleted_bytes = 0};
-  MockFunction<void(_spoor_runtime_DeletedFilesInfo)> callback{};
-  callback_ = callback.AsStdFunction();
-  EXPECT_CALL(callback, Call(expected_deleted_files_info));
-  _spoor_runtime_DeleteFlushedTraceFilesOlderThan(
-      std::numeric_limits<_spoor_runtime_SystemTimestampSeconds>::min(),
-      [](auto deleted_files_info) { callback_(deleted_files_info); });
+  {
+    constexpr _spoor_runtime_DeletedFilesInfo expected_deleted_files_info{
+        .deleted_files = 0, .deleted_bytes = 0};
+    MockFunction<void(_spoor_runtime_DeletedFilesInfo)> callback{};
+    absl::Notification done{};
+    callback_ = callback.AsStdFunction();
+    EXPECT_CALL(callback, Call(expected_deleted_files_info))
+        .WillOnce(Notify(&done));
+    _spoor_runtime_DeleteFlushedTraceFilesOlderThan(
+        std::numeric_limits<_spoor_runtime_SystemTimestampSeconds>::min(),
+        [](auto deleted_files_info) { callback_(deleted_files_info); });
+    const auto success =
+        done.WaitForNotificationWithTimeout(kNotificationTimeout);
+    ASSERT_TRUE(success);
+  }
+  {
+    constexpr spoor::runtime::DeletedFilesInfo expected_deleted_files_info{
+        .deleted_files = 0, .deleted_bytes = 0};
+    MockFunction<void(spoor::runtime::DeletedFilesInfo)> callback{};
+    absl::Notification done{};
+    EXPECT_CALL(callback, Call(expected_deleted_files_info))
+        .WillOnce(Notify(&done));
+    spoor::runtime::DeleteFlushedTraceFilesOlderThan(
+        std::numeric_limits<spoor::runtime::SystemTimestampSeconds>::min(),
+        callback.AsStdFunction());
+    const auto success =
+        done.WaitForNotificationWithTimeout(kNotificationTimeout);
+    ASSERT_TRUE(success);
+  }
 }
 
 }  // namespace delete_flushed_trace_files_older_than_test
 
 TEST(Runtime, GetConfig) {  // NOLINT
-  constexpr _spoor_runtime_Config expected_config{
-      .trace_file_path = nullptr,
-      .session_id = 0,
-      .thread_event_buffer_capacity = 0,
-      .max_reserved_event_buffer_slice_capacity = 0,
-      .max_dynamic_event_buffer_slice_capacity = 0,
-      .reserved_event_pool_capacity = 0,
-      .dynamic_event_pool_capacity = 0,
-      .dynamic_event_slice_borrow_cas_attempts = 0,
-      .event_buffer_retention_duration_nanoseconds = 0,
-      .max_flush_buffer_to_file_attempts = 0,
-      .flush_all_events = false};
-  const auto config = _spoor_runtime_GetConfig();
-  ASSERT_EQ(config, expected_config);
+  {
+    constexpr _spoor_runtime_Config expected_config{
+        .trace_file_path_size = 0,
+        .trace_file_path = nullptr,
+        .session_id = 0,
+        .thread_event_buffer_capacity = 0,
+        .max_reserved_event_buffer_slice_capacity = 0,
+        .max_dynamic_event_buffer_slice_capacity = 0,
+        .reserved_event_pool_capacity = 0,
+        .dynamic_event_pool_capacity = 0,
+        .dynamic_event_slice_borrow_cas_attempts = 0,
+        .event_buffer_retention_duration_nanoseconds = 0,
+        .max_flush_buffer_to_file_attempts = 0,
+        .flush_all_events = false};
+    const auto config = _spoor_runtime_GetConfig();
+    ASSERT_EQ(config, expected_config);
+  }
+  {
+    const spoor::runtime::Config expected_config{
+        .trace_file_path = {},
+        .session_id = 0,
+        .thread_event_buffer_capacity = 0,
+        .max_reserved_event_buffer_slice_capacity = 0,
+        .max_dynamic_event_buffer_slice_capacity = 0,
+        .reserved_event_pool_capacity = 0,
+        .dynamic_event_pool_capacity = 0,
+        .dynamic_event_slice_borrow_cas_attempts = 0,
+        .event_buffer_retention_duration_nanoseconds = 0,
+        .max_flush_buffer_to_file_attempts = 0,
+        .flush_all_events = false};
+    const auto config = spoor::runtime::GetConfig();
+    ASSERT_EQ(config, expected_config);
+  }
 }
 
 TEST(Runtime, StubImplementation) {  // NOLINT
   ASSERT_TRUE(_spoor_runtime_StubImplementation());
+  ASSERT_TRUE(spoor::runtime::StubImplementation());
 }
 
 }  // namespace


### PR DESCRIPTION
* Implements a C++ runtime API.
* Removes redundant `Runtime` from the C API.
* Updates the callback handling to always invoke `callback` on a background thread.

I'm interested to migrate to using `std::future` instead of a callback (in a future PR) which will result in a much more ergonomic C++ API.