### PR TITLE
Install YAPF with Python 3

### DIFF
--- a/.build/templates/install-common.yml
+++ b/.build/templates/install-common.yml
@@ -11,7 +11,7 @@ steps:
 - script: echo '##vso[task.prependpath]/usr/local/opt/llvm/bin'
   displayName: Install LLVM (macOS)
   condition: eq(variables['Agent.OS'], 'Darwin')
-- script: pip install yapf
+- script: pip3 install yapf
   displayName: Install YAPF
 - script: cat .build/macos-ci.bazelrc .build/ci.bazelrc > .bazelrc
   displayName: Create .bazelrc (macOS)


### PR DESCRIPTION
Addresses a CI warning where YAPF was being installed with pip2 instead of pip3 (Python 2 is deprecated).