### PR TITLE
Python toolchain setup

### DIFF
--- a/.build/azure-pipelines.yml
+++ b/.build/azure-pipelines.yml
@@ -79,19 +79,16 @@ jobs:
     displayName: Copyright header
   - script: |
       bazel build //... \
-          --aspects toolchain/style/style.bzl%clang_format \
+          --aspects toolchain/style/style.bzl%format \
           --output_groups=report \
           --keep_going
-      git diff --exit-code
-    displayName: Clang Format
-  - script: |
       bazel run //toolchain/style:buildifier
       git diff --exit-code
-    displayName: Buildifier
+    displayName: Format
   - script: |
       bazel build //... \
           --crosstool_top=//toolchain/crosstool:llvm_toolchain \
-          --aspects toolchain/style/style.bzl%clang_tidy \
+          --aspects toolchain/style/style.bzl%lint \
           --output_groups=report \
           --keep_going
-    displayName: Clang Tidy
+    displayName: Lint

--- a/.build/templates/install-common.yml
+++ b/.build/templates/install-common.yml
@@ -11,6 +11,8 @@ steps:
 - script: echo '##vso[task.prependpath]/usr/local/opt/llvm/bin'
   displayName: Install LLVM (macOS)
   condition: eq(variables['Agent.OS'], 'Darwin')
+- script: pip install yapf
+  displayName: Install YAPF
 - script: cat .build/macos-ci.bazelrc .build/ci.bazelrc > .bazelrc
   displayName: Create .bazelrc (macOS)
   condition: eq(variables['Agent.OS'], 'Darwin')

--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,11 @@ compile_commands.json
 .DS_Store
 
 # Python
-venv
+.env
+.venv
+__pycache__/
+env/
+venv/
 
 # Testing
 coverage

--- a/.style.yapf
+++ b/.style.yapf
@@ -1,0 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+[style]
+based_on_style = google
+column_limit = 80

--- a/BUILD
+++ b/BUILD
@@ -12,3 +12,9 @@ filegroup(
     data = [".clang-tidy"],
     visibility = ["//visibility:public"],
 )
+
+filegroup(
+    name = "yapf_config",
+    data = [".style.yapf"],
+    visibility = ["//visibility:public"],
+)

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# Spoor
-[![Build Status][build-status-badge]][build-status]
+# Spoor [![Build Status][build-status-badge]][build-status]
 
 # Getting Started
 
 ## Requirements
 * A C++ compiler that supports [C++20][c++20-compiler] such as Clang 12.
+* Python 3.
 * [Bazel][bazel].
-* [Clang Format][clang-format] and [Clang Tidy][clang-tidy] to style and lint
-  code.
+* [Clang Format][clang-format], [Clang Tidy][clang-tidy], and [YAPF][yapf] to
+  format and lint code.
 
 ## Build
 ```
@@ -21,19 +21,19 @@ $ bazel test //...
 
 ## Style and lint
 
-### Format C++, Objective-C, and Protobuf files
+### Format C++, Objective-C, Python
 ```
-$ bazel build //... --aspects toolchain/style/style.bzl%clang_format --output_groups=report
+$ bazel build //... --aspects toolchain/style/style.bzl%format --output_groups=report
 ```
 
-### Format
+### Format Starlark
 ```
 $ bazel run //toolchain/style:buildifier
 ```
 
-### Lint C++ and Objective-C files
+### Lint C++
 ```
-$ bazel build //... --aspects toolchain/style/style.bzl%clang_tidy --output_groups=report
+$ bazel build //... --aspects toolchain/style/style.bzl%lint --output_groups=report
 ```
 
 ### Add copyright header
@@ -89,4 +89,5 @@ comments.
 [opencode-email]: mailto:opencode@microsoft.com
 [protoc-installation]: https://grpc.io/docs/protoc-installation/
 [style-guide]: STYLE_GUIDE.md
+[yapf]: https://github.com/google/yapf
 [yarn]: https://classic.yarnpkg.com/

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -13,6 +13,24 @@ http_archive(
     url = "https://github.com/microsoft/GSL/archive/ec6cd75d57f68b6566e1d406de20e59636a881e7.tar.gz",
 )
 
+http_archive(
+    name = "rules_python",
+    sha256 = "778197e26c5fbeb07ac2a2c5ae405b30f6cb7ad1f5510ea6fdac03bded96cc6f",
+    url = "https://github.com/bazelbuild/rules_python/releases/download/0.2.0/rules_python-0.2.0.tar.gz",
+)
+
+load("@rules_python//python:pip.bzl", "pip_install")
+
+pip_install(
+    name = "pip_deps",
+    requirements = "//:requirements.txt",
+)
+
+pip_install(
+    name = "pip_deps_dev",
+    requirements = "//:requirements-dev.txt",
+)
+
 # TODO(#133): Use LLVM's Bazel build configuration when it is checked in.
 http_archive(
     name = "com_google_llvm_bazel",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,4 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+pytest~=6.2.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.

--- a/toolchain/copyright_header/BUILD
+++ b/toolchain/copyright_header/BUILD
@@ -20,5 +20,6 @@ cc_binary(
     deps = [
         "//util:numeric",
         "//util:result",
+        "//util/flat_map",
     ],
 )

--- a/toolchain/style/BUILD
+++ b/toolchain/style/BUILD
@@ -18,3 +18,10 @@ sh_binary(
     data = ["//:clang_tidy_config"],
     visibility = ["//visibility:public"],
 )
+
+sh_binary(
+    name = "yapf",
+    srcs = ["yapf.sh"],
+    data = ["//:yapf_config"],
+    visibility = ["//visibility:public"],
+)

--- a/toolchain/style/yapf.sh
+++ b/toolchain/style/yapf.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# Usage:
+# `yapf.sh output_file input_file args...`
+
+set -eu
+
+if command -v yapf &> /dev/null; then
+  YAPF="yapf"
+else
+  echo "yapf not found"
+  exit 1
+fi
+
+OUTPUT_FILE="$1"
+shift
+INPUT_FILE="$1"
+
+"$YAPF" "$@"
+cp "$INPUT_FILE" "$OUTPUT_FILE"

--- a/toolchain/xcode/BUILD
+++ b/toolchain/xcode/BUILD
@@ -1,0 +1,25 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
+load("@pip_deps_dev//:requirements.bzl", "requirement")
+
+py_library(
+    name = "hello_lib",
+    srcs = ["hello_lib.py"],
+)
+
+py_binary(
+    name = "hello",
+    srcs = ["hello.py"],
+    deps = [":hello_lib"],
+)
+
+py_test(
+    name = "hello_test",
+    srcs = ["hello_test.py"],
+    deps = [
+        ":hello_lib",
+        requirement("pytest"),
+    ],
+)

--- a/toolchain/xcode/hello.py
+++ b/toolchain/xcode/hello.py
@@ -1,0 +1,9 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+import sys
+from hello_lib import say_hello
+
+name = sys.argv[1] if 1 < len(sys.argv) else None
+message = hello_lib.say_hello(name)
+print(message)

--- a/toolchain/xcode/hello_lib.py
+++ b/toolchain/xcode/hello_lib.py
@@ -1,0 +1,8 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+
+def say_hello(name):
+    if name is None:
+        name = "world"
+    return "Hello, {}!".format(name)

--- a/toolchain/xcode/hello_test.py
+++ b/toolchain/xcode/hello_test.py
@@ -1,0 +1,15 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+import pytest
+import sys
+import hello_lib
+
+
+def test_say_hello():
+    assert hello_lib.say_hello(None) == 'Hello, world!'
+    assert hello_lib.say_hello('name') == 'Hello, name!'
+
+
+if __name__ == '__main__':
+    sys.exit(pytest.main(sys.argv[1:]))


### PR DESCRIPTION
Set up Python support for this project.

* Build and test Python code.
* Format Python code with [YAPF](https://github.com/google/yapf) which uses a similar algorithm to Clang Tidy. This is integrated with the format Bazel aspect.
* Refactor and fix add_copyright_header.