### PR TITLE
Explicit C++11 in integration_test.sh

### DIFF
--- a/spoor/integration_test.sh
+++ b/spoor/integration_test.sh
@@ -21,6 +21,7 @@ fi
 
 "$CLANGXX" \
   "$BASE_PATH/test_data/fib.cc" \
+  -std=c++11 \
   -g \
   -O0 \
   -emit-llvm \


### PR DESCRIPTION
`integration_test.sh` fails if `clang++`'s default standard is less than C++11. This PR adds an explicit `-std=c++11` to resolve the failure in those environments.