### PR TITLE
Remove LogFunctionEntry and LogFunctionExit from the runtime API

### DIFF
--- a/spoor/runtime/runtime.cc
+++ b/spoor/runtime/runtime.cc
@@ -128,14 +128,6 @@ auto LogEvent(const EventType event, const uint64_t payload_1,
   runtime_.LogEvent(event, payload_1, payload_2);
 }
 
-auto LogFunctionEntry(const FunctionId function_id) -> void {
-  runtime_.LogFunctionEntry(function_id);
-}
-
-auto LogFunctionExit(const FunctionId function_id) -> void {
-  runtime_.LogFunctionExit(function_id);
-}
-
 auto FlushTraceEvents(std::function<void()> callback) -> void {
   runtime_.Flush(std::move(callback));
 }

--- a/spoor/runtime/runtime.h
+++ b/spoor/runtime/runtime.h
@@ -78,18 +78,6 @@ auto LogEvent(EventType event, TimestampNanoseconds steady_clock_timestamp,
 // the event.
 auto LogEvent(EventType event, uint64_t payload_1, uint64_t payload_2) -> void;
 
-// Log that the program entered a function. The function internally checks if
-// the runtime is enabled before collecting the current timestamp and logging
-// the event. A call to this function is inserted at the start of every function
-// by the compile-time instrumentation.
-auto LogFunctionEntry(FunctionId function_id) -> void;
-
-// Log that the program exited a function. The function internally checks if the
-// runtime is enabled before collecting the current timestamp and logging the
-// event. A call to this function is inserted at the end of every function by
-// the compile-time instrumentation.
-auto LogFunctionExit(FunctionId function_id) -> void;
-
 // Flush in-memory trace events to disk. The callback is invoked on a background
 // thread.
 auto FlushTraceEvents(std::function<void()> callback) -> void;
@@ -201,18 +189,6 @@ void _spoor_runtime_LogEventWithTimestamp(
 void _spoor_runtime_LogEvent(_spoor_runtime_EventType event, uint64_t payload_1,
                              uint32_t payload_2);
 
-// Log that the program entered a function. The function internally checks if
-// the runtime is enabled before collecting the current timestamp and logging
-// the event. A call to this function is inserted at the start of every function
-// by the compile-time instrumentation.
-void _spoor_runtime_LogFunctionEntry(_spoor_runtime_FunctionId function_id);
-
-// Log that the program exited a function. The function internally checks if the
-// runtime is enabled before collecting the current timestamp and logging the
-// event. A call to this function is inserted at the end of every function by
-// the compile-time instrumentation.
-void _spoor_runtime_LogFunctionExit(_spoor_runtime_FunctionId function_id);
-
 // Flush in-memory trace events to disk. The callback is invoked on a background
 // thread.
 void _spoor_runtime_FlushTraceEvents(
@@ -275,6 +251,19 @@ auto operator==(const _spoor_runtime_TraceFiles& lhs,
                 const _spoor_runtime_TraceFiles& rhs) -> bool;
 auto operator==(const _spoor_runtime_Config& lhs,
                 const _spoor_runtime_Config& rhs) -> bool;
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Internal.
+// Exposed for use by Spoor's instrumentation.
+void _spoor_runtime_LogFunctionEntry(_spoor_runtime_FunctionId function_id);
+void _spoor_runtime_LogFunctionExit(_spoor_runtime_FunctionId function_id);
+
+#ifdef __cplusplus
+}  // extern "C"
 #endif
 
 #endif  // SPOOR_RUNTIME_RUNTIME_H_

--- a/spoor/runtime/runtime_stub.cc
+++ b/spoor/runtime/runtime_stub.cc
@@ -29,10 +29,6 @@ auto LogEvent(const EventType /*unused*/, const TimestampNanoseconds /*unused*/,
 auto LogEvent(const EventType /*unused*/, const uint64_t /*unused*/,
               const uint64_t /*unused*/) -> void {}
 
-auto LogFunctionEntry(const FunctionId /*unused*/) -> void {}
-
-auto LogFunctionExit(const FunctionId /*unused*/) -> void {}
-
 auto FlushTraceEvents(std::function<void()> callback) -> void {
   if (callback == nullptr) return;
   std::thread{std::move(callback)}.detach();

--- a/spoor/runtime/runtime_stub_test.cc
+++ b/spoor/runtime/runtime_stub_test.cc
@@ -56,8 +56,6 @@ TEST(Runtime, LogEvent) {  // NOLINT
 
   spoor::runtime::LogEvent(1, 2, 3, 4);
   spoor::runtime::LogEvent(1, 2, 3);
-  spoor::runtime::LogFunctionEntry(1);
-  spoor::runtime::LogFunctionExit(1);
 }
 
 namespace flush_trace_events_test {


### PR DESCRIPTION
Removes `LogFunctionEntry` and `LogFunctionExit` from the runtime's C++ API based on [this](https://github.com/microsoft/spoor/pull/117#discussion_r626312039) conversation. We still need to expose `_spoor_runtime_LogFunctionEntry` and `_spoor_runtime_LogFunctionExit` so the instrumented code can call those functions. These functions are moved to the bottom of the file under an "Internal" comment.