### PR TITLE
Clang Tidy and Clang Format Bazel Aspects

### DIFF
--- a/.build/azure-pipelines.yml
+++ b/.build/azure-pipelines.yml
@@ -57,14 +57,15 @@ jobs:
       git diff --exit-code
     displayName: Copyright header
   - script: |
-      ./toolchain/style/clang_format.sh
+      bazel build //... --aspects toolchain/style/style.bzl%clang_format \
+          --output_groups=report
       git diff --exit-code
     displayName: Clang Format
   - script: |
       bazel run //toolchain/style:buildifier
       git diff --exit-code
     displayName: Buildifier
-  - script: ./toolchain/style/clang_tidy.sh
+  - script: |
+      bazel build //... --aspects toolchain/style/style.bzl%clang_tidy \
+          --output_groups=report --keep_going
     displayName: Clang Tidy
-    env:
-      AZURE_PIPELINES_OS: $(Agent.OS)

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -94,6 +94,8 @@ Checks: '
   -llvm-qualified-auto,
   '
 WarningsAsErrors: '*'
+# Exclusions in //toolchain/style/style.bzl
+HeaderFilterRegex: '(spoor|toolchain|util)/.*'
 FormatStyle: file
 CheckOptions:
   - key: readability-braces-around-statements.ShortStatementLines

--- a/BUILD
+++ b/BUILD
@@ -1,2 +1,14 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
+
+filegroup(
+    name = "clang_format_config",
+    data = [".clang-format"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "clang_tidy_config",
+    data = [".clang-tidy"],
+    visibility = ["//visibility:public"],
+)

--- a/README.md
+++ b/README.md
@@ -20,11 +20,25 @@ $ bazel test //...
 ```
 
 ## Style and lint
+
+### Format C++, Objective-C, and Protobuf files
 ```
-$ bazel run //toolchain/style:buildifier                # Format Starlark files
-$ ./toolchain/style/clang_format.sh                     # Format C++ and Protobuf files
-$ ./toolchain/style/clang_tidy.sh                       # Lint C++ files
-$ ./toolchain/copyright_header/add_copyright_header.sh  # Add copyright header
+$ bazel build //... --aspects toolchain/style/style.bzl%clang_format --output_groups=report
+```
+
+### Format
+```
+$ bazel run //toolchain/style:buildifier
+```
+
+### Lint C++ and Objective-C files
+```
+$ bazel build //... --aspects toolchain/style/style.bzl%clang_tidy --output_groups=report
+```
+
+### Add copyright header
+```
+$ ./toolchain/copyright_header/add_copyright_header.sh
 ```
 
 ## Compilation database

--- a/spoor/instrumentation/BUILD
+++ b/spoor/instrumentation/BUILD
@@ -1,17 +1,22 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_test")
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
+
+cc_library(
+    name = "instrumentation_info",
+    hdrs = ["instrumentation.h"],
+    copts = ["-Werror"],
+    visibility = ["//visibility:private"],
+)
 
 cc_binary(
     name = "spoor_opt",
-    srcs = [
-        "instrumentation.h",
-        "spoor_opt.cc",
-    ],
+    srcs = ["spoor_opt.cc"],
     copts = ["-Werror"],
     visibility = ["//visibility:public"],
     deps = [
+        ":instrumentation_info",
         "//spoor/instrumentation/config",
         "//spoor/instrumentation/config:command_line_config",
         "//spoor/instrumentation/inject_instrumentation",
@@ -30,10 +35,7 @@ cc_binary(
 
 SHARED_LIBRARY_NAME = "spoor_instrumentation"
 
-SHARED_LIBRARY_SRCS = [
-    "instrumentation.h",
-    "spoor_instrumentation_pass.cc",
-]
+SHARED_LIBRARY_SRCS = ["spoor_instrumentation_pass.cc"]
 
 SHARED_LIBRARY_COPTS = ["-Werror"]
 
@@ -42,6 +44,7 @@ SHARED_LIBRARY_LINKSHARED = True
 SHARED_LIBRARY_VISIBILITY = ["//visibility:public"]
 
 SHARED_LIBRARY_DEPS = [
+    ":instrumentation_info",
     "//spoor/instrumentation/config:env_config",
     "//spoor/instrumentation/inject_instrumentation",
     "//spoor/instrumentation/support",

--- a/spoor/runtime/buffer/buffer_slice_pool.h
+++ b/spoor/runtime/buffer/buffer_slice_pool.h
@@ -25,7 +25,11 @@ class BufferSlicePool : public util::memory::PtrOwner<CircularBuffer<T>> {
     kCasAttemptsExhausted,
   };
 
-  virtual constexpr ~BufferSlicePool() = default;
+  constexpr BufferSlicePool(BufferSlicePool&&) noexcept = delete;
+  constexpr auto operator=(BufferSlicePool&&) noexcept
+      -> BufferSlicePool& = delete;
+  constexpr ~BufferSlicePool() override = default;
+
   [[nodiscard]] virtual constexpr auto Borrow(SizeType preferred_slice_capacity)
       -> BorrowResult = 0;
 
@@ -37,10 +41,7 @@ class BufferSlicePool : public util::memory::PtrOwner<CircularBuffer<T>> {
  protected:
   constexpr BufferSlicePool() = default;
   constexpr BufferSlicePool(const BufferSlicePool&) = default;
-  constexpr BufferSlicePool(BufferSlicePool&&) noexcept = default;
   constexpr auto operator=(const BufferSlicePool&)
-      -> BufferSlicePool& = default;
-  constexpr auto operator=(BufferSlicePool&&) noexcept
       -> BufferSlicePool& = default;
 };
 

--- a/spoor/runtime/buffer/circular_slice_buffer.h
+++ b/spoor/runtime/buffer/circular_slice_buffer.h
@@ -32,19 +32,19 @@ class CircularSliceBuffer final : public CircularBuffer<T> {
   using SlicePool = BufferSlicePool<T>;
   using SlicesType = std::vector<OwnedSlicePtr>;
 
-  struct Options {
+  struct alignas(16) Options {
     gsl::not_null<SlicePool*> buffer_slice_pool;
     SizeType capacity;
   };
 
   CircularSliceBuffer() = delete;
-  constexpr explicit CircularSliceBuffer(const Options& options);
+  constexpr explicit CircularSliceBuffer(Options options);
   CircularSliceBuffer(const CircularSliceBuffer&) = delete;
   constexpr CircularSliceBuffer(CircularSliceBuffer&&) noexcept = default;
   auto operator=(const CircularSliceBuffer&) -> CircularSliceBuffer& = delete;
   constexpr auto operator=(CircularSliceBuffer&&) noexcept
       -> CircularSliceBuffer& = default;
-  constexpr ~CircularSliceBuffer() = default;
+  constexpr ~CircularSliceBuffer() override = default;
 
   constexpr auto Push(const T& item) -> void override;
   constexpr auto Push(T&& item) -> void override;
@@ -72,8 +72,8 @@ class CircularSliceBuffer final : public CircularBuffer<T> {
 };
 
 template <class T>
-constexpr CircularSliceBuffer<T>::CircularSliceBuffer(const Options& options)
-    : options_{options},
+constexpr CircularSliceBuffer<T>::CircularSliceBuffer(Options options)
+    : options_{std::move(options)},
       slices_{},
       size_{0},
       acquired_slices_capacity_{0},

--- a/spoor/runtime/buffer/combined_buffer_slice_pool.h
+++ b/spoor/runtime/buffer/combined_buffer_slice_pool.h
@@ -28,7 +28,7 @@ class CombinedBufferSlicePool final : public BufferSlicePool<T> {
   using ReservedPool = ReservedBufferSlicePool<T>;
   using DynamicPool = DynamicBufferSlicePool<T>;
 
-  struct Options {
+  struct alignas(64) Options {
     typename ReservedPool::Options reserved_pool_options;
     typename DynamicPool::Options dynamic_pool_options;
   };
@@ -41,7 +41,7 @@ class CombinedBufferSlicePool final : public BufferSlicePool<T> {
       -> CombinedBufferSlicePool& = delete;
   auto operator=(CombinedBufferSlicePool&&) noexcept
       -> CombinedBufferSlicePool& = delete;
-  constexpr ~CombinedBufferSlicePool() = default;
+  constexpr ~CombinedBufferSlicePool() override = default;
 
   // Borrow a buffer from the reserved pool if available. Otherwise, borrow a
   // buffer from the dynamic pool if available.

--- a/spoor/runtime/buffer/dynamic_buffer_slice_pool.h
+++ b/spoor/runtime/buffer/dynamic_buffer_slice_pool.h
@@ -28,7 +28,7 @@ class DynamicBufferSlicePool final : public BufferSlicePool<T> {
   using BorrowResult = util::result::Result<OwnedSlicePtr, BorrowError>;
   using ReturnResult = typename util::memory::PtrOwner<Slice>::Result;
 
-  struct Options {
+  struct alignas(32) Options {
     SizeType max_slice_capacity;
     SizeType capacity;
     SizeType borrow_cas_attempts;
@@ -42,7 +42,7 @@ class DynamicBufferSlicePool final : public BufferSlicePool<T> {
       -> DynamicBufferSlicePool& = delete;
   auto operator=(DynamicBufferSlicePool&&) noexcept
       -> DynamicBufferSlicePool& = delete;
-  constexpr ~DynamicBufferSlicePool();
+  constexpr ~DynamicBufferSlicePool() override;
 
   // Borrow a buffer slice from the object pool whose size is the minimum of:
   // - The preferred slice size.

--- a/spoor/runtime/buffer/owned_buffer_slice.h
+++ b/spoor/runtime/buffer/owned_buffer_slice.h
@@ -23,7 +23,7 @@ class OwnedBufferSlice final : public CircularBuffer<T> {
   constexpr OwnedBufferSlice(OwnedBufferSlice&& other) noexcept = default;
   auto operator=(const OwnedBufferSlice&) -> OwnedBufferSlice& = delete;
   auto operator=(OwnedBufferSlice&&) noexcept -> OwnedBufferSlice& = delete;
-  constexpr ~OwnedBufferSlice() = default;
+  constexpr ~OwnedBufferSlice() override = default;
 
   constexpr auto Push(const T& item) -> void override;
   constexpr auto Push(T&& item) -> void override;

--- a/spoor/runtime/buffer/reserved_buffer_slice_pool.h
+++ b/spoor/runtime/buffer/reserved_buffer_slice_pool.h
@@ -30,7 +30,7 @@ class ReservedBufferSlicePool final : public BufferSlicePool<T> {
   using BorrowResult = util::result::Result<OwnedSlicePtr, BorrowError>;
   using ReturnResult = typename util::memory::PtrOwner<Slice>::Result;
 
-  struct Options {
+  struct alignas(16) Options {
     SizeType max_slice_capacity;
     SizeType capacity;
   };
@@ -46,7 +46,7 @@ class ReservedBufferSlicePool final : public BufferSlicePool<T> {
   // Although C++20 declares `std::vector`'s destructor as `constexpr`, it is
   // not yet implemented in some versions of the STL. Therefore, this class'
   // destructor cannot be virtual.
-  ~ReservedBufferSlicePool();
+  ~ReservedBufferSlicePool() override;
 
   // Borrow a buffer slice from the object pool with its intrinsic capacity
   // (i.e. ignores the preferred slice capacity).

--- a/spoor/runtime/buffer/unowned_buffer_slice.h
+++ b/spoor/runtime/buffer/unowned_buffer_slice.h
@@ -24,7 +24,7 @@ class UnownedBufferSlice final : public CircularBuffer<T> {
   constexpr UnownedBufferSlice(UnownedBufferSlice&& other) noexcept = default;
   auto operator=(const UnownedBufferSlice&) -> UnownedBufferSlice& = delete;
   auto operator=(UnownedBufferSlice&&) noexcept -> UnownedBufferSlice& = delete;
-  constexpr ~UnownedBufferSlice() = default;
+  constexpr ~UnownedBufferSlice() override = default;
 
   constexpr auto Push(const T& item) -> void override;
   constexpr auto Push(T&& item) -> void override;

--- a/spoor/runtime/flush_queue/flush_queue_mock.h
+++ b/spoor/runtime/flush_queue/flush_queue_mock.h
@@ -13,11 +13,11 @@ namespace spoor::runtime::flush_queue::testing {
 template <class T>
 class FlushQueueMock : public FlushQueue<T> {
  public:
-  MOCK_METHOD(void, Run, (), (override));
-  MOCK_METHOD(void, Enqueue, (T && item), (override));
-  MOCK_METHOD(void, DrainAndStop, (), (override));
-  MOCK_METHOD(void, Flush, (std::function<void()>), (override));
-  MOCK_METHOD(void, Clear, (), (override));
+  MOCK_METHOD(void, Run, (), (override));                         // NOLINT
+  MOCK_METHOD(void, Enqueue, (T && item), (override));            // NOLINT
+  MOCK_METHOD(void, DrainAndStop, (), (override));                // NOLINT
+  MOCK_METHOD(void, Flush, (std::function<void()>), (override));  // NOLINT
+  MOCK_METHOD(void, Clear, (), (override));                       // NOLINT
 };
 
 }  // namespace spoor::runtime::flush_queue::testing

--- a/spoor/runtime/runtime.h
+++ b/spoor/runtime/runtime.h
@@ -28,12 +28,12 @@ using SizeType = uint64_t;
 using SystemTimestampSeconds = int64_t;
 using TimestampNanoseconds = int64_t;
 
-struct DeletedFilesInfo {
+struct alignas(16) DeletedFilesInfo {
   int32_t deleted_files;
   int64_t deleted_bytes;
 };
 
-struct Config {
+struct alignas(128) Config {
   std::filesystem::path trace_file_path;
   SessionId session_id;
   SizeType thread_event_buffer_capacity;

--- a/toolchain/style/BUILD
+++ b/toolchain/style/BUILD
@@ -4,3 +4,17 @@
 load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier")
 
 buildifier(name = "buildifier")
+
+sh_binary(
+    name = "clang_format",
+    srcs = ["clang_format.sh"],
+    data = ["//:clang_format_config"],
+    visibility = ["//visibility:public"],
+)
+
+sh_binary(
+    name = "clang_tidy",
+    srcs = ["clang_tidy.sh"],
+    data = ["//:clang_tidy_config"],
+    visibility = ["//visibility:public"],
+)

--- a/toolchain/style/clang_format.sh
+++ b/toolchain/style/clang_format.sh
@@ -2,9 +2,10 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-set -eu
+# Usage:
+# `clang_format.sh output_file input_file args...`
 
-WORKSPACE="$(bazel info workspace)"
+set -eu
 
 if command -v clang-format-12 &> /dev/null; then
   CLANG_FORMAT="clang-format-12"
@@ -15,24 +16,9 @@ else
   exit 1
 fi
 
-function run_clang_format {
-  echo "Formatting $1"
-  "$CLANG_FORMAT" \
-    -style=file \
-    -i \
-    "$1"
-}
+OUTPUT_FILE="$1"
+shift
+INPUT_FILE="$1"
 
-if [ $# -eq 0 ]; then
-  find "$WORKSPACE" \
-    -type f \
-    \( -iname '*.h' -o -iname '*.cc' -o -iname '*.proto' ! -iname 'bazel-' \) \
-    -print0 |
-      while read -d $'\0' file_name; do
-        run_clang_format "$file_name"
-      done
-else
-  for file_name in "$@"; do
-    run_clang_format "$file_name"
-  done
-fi
+"$CLANG_FORMAT" "$@" 
+cp "$INPUT_FILE" "$OUTPUT_FILE"

--- a/toolchain/style/clang_tidy.sh
+++ b/toolchain/style/clang_tidy.sh
@@ -2,9 +2,10 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-set -e
+# Usage:
+# `clang_tidy.sh input_file --export-fixes output_file -- args...`
 
-WORKSPACE="$(bazel info workspace)"
+set -eu
 
 if command -v clang-tidy-12 &> /dev/null; then
   CLANG_TIDY="clang-tidy-12"
@@ -15,42 +16,10 @@ else
   exit 1
 fi
 
-function run_clang_tidy {
-  echo "Tidying $1"
-  "$CLANG_TIDY" \
-    -p="$WORKSPACE" \
-    --checks='' \
-    --config="$(cat "$WORKSPACE"/.clang-tidy)" \
-    "$1"
-}
+OUTPUT_FILE="$3"
 
-echo "Generating compilation database"
-./toolchain/compilation_database/generate_compilation_database.sh
+# The clang_tidy Aspect requires an output file, however, Clang Tidy does not
+# create an output file if there are no errors.
+touch "$OUTPUT_FILE"
 
-echo "Building C++ targets"
-# Building all C++ targets before running Clang Tidy ensures that
-# `$(bazel info execution_root)` contains the necessary dependencies.
-bazel build $(bazel query 'kind(cc_.*, //...)')
-
-if [ $# -eq 0 ]; then
-  # `runtime.h` is excluded because the header uses a C-style API which emits
-  # numerous warnings. Suppressing the warnings via NOLINT adds a considerable
-  # amount of visual noise.
-  # TODO(#86): Compilation database support for header-only libraries.
-  find "$WORKSPACE" \
-    -type f \
-    \( -iname "*.h" -o -iname "*.cc" \) \
-    ! -name "event_logger_notifier_mock.h" \
-    ! -name "flush_queue_mock.h" \
-    ! -name "runtime.h" \
-    ! -name "trace_reader_mock.h" \
-    ! -name "trace_writer_mock.h" \
-    -print0 |
-      while read -d $'\0' file_name; do
-        run_clang_tidy "$file_name"
-      done
-else
-  for file_name in "$@"; do
-    run_clang_tidy "$file_name"
-  done
-fi
+"$CLANG_TIDY" "$@"

--- a/toolchain/style/style.bzl
+++ b/toolchain/style/style.bzl
@@ -1,0 +1,217 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+load("@rules_cc//cc:action_names.bzl", "CPP_COMPILE_ACTION_NAME")
+load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
+load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
+
+def _run_clang_format(
+        ctx,
+        clang_format_config,
+        clang_format_executable,
+        input_file):
+    inputs = depset(direct = clang_format_config.to_list() + [input_file])
+
+    output_file_name = "{}.formatted.{}".format(
+        input_file.basename[:(-1 * (len(input_file.extension) + 1))],
+        input_file.extension,
+    )
+    output_file = ctx.actions.declare_file(output_file_name)
+
+    args = ctx.actions.args()
+    args.add(output_file.path)
+    args.add(input_file.path)
+    args.add("-style=file")
+    args.add("-i")
+
+    ctx.actions.run(
+        outputs = [output_file],
+        inputs = inputs,
+        executable = clang_format_executable,
+        arguments = [args],
+        mnemonic = "ClangFormat",
+        progress_message = "Formatting {}".format(input_file.short_path),
+        use_default_shell_env = True,
+        execution_requirements = {
+            "no-sandbox": "True",  # Allow in-place source file modification.
+        },
+    )
+
+    return output_file
+
+def _run_clang_tidy(
+        ctx,
+        clang_tidy_config,
+        clang_tidy_executable,
+        flags,
+        compilation_context,
+        input_file,
+        target_name):
+    inputs = depset(
+        direct = clang_tidy_config.to_list() + [input_file],
+        transitive = [compilation_context.headers],
+    )
+
+    output_file_name = "{}.{}.clang_tidy.yml".format(
+        input_file.basename.replace(".", "_"),
+        target_name,
+    )
+    output_file = ctx.actions.declare_file(output_file_name)
+
+    # Exclude files by only linting lines out of its range.
+    exclude = [[100000, 100000]]
+    line_filter = struct(key = [
+        struct(name = "spoor/runtime/runtime.h", lines = exclude),
+        struct(name = ".pb.h", lines = exclude),
+        struct(name = ".cc"),
+        struct(name = ".h"),
+        struct(name = ".m"),
+        struct(name = ".mm"),
+    ]).to_json()[len("{\"key\":"):(-1 * len("}"))]
+
+    args = ctx.actions.args()
+    args.add(input_file.path)
+    args.add("--export-fixes", output_file.path)
+    args.add("--line-filter={}".format(line_filter))
+    args.add("--")
+    args.add_all(flags)
+    args.add_all(
+        compilation_context.defines.to_list(),
+        format_each = "-D%s",
+    )
+    args.add_all(
+        compilation_context.local_defines.to_list(),
+        format_each = "-D%s",
+    )
+    args.add_all(
+        compilation_context.framework_includes.to_list(),
+        format_each = "-F%s",
+    )
+    args.add_all(
+        compilation_context.includes.to_list(),
+        format_each = "-I%s",
+    )
+    args.add_all(
+        compilation_context.system_includes.to_list(),
+        before_each = "-isystem",
+    )
+    args.add_all(
+        compilation_context.quote_includes.to_list(),
+        before_each = "-iquote",
+    )
+
+    ctx.actions.run(
+        outputs = [output_file],
+        inputs = inputs,
+        executable = clang_tidy_executable,
+        arguments = [args],
+        mnemonic = "ClangTidy",
+        progress_message = "Tidying {}".format(input_file.short_path),
+        use_default_shell_env = True,
+    )
+
+    return output_file
+
+def _clang_format_impl(target, ctx):
+    clang_format_config = ctx.attr._clang_format_config.data_runfiles.files
+    clang_format_executable = ctx.attr._clang_format_executable.files_to_run
+
+    supported_extensions = ["cc", "h", "m", "mm", "proto"]
+    input_files = []
+    for input_target in getattr(ctx.rule.attr, "srcs", []):
+        for file in input_target.files.to_list():
+            if file.is_source and file.extension in supported_extensions:
+                input_files.append(file)
+    if CcInfo in target:
+        for file in target[CcInfo].compilation_context.direct_headers:
+            if file.is_source and file.extension in supported_extensions:
+                input_files.append(file)
+
+    output_files = []
+    for input_file in input_files:
+        output_file = _run_clang_format(
+            ctx,
+            clang_format_config,
+            clang_format_executable,
+            input_file,
+        )
+        output_files.append(output_file)
+
+    return [OutputGroupInfo(report = depset(direct = output_files))]
+
+def _clang_tidy_impl(target, ctx):
+    if CcInfo not in target:
+        return []
+
+    clang_tidy_config = ctx.attr._clang_tidy_config.data_runfiles.files
+    clang_tidy_executable = ctx.attr._clang_tidy_executable.files_to_run
+
+    cc_toolchain = find_cpp_toolchain(ctx)
+    cc_feature_configuration = cc_common.configure_features(
+        ctx = ctx,
+        cc_toolchain = cc_toolchain,
+    )
+    cc_user_compile_flags = ctx.fragments.cpp.cxxopts + ctx.fragments.cpp.copts
+    cc_compile_variables = cc_common.create_compile_variables(
+        feature_configuration = cc_feature_configuration,
+        cc_toolchain = cc_toolchain,
+        user_compile_flags = cc_user_compile_flags,
+    )
+    cc_flags = cc_common.get_memory_inefficient_command_line(
+        feature_configuration = cc_feature_configuration,
+        action_name = CPP_COMPILE_ACTION_NAME,
+        variables = cc_compile_variables,
+    )
+    rule_flags = getattr(ctx.rule.attr, "copts", [])
+    flags = cc_flags + rule_flags
+
+    compilation_context = target[CcInfo].compilation_context
+
+    input_files = []
+    for src in getattr(ctx.rule.attr, "srcs", []):
+        input_files += [src for src in src.files.to_list() if src.is_source]
+
+    output_files = []
+    for input_file in input_files:
+        output_file = _run_clang_tidy(
+            ctx,
+            clang_tidy_config,
+            clang_tidy_executable,
+            flags,
+            compilation_context,
+            input_file,
+            target.label.name,
+        )
+        output_files.append(output_file)
+
+    return [OutputGroupInfo(report = depset(direct = output_files))]
+
+clang_format = aspect(
+    implementation = _clang_format_impl,
+    attrs = {
+        "_clang_format_executable": attr.label(
+            default = Label("//toolchain/style:clang_format"),
+        ),
+        "_clang_format_config": attr.label(
+            default = Label("//:clang_format_config"),
+        ),
+    },
+    doc = "Run Clang Format and apply changes.",
+)
+
+clang_tidy = aspect(
+    implementation = _clang_tidy_impl,
+    fragments = ["cpp"],
+    attrs = {
+        "_cc_toolchain": attr.label(
+            default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
+        ),
+        "_clang_tidy_executable": attr.label(
+            default = Label("//toolchain/style:clang_tidy"),
+        ),
+        "_clang_tidy_config": attr.label(
+            default = Label("//:clang_tidy_config"),
+        ),
+    },
+    doc = "Run Clang Tidy and report violations.",
+)

--- a/util/flags/optional.h
+++ b/util/flags/optional.h
@@ -20,9 +20,7 @@ class Optional {
   constexpr Optional(const T& item);  // NOLINT(google-explicit-constructor)
   constexpr Optional(T&& item);       // NOLINT(google-explicit-constructor)
   // NOLINTNEXTLINE(google-explicit-constructor)
-  constexpr Optional(const std::optional<T>& optional);
-  // NOLINTNEXTLINE(google-explicit-constructor)
-  constexpr Optional(std::optional<T>&& optional);
+  constexpr Optional(std::optional<T> optional);
 
   [[nodiscard]] constexpr auto HasValue() const -> bool;
   [[nodiscard]] constexpr auto Value() const& -> const T&;
@@ -51,12 +49,8 @@ template <class T>
 constexpr Optional<T>::Optional(T&& item) : item_{std::move(item)} {}
 
 template <class T>
-constexpr Optional<T>::Optional(const std::optional<T>& optional)
-    : item_{optional} {}
-
-template <class T>
-constexpr Optional<T>::Optional(std::optional<T>&& optional)
-    : item_{optional} {}
+constexpr Optional<T>::Optional(std::optional<T> optional)
+    : item_{std::move(optional)} {}
 
 template <class T>
 constexpr auto Optional<T>::HasValue() const -> bool {

--- a/util/flags/optional_test.cc
+++ b/util/flags/optional_test.cc
@@ -30,21 +30,7 @@ TEST(Optional, RvalueConstructor) {  // NOLINT
   ASSERT_EQ(optional.Value(), 42);
 }
 
-TEST(Optional, StdOptionalLvalueConstructor) {  // NOLINT
-  {
-    constexpr std::optional<int64> std_optional{42};
-    constexpr Optional optional{std_optional};
-    ASSERT_TRUE(optional.HasValue());
-    ASSERT_EQ(optional.Value(), std_optional);
-  }
-  {
-    constexpr std::optional<int64> std_optional{};
-    constexpr Optional optional{std_optional};
-    ASSERT_FALSE(optional.HasValue());
-  }
-}
-
-TEST(Optional, StdOptionalRvalueConstructor) {  // NOLINT
+TEST(Optional, StdOptionalConstructor) {  // NOLINT
   {
     constexpr Optional optional{std::optional<int64>{42}};
     ASSERT_TRUE(optional.HasValue());

--- a/util/flat_map/flat_map.h
+++ b/util/flat_map/flat_map.h
@@ -31,17 +31,17 @@ class FlatMap {
   // NOLINTNEXTLINE(readability-identifier-naming)
   [[nodiscard]] constexpr auto size() const -> decltype(Size);
   // NOLINTNEXTLINE(readability-identifier-naming)
-  constexpr auto begin() const -> ConstIterator;
+  [[nodiscard]] constexpr auto begin() const -> ConstIterator;
   // NOLINTNEXTLINE(readability-identifier-naming)
-  constexpr auto begin() -> Iterator;
+  [[nodiscard]] constexpr auto begin() -> Iterator;
   // NOLINTNEXTLINE(readability-identifier-naming)
-  constexpr auto cbegin() const -> ConstIterator;
+  [[nodiscard]] constexpr auto cbegin() const -> ConstIterator;
   // NOLINTNEXTLINE(readability-identifier-naming)
-  constexpr auto end() const -> ConstIterator;
+  [[nodiscard]] constexpr auto end() const -> ConstIterator;
   // NOLINTNEXTLINE(readability-identifier-naming)
-  constexpr auto end() -> Iterator;
+  [[nodiscard]] constexpr auto end() -> Iterator;
   // NOLINTNEXTLINE(readability-identifier-naming)
-  constexpr auto cend() const -> ConstIterator;
+  [[nodiscard]] constexpr auto cend() const -> ConstIterator;
 
  private:
   std::array<ValueType, Size> data_;
@@ -61,7 +61,7 @@ template <std::size_t... Indices>
 constexpr FlatMap<Key, Value, Size>::FlatMap(
     std::initializer_list<ValueType>& data,
     std::index_sequence<Indices...> /*unused*/)
-    : data_{*(data.begin() + Indices)...} {}
+    : data_{*(std::next(data.begin(), Indices))...} {}
 
 template <class Key, class Value, std::size_t Size>
 constexpr auto FlatMap<Key, Value, Size>::FirstValueForKey(const Key& key) const

--- a/util/memory/owned_ptr.h
+++ b/util/memory/owned_ptr.h
@@ -68,7 +68,7 @@ constexpr auto OwnedPtr<T>::Ptr() const -> T* {
 
 template <class T>
 constexpr auto OwnedPtr<T>::Take() -> T* {
-  auto ptr = ptr_;
+  auto* ptr = ptr_;
   ptr_ = nullptr;
   owner_ = nullptr;
   return ptr;

--- a/util/result.h
+++ b/util/result.h
@@ -65,6 +65,7 @@ class Result {
 
  private:
   template <class T1, class T2, class E1, class E2>
+  // False positive. NOLINTNEXTLINE(readability-redundant-declaration)
   friend constexpr auto operator==(const Result<T1, E1>& lhs,
                                    const Result<T2, E2>& rhs) -> bool;
 

--- a/util/time/clock_mock.h
+++ b/util/time/clock_mock.h
@@ -33,10 +33,6 @@ constexpr auto MakeTimePoint(const int64 timestamp_nanoseconds)
   const auto duration =
       std::chrono::duration_cast<typename ChronoClock::duration>(
           duration_nanoseconds);
-  // `ChronoClock` might have a different duration than
-  // `std::chrono::nanoseconds` resulting in a loss of precision.
-  assert(std::chrono::duration_cast<std::chrono::nanoseconds>(duration) ==
-         duration_nanoseconds);
   return std::chrono::time_point<ChronoClock>{duration};
 }
 


### PR DESCRIPTION
Runs Clang Tidy and Clang Format using an Aspect to take advantage of Bazel's build system. This makes these style checks considerably faster. Clean (empty cache) runs are faster thanks to parallelization and because we no longer need to generate a compilation database. Additionally, incremental runs much faster because we only run the checks on the source files that have changed (and their dependencies for Clang Tidy).

Resolves #13, #14, and #86, and introduces #135. I don't feel that this bug is a blocker but is something about which we should be aware.

The new Clang Tidy technique picked up additional headers lint violations that were previously undetected. These are now fixed.

### Metrics

At the time of this writing doing a "clean" run (empty cache) on my machine, Clang Tidy is now  **5x faster** and Clang Format is now **4x faster**.

Clang Tidy | Original (s) | New (s)
--- | ---: | ---:
Clean | 1,995.58 | 323.96
Single file modification* | 1,995.58 | 25.51
No modifications | 1,995.58 | 0.70

Clang Format | Original (s) | New (s)
--- | ---: | ---:
Clean | 5.94 | 1.16
Single file modification | 5.94 | 0.84
No modifications | 5.94 | 0.26

In CI, the Clang Tidy step is down from >50 minutes to 16-23 minutes.

Note: Wall clock time.

\* Single file modification at the top of the dependency graph.