### PR TITLE
Refactor instrumentation function map output file config

### DIFF
--- a/spoor/instrumentation/config/command_line_config.cc
+++ b/spoor/instrumentation/config/command_line_config.cc
@@ -47,11 +47,6 @@ ABSL_FLAG(  // NOLINT
     spoor::instrumentation::config::kInjectInstrumentationDefaultValue,
     spoor::instrumentation::config::kInjectInstrumentationDoc);
 ABSL_FLAG(  // NOLINT
-    std::string, instrumentation_map_output_path,
-    std::string{spoor::instrumentation::config::
-                    kInstrumentedFunctionMapOutputPathDefaultValue},
-    spoor::instrumentation::config::kInstrumentedFunctionMapOutputPathDoc);
-ABSL_FLAG(  // NOLINT
     uint32, min_instruction_threshold,
     spoor::instrumentation::config::kMinInstructionThresholdDefaultValue,
     spoor::instrumentation::config::kMinInstructionThresholdDoc);
@@ -64,6 +59,11 @@ ABSL_FLAG(  // NOLINT
     std::string, output_file,
     std::string{spoor::instrumentation::config::kOutputFileDefaultValue},
     spoor::instrumentation::config::kOutputFileDoc);
+ABSL_FLAG(  // NOLINT
+    std::string, output_function_map_file,
+    std::string{
+        spoor::instrumentation::config::kOutputFunctionMapFileDefaultValue},
+    spoor::instrumentation::config::kOutputFunctionMapFileDoc);
 ABSL_FLAG(  // NOLINT
     spoor::instrumentation::config::OutputLanguage, output_language,
     spoor::instrumentation::config::kOutputLanguageDefaultValue,
@@ -87,12 +87,12 @@ auto ConfigFromCommandLineOrEnv(const int argc, char** argv,
   absl::SetFlag(&FLAGS_initialize_runtime, env_config.initialize_runtime);
   absl::SetFlag(&FLAGS_inject_instrumentation,
                 env_config.inject_instrumentation);
-  absl::SetFlag(&FLAGS_instrumentation_map_output_path,
-                env_config.instrumented_function_map_output_path);
   absl::SetFlag(&FLAGS_min_instruction_threshold,
                 env_config.min_instruction_threshold);
   absl::SetFlag(&FLAGS_module_id, env_config.module_id);
   absl::SetFlag(&FLAGS_output_file, env_config.output_file);
+  absl::SetFlag(&FLAGS_output_function_map_file,
+                env_config.output_function_map_file);
   absl::SetFlag(&FLAGS_output_language, env_config.output_language);
   auto positional_args = absl::ParseCommandLine(argc, argv);
   Config config{
@@ -104,12 +104,11 @@ auto ConfigFromCommandLineOrEnv(const int argc, char** argv,
           absl::GetFlag(FLAGS_function_blocklist_file).StdOptional(),
       .initialize_runtime = absl::GetFlag(FLAGS_initialize_runtime),
       .inject_instrumentation = absl::GetFlag(FLAGS_inject_instrumentation),
-      .instrumented_function_map_output_path =
-          absl::GetFlag(FLAGS_instrumentation_map_output_path),
       .min_instruction_threshold =
           absl::GetFlag(FLAGS_min_instruction_threshold),
       .module_id = absl::GetFlag(FLAGS_module_id).StdOptional(),
       .output_file = absl::GetFlag(FLAGS_output_file),
+      .output_function_map_file = absl::GetFlag(FLAGS_output_function_map_file),
       .output_language = absl::GetFlag(FLAGS_output_language)};
   return std::make_pair(std::move(config), std::move(positional_args));
 }

--- a/spoor/instrumentation/config/command_line_config.h
+++ b/spoor/instrumentation/config/command_line_config.h
@@ -24,10 +24,10 @@ ABSL_DECLARE_FLAG(  // NOLINT
     util::flags::Optional<std::string>, function_blocklist_file);
 ABSL_DECLARE_FLAG(bool, initialize_runtime);                       // NOLINT
 ABSL_DECLARE_FLAG(bool, inject_instrumentation);                   // NOLINT
-ABSL_DECLARE_FLAG(std::string, instrumentation_map_output_path);   // NOLINT
 ABSL_DECLARE_FLAG(uint32, min_instruction_threshold);              // NOLINT
 ABSL_DECLARE_FLAG(util::flags::Optional<std::string>, module_id);  // NOLINT
 ABSL_DECLARE_FLAG(std::string, output_file);                       // NOLINT
+ABSL_DECLARE_FLAG(std::string, output_function_map_file);          // NOLINT
 ABSL_DECLARE_FLAG(                                                 // NOLINT
     spoor::instrumentation::config::OutputLanguage, output_language);
 

--- a/spoor/instrumentation/config/config.cc
+++ b/spoor/instrumentation/config/config.cc
@@ -11,10 +11,9 @@ auto operator==(const Config& lhs, const Config& rhs) -> bool {
          lhs.enable_runtime == rhs.enable_runtime &&
          lhs.initialize_runtime == rhs.initialize_runtime &&
          lhs.inject_instrumentation == rhs.inject_instrumentation &&
-         lhs.instrumented_function_map_output_path ==
-             rhs.instrumented_function_map_output_path &&
          lhs.min_instruction_threshold == rhs.min_instruction_threshold &&
          lhs.module_id == rhs.module_id && lhs.output_file == rhs.output_file &&
+         lhs.output_function_map_file == rhs.output_function_map_file &&
          lhs.output_language == rhs.output_language;
 }
 

--- a/spoor/instrumentation/config/config.h
+++ b/spoor/instrumentation/config/config.h
@@ -25,10 +25,10 @@ struct alignas(128) Config {
   std::optional<std::string> function_blocklist_file;
   bool initialize_runtime;
   bool inject_instrumentation;
-  std::string instrumented_function_map_output_path;
   uint32 min_instruction_threshold;
   std::optional<std::string> module_id;
   std::string output_file;
+  std::string output_function_map_file;
   OutputLanguage output_language;
 };
 
@@ -66,9 +66,9 @@ constexpr std::string_view kInjectInstrumentationDoc{
     "Inject Spoor instrumentation."};
 constexpr auto kInjectInstrumentationDefaultValue{true};
 
-constexpr std::string_view kInstrumentedFunctionMapOutputPathDoc{
+constexpr std::string_view kOutputFunctionMapFileDoc{
     "Spoor function map output file."};
-constexpr std::string_view kInstrumentedFunctionMapOutputPathDefaultValue{"."};
+constexpr std::string_view kOutputFunctionMapFileDefaultValue{};
 
 constexpr std::string_view kMinInstructionThresholdDoc{
     "Minimum number of LLVM IR instructions required to instrument a "

--- a/spoor/instrumentation/config/config_test.cc
+++ b/spoor/instrumentation/config/config_test.cc
@@ -18,10 +18,10 @@ TEST(Config, ConfigEquality) {  // NOLINT
       .function_blocklist_file = "/path/to/blocklist.txt",
       .initialize_runtime = false,
       .inject_instrumentation = false,
-      .instrumented_function_map_output_path = "/path/to/output/",
       .min_instruction_threshold = 42,
       .module_id = "ModuleId",
       .output_file = "/path/to/output_file.ll",
+      .output_function_map_file = "/path/to/file.spoor_function_map",
       .output_language = OutputLanguage::kIr};
   const Config config_b{
       .enable_runtime = false,
@@ -30,10 +30,10 @@ TEST(Config, ConfigEquality) {  // NOLINT
       .function_blocklist_file = "/path/to/blocklist.txt",
       .initialize_runtime = false,
       .inject_instrumentation = false,
-      .instrumented_function_map_output_path = "/path/to/output/",
       .min_instruction_threshold = 42,
       .module_id = "ModuleId",
       .output_file = "/path/to/output_file.ll",
+      .output_function_map_file = "/path/to/file.spoor_function_map",
       .output_language = OutputLanguage::kIr};
   const Config config_c{.enable_runtime = true,
                         .force_binary_output = false,
@@ -41,10 +41,10 @@ TEST(Config, ConfigEquality) {  // NOLINT
                         .function_blocklist_file = "",
                         .initialize_runtime = true,
                         .inject_instrumentation = true,
-                        .instrumented_function_map_output_path = "",
                         .min_instruction_threshold = 0,
                         .module_id = "",
                         .output_file = "",
+                        .output_function_map_file = "",
                         .output_language = OutputLanguage::kBitcode};
   ASSERT_EQ(config_a, config_b);
   ASSERT_NE(config_a, config_c);

--- a/spoor/instrumentation/config/env_config.cc
+++ b/spoor/instrumentation/config/env_config.cc
@@ -31,9 +31,6 @@ auto ConfigFromEnv(const util::env::GetEnv& get_env) -> Config {
       .inject_instrumentation =
           GetEnvOrDefault(kInjectInstrumentationKey.data(),
                           kInjectInstrumentationDefaultValue, get_env),
-      .instrumented_function_map_output_path = GetEnvOrDefault(
-          kInstrumentedFunctionMapOutputPathKey.data(),
-          std::string{kInstrumentedFunctionMapOutputPathDefaultValue}, get_env),
       .min_instruction_threshold =
           GetEnvOrDefault(kMinInstructionThresholdKey.data(),
                           kMinInstructionThresholdDefaultValue, get_env),
@@ -41,6 +38,9 @@ auto ConfigFromEnv(const util::env::GetEnv& get_env) -> Config {
                                    true, get_env),
       .output_file = GetEnvOrDefault(
           kOutputFileKey.data(), std::string{kOutputFileDefaultValue}, get_env),
+      .output_function_map_file = GetEnvOrDefault(
+          kOutputFunctionMapFileKey.data(),
+          std::string{kOutputFunctionMapFileDefaultValue}, get_env),
       .output_language = GetEnvOrDefault(kOutputLanguageKey.data(),
                                          kOutputLanguageDefaultValue,
                                          kOutputLanguages, true, get_env)};

--- a/spoor/instrumentation/config/env_config.h
+++ b/spoor/instrumentation/config/env_config.h
@@ -22,12 +22,12 @@ constexpr std::string_view kInitializeRuntimeKey{
     "SPOOR_INSTRUMENTATION_RUNTIME_INITIALIZE_RUNTIME"};
 constexpr std::string_view kInjectInstrumentationKey{
     "SPOOR_INSTRUMENTATION_INJECT_INSTRUMENTATION"};
-constexpr std::string_view kInstrumentedFunctionMapOutputPathKey{
-    "SPOOR_INSTRUMENTATION_INSTRUMENTED_FUNCTION_MAP_OUTPUT_PATH"};
 constexpr std::string_view kMinInstructionThresholdKey{
     "SPOOR_INSTRUMENTATION_MIN_INSTRUCTION_THRESHOLD"};
 constexpr std::string_view kModuleIdKey{"SPOOR_INSTRUMENTATION_MODULE_ID"};
 constexpr std::string_view kOutputFileKey{"SPOOR_INSTRUMENTATION_OUTPUT_FILE"};
+constexpr std::string_view kOutputFunctionMapFileKey{
+    "SPOOR_INSTRUMENTATION_OUTPUT_FUNCTION_MAP_FILE"};
 constexpr std::string_view kOutputLanguageKey{
     "SPOOR_INSTRUMENTATION_OUTPUT_LANGUAGE"};
 

--- a/spoor/instrumentation/config/env_config_test.cc
+++ b/spoor/instrumentation/config/env_config_test.cc
@@ -20,27 +20,28 @@ using spoor::instrumentation::config::kFunctionAllowListFileKey;
 using spoor::instrumentation::config::kFunctionBlocklistFileKey;
 using spoor::instrumentation::config::kInitializeRuntimeKey;
 using spoor::instrumentation::config::kInjectInstrumentationKey;
-using spoor::instrumentation::config::kInstrumentedFunctionMapOutputPathKey;
 using spoor::instrumentation::config::kMinInstructionThresholdKey;
 using spoor::instrumentation::config::kModuleIdKey;
 using spoor::instrumentation::config::kOutputFileKey;
+using spoor::instrumentation::config::kOutputFunctionMapFileKey;
 using spoor::instrumentation::config::kOutputLanguageKey;
 using spoor::instrumentation::config::OutputLanguage;
 
 TEST(EnvConfig, GetsUserProvidedValue) {  // NOLINT
   const auto get_env = [](const char* key) {
     constexpr util::flat_map::FlatMap<std::string_view, std::string_view, 11>
-        environment{{kEnableRuntimeKey, "false"},
-                    {kForceBinaryOutputKey, "true"},
-                    {kFunctionAllowListFileKey, "/path/to/allow_list.txt"},
-                    {kFunctionBlocklistFileKey, "/path/to/blocklist.txt"},
-                    {kInitializeRuntimeKey, "false"},
-                    {kInjectInstrumentationKey, "false"},
-                    {kInstrumentedFunctionMapOutputPathKey, "/path/to/output/"},
-                    {kMinInstructionThresholdKey, "42"},
-                    {kModuleIdKey, "ModuleId"},
-                    {kOutputFileKey, "/path/to/output_file.ll"},
-                    {kOutputLanguageKey, "      iR     "}};
+        environment{
+            {kEnableRuntimeKey, "false"},
+            {kForceBinaryOutputKey, "true"},
+            {kFunctionAllowListFileKey, "/path/to/allow_list.txt"},
+            {kFunctionBlocklistFileKey, "/path/to/blocklist.txt"},
+            {kInitializeRuntimeKey, "false"},
+            {kInjectInstrumentationKey, "false"},
+            {kMinInstructionThresholdKey, "42"},
+            {kModuleIdKey, "ModuleId"},
+            {kOutputFileKey, "/path/to/output_file.ll"},
+            {kOutputFunctionMapFileKey, "/path/to/file.spoor_function_map"},
+            {kOutputLanguageKey, "      iR     "}};
     return environment.FirstValueForKey(key).value_or(nullptr).data();
   };
   const Config expected_config{
@@ -50,10 +51,10 @@ TEST(EnvConfig, GetsUserProvidedValue) {  // NOLINT
       .function_blocklist_file = "/path/to/blocklist.txt",
       .initialize_runtime = false,
       .inject_instrumentation = false,
-      .instrumented_function_map_output_path = "/path/to/output/",
       .min_instruction_threshold = 42,
       .module_id = "ModuleId",
       .output_file = "/path/to/output_file.ll",
+      .output_function_map_file = "/path/to/file.spoor_function_map",
       .output_language = OutputLanguage::kIr};
   ASSERT_EQ(ConfigFromEnv(get_env), expected_config);
 }
@@ -68,10 +69,10 @@ TEST(EnvConfig, UsesDefaultValueWhenNotSpecified) {  // NOLINT
                                .function_blocklist_file = {},
                                .initialize_runtime = true,
                                .inject_instrumentation = true,
-                               .instrumented_function_map_output_path = ".",
                                .min_instruction_threshold = 0,
                                .module_id = {},
                                .output_file = "-",
+                               .output_function_map_file = "",
                                .output_language = OutputLanguage::kBitcode};
   ASSERT_EQ(ConfigFromEnv(get_env), expected_config);
 }
@@ -85,10 +86,10 @@ TEST(EnvConfig, UsesDefaultValueForEmptyStringValues) {  // NOLINT
                     {kFunctionBlocklistFileKey, ""},
                     {kInitializeRuntimeKey, ""},
                     {kInjectInstrumentationKey, ""},
-                    {kInstrumentedFunctionMapOutputPathKey, ""},
                     {kMinInstructionThresholdKey, ""},
                     {kModuleIdKey, ""},
                     {kOutputFileKey, ""},
+                    {kOutputFunctionMapFileKey, ""},
                     {kOutputLanguageKey, ""}};
     return environment.FirstValueForKey(key).value_or(nullptr).data();
   };
@@ -98,10 +99,10 @@ TEST(EnvConfig, UsesDefaultValueForEmptyStringValues) {  // NOLINT
                                .function_blocklist_file = {},
                                .initialize_runtime = true,
                                .inject_instrumentation = true,
-                               .instrumented_function_map_output_path = "",
                                .min_instruction_threshold = 0,
                                .module_id = {},
                                .output_file = "",
+                               .output_function_map_file = "",
                                .output_language = OutputLanguage::kBitcode};
   ASSERT_EQ(ConfigFromEnv(get_env), expected_config);
 }

--- a/spoor/instrumentation/inject_instrumentation/BUILD
+++ b/spoor/instrumentation/inject_instrumentation/BUILD
@@ -22,7 +22,6 @@ cc_library(
         "//util:numeric",
         "//util/time:clock",
         "@com_apple_swift//:demangle",
-        "@com_google_absl//absl/strings:str_format",
         "@com_google_cityhash//:city_hash",
         "@com_microsoft_gsl//:gsl",
         "@llvm-project//llvm:Core",

--- a/spoor/instrumentation/inject_instrumentation/inject_instrumentation.h
+++ b/spoor/instrumentation/inject_instrumentation/inject_instrumentation.h
@@ -6,9 +6,8 @@
 
 #pragma once
 
-#include <filesystem>
-#include <functional>
 #include <memory>
+#include <ostream>
 #include <string>
 #include <unordered_set>
 #include <utility>
@@ -19,26 +18,18 @@
 #include "llvm/IR/Module.h"
 #include "llvm/IR/PassManager.h"
 #include "llvm/Passes/PassPlugin.h"
-#include "llvm/Support/raw_ostream.h"
 #include "spoor/proto/spoor.pb.h"
 #include "util/numeric.h"
 #include "util/time/clock.h"
 
 namespace spoor::instrumentation::inject_instrumentation {
 
-constexpr std::string_view kInstrumentedFunctionMapFileExtension{
-    "spoor_function_map"};
-
 class InjectInstrumentation
     : public llvm::PassInfoMixin<InjectInstrumentation> {
  public:
   struct alignas(128) Options {
     bool inject_instrumentation;
-    std::filesystem::path instrumented_function_map_output_path;
-    std::function<std::unique_ptr<llvm::raw_ostream>(
-        llvm::StringRef /*file_path*/,
-        gsl::not_null<std::error_code*> /*error*/)>
-        instrumented_function_map_output_stream;
+    std::unique_ptr<std::ostream> output_function_map_stream;
     std::unique_ptr<util::time::SystemClock> system_clock;
     std::unordered_set<std::string> function_allow_list;
     std::unordered_set<std::string> function_blocklist;

--- a/spoor/instrumentation/register_pass_test.sh
+++ b/spoor/instrumentation/register_pass_test.sh
@@ -24,7 +24,8 @@ else
   exit 1
 fi
 
-OUTPUT_IR_FILE="instrumented.ll"
+OUTPUT_IR_FILE="fib_instrumented.ll"
+export SPOOR_INSTRUMENTATION_OUTPUT_FUNCTION_MAP_FILE="fib.spoor_function_map"
 
 # TODO(#131): Fix `opt` pass plugin support for IR instrumentation.
 set +e
@@ -37,12 +38,9 @@ set -e
 
 exit 0
 
-FUNCTION_MAP_FILE=$(find . -type f -name "*.spoor_function_map")
-
-if ! [[ -s "$FUNCTION_MAP_FILE" ]]; then
-  echo "The function map file '$FUNCTION_MAP_FILE' is empty."
+if ! [[ -s "$SPOOR_INSTRUMENTATION_OUTPUT_FUNCTION_MAP_FILE" ]]; then
+  echo "The function map file" \
+      "'$SPOOR_INSTRUMENTATION_OUTPUT_FUNCTION_MAP_FILE' is empty or was not" \
+      "created."
   exit 1
 fi
-
-grep _spoor_runtime_LogFunctionEntry "$OUTPUT_IR_FILE" > /dev/null
-grep _spoor_runtime_LogFunctionExit "$OUTPUT_IR_FILE" > /dev/null

--- a/spoor/instrumentation/spoor_opt_test.sh
+++ b/spoor/instrumentation/spoor_opt_test.sh
@@ -6,16 +6,17 @@ set -e
 
 BASE_PATH="spoor/instrumentation"
 SPOOR_OPT="$BASE_PATH/spoor_opt"
-OUTPUT_IR_FILE="instrumented.ll"
+OUTPUT_IR_FILE="fib_instrumented.ll"
+OUTPUT_INSTRUMENTED_FUNCTION_MAP_FILE="fib.spoor_function_map"
 
 "$SPOOR_OPT" "$BASE_PATH/test_data/fib.ll" \
   --output_language=ir \
+  --output_function_map_file="$OUTPUT_INSTRUMENTED_FUNCTION_MAP_FILE" \
   --output_file="$OUTPUT_IR_FILE"
 
-FUNCTION_MAP_FILE=$(find . -type f -name "*.spoor_function_map")
-
-if ! [[ -s "$FUNCTION_MAP_FILE" ]]; then
-  echo "The function map file '$FUNCTION_MAP_FILE' is empty."
+if ! [[ -s "$OUTPUT_INSTRUMENTED_FUNCTION_MAP_FILE" ]]; then
+  echo "The function map file '$OUTPUT_INSTRUMENTED_FUNCTION_MAP_FILE' is" \
+      "empty or was not created."
   exit 1
 fi
 

--- a/spoor/integration_test.sh
+++ b/spoor/integration_test.sh
@@ -8,6 +8,7 @@ BASE_PATH="spoor"
 OUTPUT_EXECUTABLE_FILE="fib"
 UNINSTRUMENTED_IR_FILE="fib.ll"
 INSTRUMENTED_IR_FILE="fib_instrumented.ll"
+OUTPUT_FUNCTION_MAP_FILE="fib.spoor_function_map"
 OUTPUT_EXECUTABLE_FILE="fib"
 
 if command -v clang++-12 &> /dev/null; then
@@ -29,8 +30,10 @@ fi
   -o "$UNINSTRUMENTED_IR_FILE"
 
 "$BASE_PATH/instrumentation/spoor_opt" \
+  "$UNINSTRUMENTED_IR_FILE" \
   --output_language=ir \
-  "$UNINSTRUMENTED_IR_FILE" > "$INSTRUMENTED_IR_FILE"
+  --output_function_map_file="$OUTPUT_FUNCTION_MAP_FILE" \
+  --output_file="$INSTRUMENTED_IR_FILE"
 
 "$CLANGXX" \
   "$INSTRUMENTED_IR_FILE" \
@@ -47,5 +50,5 @@ if [ "$RESULT" != "$EXPECTED_RESULT" ]; then
   exit 1
 fi
 
-ls | grep ".spoor_function_map" > /dev/null
+ls | grep "$OUTPUT_FUNCTION_MAP_FILE" > /dev/null
 ls | grep ".spoor_trace" > /dev/null


### PR DESCRIPTION
Refactors the instrumentation config to accept a single function map output file instead of a directory.

* The primary motivation for this change was better interoperability with the toolchain wrapper.
* Bonus: We can now create the file outside the pass and just provide an output stream to the config!
* Bonus: We can now use a `std::ofstream` instead of LLVM's file stream. This has the advantage of allowing us to use Protobuf's `SerializeToOstream` method and prevents a copy to an intermediate string buffer.