### PR TITLE
Parallelize CI sanitizers

### DIFF
--- a/.build/azure-pipelines.yml
+++ b/.build/azure-pipelines.yml
@@ -8,33 +8,48 @@ jobs:
 - job: build_and_test
   strategy:
     matrix:
-      # TODO(#58): Support Linux in CI.
+      # TODO(#58): Support Linux in CI and reintroduce UBSAN (Linux only).
       mac:
         imageName: 'macos-10.15'
   pool:
     vmImage: $(imageName)
   steps:
   - template: ./templates/install-common.yml
-  - script: |
-      bazel build //...
+  - script: bazel build //...
     displayName: Build
-  - script: |
-      bazel test //...
+  - script: bazel test //...
     displayName: Test
   - script: ./toolchain/benchmark/run_benchmarks.sh
     displayName: Benchmark
-  - script: ./toolchain/compilation_database/generate_compilation_database.sh
-    displayName: Generate compilation database
+- job: address_sanitizer
+  strategy:
+    matrix:
+      mac:
+        imageName: 'macos-10.15'
+  pool:
+    vmImage: $(imageName)
+  steps:
+  - template: ./templates/install-common.yml
   - script: bazel test --config=asan $(bazel query 'kind(cc_.*, tests(//...))')
     displayName: Address sanitizer
+- job: thread_sanitizer
+  strategy:
+    matrix:
+      mac:
+        imageName: 'macos-10.15'
+  pool:
+    vmImage: $(imageName)
+  steps:
+  - template: ./templates/install-common.yml
   - script: bazel test --config=tsan $(bazel query 'kind(cc_.*, tests(//...))')
     displayName: Thread sanitizer
-  - script: bazel test --config=ubsan $(bazel query 'kind(cc_.*, tests(//...))')
-    displayName: Undefined behavior sanitizer
-    condition: eq(variables['Agent.OS'], 'Linux')
 - job: style_and_lint
+  strategy:
+    matrix:
+      mac:
+        imageName: 'macos-10.15'
   pool:
-    vmImage: 'macos-10.15'
+    vmImage: $(imageName)
   steps:
   - template: ./templates/install-common.yml
   - script: |

--- a/.build/templates/install-common.yml
+++ b/.build/templates/install-common.yml
@@ -8,10 +8,7 @@ steps:
     sudo ./llvm.sh 12
   displayName: Install LLVM (Linux)
   condition: eq(variables['Agent.OS'], 'Linux')
-- script: |
-    brew update
-    brew upgrade --force llvm@12
-    echo '##vso[task.prependpath]/usr/local/opt/llvm/bin'
+- script: echo '##vso[task.prependpath]/usr/local/opt/llvm/bin'
   displayName: Install LLVM (macOS)
   condition: eq(variables['Agent.OS'], 'Darwin')
 - script: cp ./.build/ci.bazelrc ./.bazelrc


### PR DESCRIPTION
#125 compiles LLVM from source and significantly increases the build time. When running the sanitizers serially, we exceed 60 minute time cap since running each sanitizer results in a clean build. This PR:
* Parallelizes ASAN and TSAN by running them as separate build jobs.
* Removes the `brew update` and `brew install` LLVM installation steps on macOS since it's already installed on the VM (and as a result saves ~30 seconds).
* Removes the compilation database step since it's also performed as part of the Clang Tidy step.