### PR TITLE
Integration test

### DIFF
--- a/spoor/BUILD
+++ b/spoor/BUILD
@@ -1,2 +1,14 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
+
+sh_test(
+    name = "integration_test",
+    size = "small",
+    srcs = ["integration_test.sh"],
+    data = [
+        "//spoor/instrumentation:spoor_opt",
+        "//spoor/runtime:spoor_runtime",
+        "//spoor/test_data",
+    ],
+    visibility = ["//visibility:private"],
+)

--- a/spoor/instrumentation/inject_instrumentation/inject_instrumentation.cc
+++ b/spoor/instrumentation/inject_instrumentation/inject_instrumentation.cc
@@ -43,11 +43,10 @@ using google::protobuf::util::TimeUtil;
 
 constexpr std::string_view kMainFunctionName{"main"};
 constexpr std::string_view kInitializeRuntimeFunctionName{
-    "_spoor_runtime_InitializeRuntime"};
+    "_spoor_runtime_Initialize"};
 constexpr std::string_view kDeinitializeRuntimeFunctionName{
-    "_spoor_runtime_DeinitializeRuntime"};
-constexpr std::string_view kEnableRuntimeFunctionName{
-    "_spoor_runtime_EnableRuntime"};
+    "_spoor_runtime_Deinitialize"};
+constexpr std::string_view kEnableRuntimeFunctionName{"_spoor_runtime_Enable"};
 constexpr std::string_view kLogFunctionEntryFunctionName{
     "_spoor_runtime_LogFunctionEntry"};
 constexpr std::string_view kLogFunctionExitFunctionName{

--- a/spoor/instrumentation/test_data/fib_instrumented.ll
+++ b/spoor/instrumentation/test_data/fib_instrumented.ll
@@ -22,12 +22,12 @@ define i32 @main() {
   call void @_spoor_runtime_LogFunctionEntry(i64 7304034947084320769)
   %1 = tail call i32 @_Z9Fibonaccii(i32 7)
   call void @_spoor_runtime_LogFunctionExit(i64 7304034947084320769)
-  call void @_spoor_runtime_DeinitializeRuntime()
+  call void @_spoor_runtime_Deinitialize()
   ret i32 %1
 }
 
-declare void @_spoor_runtime_InitializeRuntime()
-declare void @_spoor_runtime_DeinitializeRuntime()
-declare void @_spoor_runtime_EnableRuntime()
+declare void @_spoor_runtime_Initialize()
+declare void @_spoor_runtime_Deinitialize()
+declare void @_spoor_runtime_Enable()
 declare void @_spoor_runtime_LogFunctionEntry(i64)
 declare void @_spoor_runtime_LogFunctionExit(i64)

--- a/spoor/instrumentation/test_data/fib_instrumented_initialized.ll
+++ b/spoor/instrumentation/test_data/fib_instrumented_initialized.ll
@@ -19,16 +19,16 @@ define i32 @_Z9Fibonaccii(i32 %0) {
 }
 
 define i32 @main() {
-  call void @_spoor_runtime_InitializeRuntime()
+  call void @_spoor_runtime_Initialize()
   call void @_spoor_runtime_LogFunctionEntry(i64 7304034947084320769)
   %1 = tail call i32 @_Z9Fibonaccii(i32 7)
   call void @_spoor_runtime_LogFunctionExit(i64 7304034947084320769)
-  call void @_spoor_runtime_DeinitializeRuntime()
+  call void @_spoor_runtime_Deinitialize()
   ret i32 %1
 }
 
-declare void @_spoor_runtime_InitializeRuntime()
-declare void @_spoor_runtime_DeinitializeRuntime()
-declare void @_spoor_runtime_EnableRuntime()
+declare void @_spoor_runtime_Initialize()
+declare void @_spoor_runtime_Deinitialize()
+declare void @_spoor_runtime_Enable()
 declare void @_spoor_runtime_LogFunctionEntry(i64)
 declare void @_spoor_runtime_LogFunctionExit(i64)

--- a/spoor/instrumentation/test_data/fib_instrumented_initialized_enabled.ll
+++ b/spoor/instrumentation/test_data/fib_instrumented_initialized_enabled.ll
@@ -19,17 +19,17 @@ define i32 @_Z9Fibonaccii(i32 %0) {
 }
 
 define i32 @main() {
-  call void @_spoor_runtime_InitializeRuntime()
-  call void @_spoor_runtime_EnableRuntime()
+  call void @_spoor_runtime_Initialize()
+  call void @_spoor_runtime_Enable()
   call void @_spoor_runtime_LogFunctionEntry(i64 7304034947084320769)
   %1 = tail call i32 @_Z9Fibonaccii(i32 7)
   call void @_spoor_runtime_LogFunctionExit(i64 7304034947084320769)
-  call void @_spoor_runtime_DeinitializeRuntime()
+  call void @_spoor_runtime_Deinitialize()
   ret i32 %1
 }
 
-declare void @_spoor_runtime_InitializeRuntime()
-declare void @_spoor_runtime_DeinitializeRuntime()
-declare void @_spoor_runtime_EnableRuntime()
+declare void @_spoor_runtime_Initialize()
+declare void @_spoor_runtime_Deinitialize()
+declare void @_spoor_runtime_Enable()
 declare void @_spoor_runtime_LogFunctionEntry(i64)
 declare void @_spoor_runtime_LogFunctionExit(i64)

--- a/spoor/instrumentation/test_data/fib_only_main_instrumented.ll
+++ b/spoor/instrumentation/test_data/fib_only_main_instrumented.ll
@@ -19,12 +19,12 @@ define i32 @main() {
   call void @_spoor_runtime_LogFunctionEntry(i64 7304034947084320769)
   %1 = tail call i32 @_Z9Fibonaccii(i32 7)
   call void @_spoor_runtime_LogFunctionExit(i64 7304034947084320769)
-  call void @_spoor_runtime_DeinitializeRuntime()
+  call void @_spoor_runtime_Deinitialize()
   ret i32 %1
 }
 
-declare void @_spoor_runtime_InitializeRuntime()
-declare void @_spoor_runtime_DeinitializeRuntime()
-declare void @_spoor_runtime_EnableRuntime()
+declare void @_spoor_runtime_Initialize()
+declare void @_spoor_runtime_Deinitialize()
+declare void @_spoor_runtime_Enable()
 declare void @_spoor_runtime_LogFunctionEntry(i64)
 declare void @_spoor_runtime_LogFunctionExit(i64)

--- a/spoor/integration_test.sh
+++ b/spoor/integration_test.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+set -e
+
+BASE_PATH="spoor"
+OUTPUT_EXECUTABLE_FILE="fib"
+UNINSTRUMENTED_IR_FILE="fib.ll"
+INSTRUMENTED_IR_FILE="fib_instrumented.ll"
+OUTPUT_EXECUTABLE_FILE="fib"
+
+if command -v clang++-12 &> /dev/null; then
+  CLANGXX="clang++-12"
+elif command -v clang++ &> /dev/null; then
+  CLANGXX="clang++"
+else
+  echo "clang++ not found"
+  exit 1
+fi
+
+"$CLANGXX" \
+  "$BASE_PATH/test_data/fib.cc" \
+  -g \
+  -O0 \
+  -emit-llvm \
+  -S \
+  -o "$UNINSTRUMENTED_IR_FILE"
+
+"$BASE_PATH/instrumentation/spoor_opt" \
+  --output_language=ir \
+  "$UNINSTRUMENTED_IR_FILE" > "$INSTRUMENTED_IR_FILE"
+
+"$CLANGXX" \
+  "$INSTRUMENTED_IR_FILE" \
+  -L"$BASE_PATH/runtime" \
+  -lspoor_runtime \
+  -o "$OUTPUT_EXECUTABLE_FILE"
+
+RESULT="$($OUTPUT_EXECUTABLE_FILE)"
+
+EXPECTED_RESULT="13"
+if [ "$RESULT" != "$EXPECTED_RESULT" ]; then
+  echo "Unexpected result for Fibonacci(7)." \
+    "Expected $EXPECTED_RESULT, got $RESULT."
+  exit 1
+fi
+
+ls | grep ".spoor_function_map" > /dev/null
+ls | grep ".spoor_trace" > /dev/null

--- a/spoor/runtime/BUILD
+++ b/spoor/runtime/BUILD
@@ -27,6 +27,7 @@ cc_library(
 
 cc_static_library(
     name = "spoor_runtime",
+    visibility = ["//visibility:public"],
     deps = [":runtime"],
 )
 
@@ -44,6 +45,7 @@ cc_library(
 
 cc_static_library(
     name = "spoor_runtime_stub",
+    visibility = ["//visibility:public"],
     deps = [":runtime_stub"],
 )
 

--- a/spoor/test_data/BUILD
+++ b/spoor/test_data/BUILD
@@ -1,0 +1,9 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+filegroup(
+    name = "test_data",
+    testonly = True,
+    srcs = ["fib.cc"],
+    visibility = ["//spoor:__subpackages__"],
+)

--- a/spoor/test_data/fib.cc
+++ b/spoor/test_data/fib.cc
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include <cstdio>
+
+auto Fibonacci(int n) -> int {  // NOLINT(misc-no-recursion)
+  if (n < 2) return n;
+  return Fibonacci(n - 1) + Fibonacci(n - 2);
+}
+
+auto main() -> int {
+  printf("%d", Fibonacci(7));  // NOLINT(cppcoreguidelines-pro-type-vararg)
+}

--- a/toolchain/cc_static_library.bzl
+++ b/toolchain/cc_static_library.bzl
@@ -83,7 +83,10 @@ def _cc_static_library_impl(ctx):
         env = env,
     )
 
-    default_info = DefaultInfo(files = depset(direct = [output_file]))
+    default_info = DefaultInfo(
+        files = depset([output_file]),
+        runfiles = ctx.runfiles(files = [output_file]),
+    )
     this_cc_info = CcInfo(
         compilation_context = compilation_context,
         linking_context = linking_context,


### PR DESCRIPTION
Implements an integration test that instruments and runs a C++ file. We'll expand the test when the trace parsing logic is checked in.

Resolves an issue introduced in #127 that renamed the C initialize, deinitialize, enable, and disable functions but didn't update the injected instrumentation names. I looked into compile-time reflection techniques to automatically determine the symbol name to prevent this mistake, however, the reflection would add a layer of indirection to our public header file that isn't worth the tradeoff, especially because we can catch the mistake with a unit test.