### PR TITLE
Trace file reader

### DIFF
--- a/spoor/runtime/flush_queue/disk_flush_queue.cc
+++ b/spoor/runtime/flush_queue/disk_flush_queue.cc
@@ -150,9 +150,9 @@ auto DiskFlushQueue::TraceFilePath(const FlushInfo& flush_info) const
   const auto timestamp = std::chrono::duration_cast<std::chrono::nanoseconds>(
                              flush_info.flush_timestamp.time_since_epoch())
                              .count();
-  const auto file_name =
-      absl::StrFormat("%016x-%016x-%016x.%s", options_.session_id,
-                      flush_info.thread_id, timestamp, kTraceFileExtension);
+  const auto file_name = absl::StrFormat(
+      "%016x-%016x-%016x.%s", options_.session_id, flush_info.thread_id,
+      timestamp, trace::kTraceFileExtension);
   return options_.trace_file_path / file_name;
 }
 

--- a/spoor/runtime/flush_queue/disk_flush_queue.h
+++ b/spoor/runtime/flush_queue/disk_flush_queue.h
@@ -26,8 +26,6 @@
 
 namespace spoor::runtime::flush_queue {
 
-constexpr std::string_view kTraceFileExtension{"spoor_trace"};
-
 class DiskFlushQueue final
     : public FlushQueue<buffer::CircularSliceBuffer<trace::Event>> {
  public:

--- a/spoor/runtime/flush_queue/disk_flush_queue_test.cc
+++ b/spoor/runtime/flush_queue/disk_flush_queue_test.cc
@@ -26,13 +26,13 @@
 namespace {
 
 using spoor::runtime::flush_queue::DiskFlushQueue;
-using spoor::runtime::flush_queue::kTraceFileExtension;
 using spoor::runtime::trace::CompressionStrategy;
 using spoor::runtime::trace::Event;
 using spoor::runtime::trace::EventType;
 using spoor::runtime::trace::Header;
 using spoor::runtime::trace::kEndianness;
 using spoor::runtime::trace::kMagicNumber;
+using spoor::runtime::trace::kTraceFileExtension;
 using spoor::runtime::trace::kTraceFileVersion;
 using spoor::runtime::trace::TimestampNanoseconds;
 using spoor::runtime::trace::TraceWriter;

--- a/spoor/runtime/runtime.cc
+++ b/spoor/runtime/runtime.cc
@@ -23,6 +23,7 @@
 #include "spoor/runtime/trace/trace_file_reader.h"
 #include "spoor/runtime/trace/trace_file_writer.h"
 #include "util/compression/compressor_factory.h"
+#include "util/file_system/local_file_reader.h"
 #include "util/file_system/local_file_system.h"
 #include "util/file_system/local_file_writer.h"
 #include "util/numeric.h"
@@ -63,10 +64,12 @@ util::time::SteadyClock steady_clock_{};
 // clang-format off NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables, fuchsia-statically-constructed-objects) clang-format on
 util::file_system::LocalFileSystem file_system_{};
 // clang-format off NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables, fuchsia-statically-constructed-objects) clang-format on
+util::file_system::LocalFileReader file_reader_{};
+// clang-format off NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables, fuchsia-statically-constructed-objects) clang-format on
 util::file_system::LocalFileWriter file_writer_{};
 // clang-format off NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables, fuchsia-statically-constructed-objects) clang-format on
 spoor::runtime::trace::TraceFileReader trace_reader_{
-    {.file_system = &file_system_}};
+    {.file_system = &file_system_, .file_reader = &file_reader_}};
 // clang-format off NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables, fuchsia-statically-constructed-objects) clang-format on
 spoor::runtime::trace::TraceFileWriter trace_writer_{
     {.file_writer = &file_writer_,

--- a/spoor/runtime/trace/BUILD
+++ b/spoor/runtime/trace/BUILD
@@ -52,6 +52,26 @@ cc_test(
 )
 
 cc_test(
+    name = "trace_file_reader_test",
+    size = "small",
+    srcs = ["trace_file_reader_test.cc"],
+    copts = SPOOR_DEFAULT_TEST_COPTS,
+    linkopts = SPOOR_DEFAULT_TEST_LINKOPTS,
+    visibility = ["//visibility:private"],
+    deps = [
+        ":trace",
+        "//util:result",
+        "//util/compression",
+        "//util/file_system:file_system_mock",
+        "//util/flat_map",
+        "@com_google_absl//absl/base:endian",
+        "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest_main",
+        "@com_microsoft_gsl//:gsl",
+    ],
+)
+
+cc_test(
     name = "trace_file_writer_test",
     size = "small",
     srcs = ["trace_file_writer_test.cc"],

--- a/spoor/runtime/trace/trace.h
+++ b/spoor/runtime/trace/trace.h
@@ -4,7 +4,9 @@
 #pragma once
 
 #include <array>
+#include <string_view>
 #include <type_traits>
+#include <vector>
 
 #include "absl/base/internal/endian.h"
 #include "gsl/gsl"
@@ -28,6 +30,8 @@ using TraceFileVersion = uint32;
 // IMPORTANT: Increment the version number if the Header or Event structure
 // changes.
 constexpr TraceFileVersion kTraceFileVersion{0};
+
+constexpr std::string_view kTraceFileExtension{"spoor_trace"};
 
 // Inspired by PNG's magic number.
 constexpr MagicNumber kMagicNumber{
@@ -92,6 +96,13 @@ static_assert(sizeof(Event) == 24);
 
 constexpr auto operator==(const Event& lhs, const Event& rhs) -> bool;
 
+struct alignas(128) TraceFile {
+  Header header;
+  std::vector<Event> events;
+};
+
+constexpr auto operator==(const TraceFile& lhs, const TraceFile& rhs) -> bool;
+
 constexpr auto operator==(const Header& lhs, const Header& rhs) -> bool {
   return lhs.magic_number == rhs.magic_number &&
          lhs.endianness == rhs.endianness &&
@@ -107,6 +118,10 @@ constexpr auto operator==(const Event& lhs, const Event& rhs) -> bool {
   return lhs.steady_clock_timestamp == rhs.steady_clock_timestamp &&
          lhs.payload_1 == rhs.payload_1 && lhs.type == rhs.type &&
          lhs.payload_2 == rhs.payload_2;
+}
+
+constexpr auto operator==(const TraceFile& lhs, const TraceFile& rhs) -> bool {
+  return lhs.header == rhs.header && lhs.events == rhs.events;
 }
 
 }  // namespace spoor::runtime::trace

--- a/spoor/runtime/trace/trace_file_reader.cc
+++ b/spoor/runtime/trace/trace_file_reader.cc
@@ -3,57 +3,123 @@
 
 #include "spoor/runtime/trace/trace_file_reader.h"
 
+#include <algorithm>
 #include <array>
 #include <filesystem>
 #include <fstream>
-#include <regex>
+#include <ios>
+#include <vector>
 
 #include "absl/base/internal/endian.h"
+#include "absl/strings/str_cat.h"
+#include "gsl/gsl"
 #include "spoor/runtime/trace/trace.h"
+#include "util/compression/compressor_factory.h"
 
 namespace spoor::runtime::trace {
 
-// NOLINTNEXTLINE(fuchsia-statically-constructed-objects)
-const std::regex kTraceFileNamePattern{
-    R"([0-9a-f]{16}-[0-9a-f]{16}-[0-9a-f]{16}\.spoor)"};
+using Error = TraceReader::Error;
 
 TraceFileReader::TraceFileReader(Options options)
     : options_{std::move(options)} {}
 
 auto TraceFileReader::MatchesTraceFileConvention(
-    const std::filesystem::path& file) const -> bool {
-  const auto result = options_.file_system->IsRegularFile(file);
+    const std::filesystem::path& file_path) const -> bool {
+  const auto result = options_.file_system->IsRegularFile(file_path);
   const auto is_regular_file = result.OkOr(false);
   return is_regular_file &&
-         std::regex_match(file.filename().string(), kTraceFileNamePattern);
+         file_path.extension() == absl::StrCat(".", kTraceFileExtension);
 }
 
-auto TraceFileReader::ReadHeader(const std::filesystem::path& file) const
-    -> Result {
-  std::ifstream file_stream{file};
-  if (!file_stream.is_open()) return Error::kFailedToOpenFile;
-  std::array<char, sizeof(Header)> header_buffer{};
-  file_stream.read(header_buffer.data(), header_buffer.size());
-  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-  auto* header = reinterpret_cast<Header*>(header_buffer.data());
-  if (header->magic_number != kMagicNumber) {
-    return Error::kMagicNumberDoesNotMatch;
+auto TraceFileReader::ReadHeader(const std::filesystem::path& file_path) const
+    -> util::result::Result<Header, Error> {
+  auto& file = *options_.file_reader;
+  file.Open(file_path, std::ios::binary);
+  if (!file.IsOpen()) return Error::kFailedToOpenFile;
+  auto finally = gsl::finally([&file] { file.Close(); });
+  const auto buffer = file.Read(sizeof(Header));
+  if (buffer.size() != sizeof(Header)) return Error::kCorruptData;
+  const auto header =
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+      HeaderToHostByteOrder(*reinterpret_cast<const Header*>(buffer.data()));
+  if (header.magic_number != kMagicNumber) return Error::kCorruptData;
+  if (header.version != kTraceFileVersion) return Error::kUnknownVersion;
+  return header;
+}
+
+auto TraceFileReader::Read(const std::filesystem::path& file_path) const
+    -> util::result::Result<TraceFile, Error> {
+  auto& file = *options_.file_reader;
+  file.Open(file_path, std::ios::binary);
+  if (!file.IsOpen()) return Error::kFailedToOpenFile;
+  auto finally = gsl::finally([&file] { file.Close(); });
+  const auto buffer = file.Read();
+  if (buffer.size() < sizeof(Header)) return Error::kCorruptData;
+  const auto header =
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+      HeaderToHostByteOrder(*reinterpret_cast<const Header*>(buffer.data()));
+  if (header.magic_number != kMagicNumber) return Error::kCorruptData;
+  if (header.version != kTraceFileVersion) return Error::kUnknownVersion;
+  const auto compressor = util::compression::MakeCompressor(
+      header.compression_strategy, header.event_count * sizeof(Event));
+  const auto compressed_data_begin =
+      std::next(std::cbegin(buffer), sizeof(Header));
+  const auto compressed_data_end = std::cend(buffer);
+  const auto uncompressed_result = compressor->Uncompress(
+      {&(*compressed_data_begin),
+       gsl::narrow_cast<gsl::span<const char>::size_type>(
+           std::distance(compressed_data_begin, compressed_data_end))});
+  if (uncompressed_result.IsErr()) return Error::kCorruptData;
+  const auto uncompressed_data = uncompressed_result.Ok();
+  if (uncompressed_data.size() != header.event_count * sizeof(Event)) {
+    return Error::kCorruptData;
   }
-  if (kEndianness != header->endianness) {
-    header->version = absl::gbswap_32(header->version);
-    header->session_id = absl::gbswap_64(header->session_id);
-    header->process_id = static_cast<ProcessId>(
-        absl::gbswap_64(static_cast<uint64>(header->process_id)));
-    header->thread_id = absl::gbswap_64(header->thread_id);
-    header->system_clock_timestamp = static_cast<TimestampNanoseconds>(
-        absl::gbswap_64(static_cast<uint64>(header->system_clock_timestamp)));
-    header->steady_clock_timestamp = static_cast<TimestampNanoseconds>(
-        absl::gbswap_64(static_cast<uint64>(header->steady_clock_timestamp)));
-    header->event_count = static_cast<EventCount>(
-        absl::gbswap_32(static_cast<uint32>(header->event_count)));
-  }
-  if (header->version != kTraceFileVersion) return Error::kUnknownVersion;
-  return *header;
+  std::vector<Event> events{};
+  events.reserve(header.event_count);
+  const auto* const uncompressed_buffer_events_begin =
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+      reinterpret_cast<const Event*>(uncompressed_data.data());
+  std::transform(
+      uncompressed_buffer_events_begin,
+      std::next(uncompressed_buffer_events_begin, header.event_count),
+      std::back_inserter(events), [&](const auto event) {
+        return EventToHostByteOrder(event, header.endianness);
+      });
+  return TraceFile{.header = header, .events = std::move(events)};
+}
+
+auto TraceFileReader::HeaderToHostByteOrder(const Header header) -> Header {
+  if (header.endianness == kEndianness) return header;
+  return {
+      .magic_number = header.magic_number,
+      .endianness = header.endianness,
+      .version = absl::gbswap_32(header.version),
+      .session_id = absl::gbswap_64(header.session_id),
+      .process_id = static_cast<ProcessId>(
+          absl::gbswap_64(static_cast<uint64>(header.process_id))),
+      .thread_id = absl::gbswap_64(header.thread_id),
+      .system_clock_timestamp = static_cast<TimestampNanoseconds>(
+          absl::gbswap_64(static_cast<uint64>(header.system_clock_timestamp))),
+      .steady_clock_timestamp = static_cast<TimestampNanoseconds>(
+          absl::gbswap_64(static_cast<uint64>(header.steady_clock_timestamp))),
+      .event_count = static_cast<EventCount>(
+          absl::gbswap_32(static_cast<uint32>(header.event_count))),
+      .padding = header.padding,
+  };
+}
+
+auto TraceFileReader::EventToHostByteOrder(const Event event,
+                                           const Endian data_endianness)
+    -> Event {
+  if (data_endianness == kEndianness) return event;
+  return {
+      .steady_clock_timestamp = static_cast<TimestampNanoseconds>(
+          absl::gbswap_64(static_cast<uint64>(event.steady_clock_timestamp))),
+      .payload_1 = absl::gbswap_64(event.payload_1),
+      .type = static_cast<EventType>(
+          absl::gbswap_64(static_cast<uint32>(event.type))),
+      .payload_2 = absl::gbswap_32(event.payload_2),
+  };
 }
 
 }  // namespace spoor::runtime::trace

--- a/spoor/runtime/trace/trace_file_reader.h
+++ b/spoor/runtime/trace/trace_file_reader.h
@@ -7,25 +7,34 @@
 
 #include "gsl/gsl"
 #include "spoor/runtime/trace/trace_reader.h"
+#include "util/file_system/file_reader.h"
 #include "util/file_system/file_system.h"
 
 namespace spoor::runtime::trace {
 
 class TraceFileReader final : public TraceReader {
  public:
-  struct Options {
+  struct alignas(16) Options {
     gsl::not_null<util::file_system::FileSystem*> file_system;
+    gsl::not_null<util::file_system::FileReader*> file_reader;
   };
 
   explicit TraceFileReader(Options options);
 
   [[nodiscard]] auto MatchesTraceFileConvention(
-      const std::filesystem::path& file) const -> bool override;
-  [[nodiscard]] auto ReadHeader(const std::filesystem::path& file) const
-      -> Result override;
+      const std::filesystem::path& file_path) const -> bool override;
+  [[nodiscard]] auto ReadHeader(const std::filesystem::path& file_path) const
+      -> util::result::Result<Header, Error> override;
+  [[nodiscard]] auto Read(const std::filesystem::path& file_path) const
+      -> util::result::Result<TraceFile, Error> override;
 
  private:
   Options options_;
+
+  [[nodiscard]] static auto HeaderToHostByteOrder(Header header) -> Header;
+  [[nodiscard]] static auto EventToHostByteOrder(Event event,
+                                                 Endian data_endianness)
+      -> Event;
 };
 
 }  // namespace spoor::runtime::trace

--- a/spoor/runtime/trace/trace_file_reader_test.cc
+++ b/spoor/runtime/trace/trace_file_reader_test.cc
@@ -1,0 +1,667 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "spoor/runtime/trace/trace_file_reader.h"
+
+#include <algorithm>
+#include <limits>
+#include <string>
+#include <system_error>
+
+#include "absl/base/internal/endian.h"
+#include "absl/strings/str_cat.h"
+#include "gmock/gmock.h"
+#include "gsl/gsl"
+#include "gtest/gtest.h"
+#include "util/compression/compressor_factory.h"
+#include "util/file_system/file_reader_mock.h"
+#include "util/file_system/file_system_mock.h"
+#include "util/flat_map/flat_map.h"
+#include "util/result.h"
+
+namespace {
+
+using spoor::runtime::trace::CompressionStrategy;
+using spoor::runtime::trace::Endian;
+using spoor::runtime::trace::Event;
+using spoor::runtime::trace::EventCount;
+using spoor::runtime::trace::Header;
+using spoor::runtime::trace::kEndianness;
+using spoor::runtime::trace::kMagicNumber;
+using spoor::runtime::trace::kTraceFileVersion;
+using spoor::runtime::trace::TraceFile;
+using spoor::runtime::trace::TraceFileReader;
+using spoor::runtime::trace::TraceFileVersion;
+using testing::_;
+using testing::Return;
+using util::file_system::testing::FileReaderMock;
+using util::file_system::testing::FileSystemMock;
+using Error = spoor::runtime::trace::TraceFileReader::Error;
+
+TEST(TraceFileReader, MatchesTraceFileConvention) {  // NOLINT
+  const util::flat_map::FlatMap<std::filesystem::path, bool, 3>
+      matching_paths_is_regular_file{{
+          {"/path/to/"
+           "ffffffffffffffff-ffffffffffffffff-ffffffffffffffff.spoor_trace",
+           true},
+          {"ffffffffffffffff-ffffffffffffffff-ffffffffffffffff.spoor_trace",
+           true},
+          {"a.spoor_trace", true},
+      }};
+  const util::flat_map::FlatMap<std::filesystem::path,
+                                util::result::Result<bool, std::error_code>, 7>
+      not_matching_paths_is_regular_file{{
+          {"b.spoor", true},
+          {"c.trace", true},
+          {"d.spoor-trace", true},
+          {"e.spoor_trace", false},
+          {"f.spoor_trace", std::error_code{}},
+          {"/path/spoor_trace/foo.bar", true},
+          {"/path/trace.spoor_trace/foo.bar", true},
+      }};
+  FileSystemMock file_system{};
+  EXPECT_CALL(file_system, IsRegularFile(_))
+      .WillRepeatedly(
+          [&](const auto& path) -> util::result::Result<bool, std::error_code> {
+            const auto is_regular_file =
+                matching_paths_is_regular_file.FirstValueForKey(path);
+            if (is_regular_file.has_value()) return is_regular_file.value();
+            return not_matching_paths_is_regular_file.FirstValueForKey(path)
+                .value();
+          });
+  FileReaderMock file_reader{};
+  TraceFileReader trace_file_reader{{
+      .file_system = &file_system,
+      .file_reader = &file_reader,
+  }};
+  std::for_each(
+      std::cbegin(matching_paths_is_regular_file),
+      std::cend(matching_paths_is_regular_file),
+      [&](const auto& path_is_regular_file) {
+        const auto& [path, _] = path_is_regular_file;
+        ASSERT_TRUE(trace_file_reader.MatchesTraceFileConvention(path));
+      });
+  std::for_each(
+      std::cbegin(not_matching_paths_is_regular_file),
+      std::cend(not_matching_paths_is_regular_file),
+      [&](const auto& path_is_regular_file) {
+        const auto& [path, _] = path_is_regular_file;
+        ASSERT_FALSE(trace_file_reader.MatchesTraceFileConvention(path));
+      });
+}
+
+TEST(TraceFileReader, ReadHeaderParsesGoodData) {  // NOLINT
+  const std::filesystem::path file_path{"/path/to/trace.spoor_trace"};
+  const Header header{
+      .magic_number = kMagicNumber,
+      .endianness = kEndianness,
+      .compression_strategy = CompressionStrategy::kNone,
+      .version = kTraceFileVersion,
+      .session_id = 1,
+      .process_id = 2,
+      .thread_id = 3,
+      .system_clock_timestamp = 4,
+      .steady_clock_timestamp = 5,
+      .event_count = 0,
+      .padding = {},
+  };
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+  const std::string buffer{reinterpret_cast<const char*>(&header),
+                           sizeof(header)};
+  FileSystemMock file_system{};
+  FileReaderMock file_reader{};
+  EXPECT_CALL(file_reader, Open(file_path, std::ios::binary));
+  EXPECT_CALL(file_reader, IsOpen()).WillOnce(Return(true));
+  EXPECT_CALL(file_reader, Read(sizeof(Header))).WillOnce(Return(buffer));
+  EXPECT_CALL(file_reader, Close());
+  TraceFileReader trace_file_reader{{
+      .file_system = &file_system,
+      .file_reader = &file_reader,
+  }};
+  const auto result = trace_file_reader.ReadHeader(file_path);
+  ASSERT_TRUE(result.IsOk());
+  const auto& retrieved_header = result.Ok();
+  ASSERT_EQ(retrieved_header, header);
+}
+
+TEST(TraceFileReader, ReadHeaderHandlesFailedToOpenFile) {  // NOLINT
+  const std::filesystem::path file_path{"/path/to/trace.spoor_trace"};
+  FileSystemMock file_system{};
+  FileReaderMock file_reader{};
+  EXPECT_CALL(file_reader, Open(file_path, std::ios::binary));
+  EXPECT_CALL(file_reader, IsOpen()).WillOnce(Return(false));
+  TraceFileReader trace_file_reader{{
+      .file_system = &file_system,
+      .file_reader = &file_reader,
+  }};
+  const auto result = trace_file_reader.ReadHeader(file_path);
+  ASSERT_TRUE(result.IsErr());
+  const auto& error = result.Err();
+  ASSERT_EQ(error, Error::kFailedToOpenFile);
+}
+
+TEST(TraceFileReader, ReadHeaderHandlesFileTooSmall) {  // NOLINT
+  const std::filesystem::path file_path{"/path/to/trace.spoor_trace"};
+  const Header header{
+      .magic_number = kMagicNumber,
+      .endianness = kEndianness,
+      .compression_strategy = CompressionStrategy::kNone,
+      .version = kTraceFileVersion,
+      .session_id = 1,
+      .process_id = 2,
+      .thread_id = 3,
+      .system_clock_timestamp = 4,
+      .steady_clock_timestamp = 5,
+      .event_count = 0,
+      .padding = {},
+  };
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+  const std::string buffer{reinterpret_cast<const char*>(&header),
+                           sizeof(header) - 1};
+  FileSystemMock file_system{};
+  FileReaderMock file_reader{};
+  EXPECT_CALL(file_reader, Open(file_path, std::ios::binary));
+  EXPECT_CALL(file_reader, IsOpen()).WillOnce(Return(true));
+  EXPECT_CALL(file_reader, Read(sizeof(Header))).WillOnce(Return(buffer));
+  EXPECT_CALL(file_reader, Close());
+  TraceFileReader trace_file_reader{{
+      .file_system = &file_system,
+      .file_reader = &file_reader,
+  }};
+  const auto result = trace_file_reader.ReadHeader(file_path);
+  ASSERT_TRUE(result.IsErr());
+  const auto& error = result.Err();
+  ASSERT_EQ(error, Error::kCorruptData);
+}
+
+TEST(TraceFileReader, ReadHeaderHandlesBadMagicNumber) {  // NOLINT
+  const std::filesystem::path file_path{"/path/to/trace.spoor_trace"};
+  const Header header{
+      .magic_number = {},
+      .endianness = kEndianness,
+      .compression_strategy = CompressionStrategy::kNone,
+      .version = kTraceFileVersion,
+      .session_id = 1,
+      .process_id = 2,
+      .thread_id = 3,
+      .system_clock_timestamp = 4,
+      .steady_clock_timestamp = 5,
+      .event_count = 0,
+      .padding = {},
+  };
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+  const std::string buffer{reinterpret_cast<const char*>(&header),
+                           sizeof(header)};
+  FileSystemMock file_system{};
+  FileReaderMock file_reader{};
+  EXPECT_CALL(file_reader, Open(file_path, std::ios::binary));
+  EXPECT_CALL(file_reader, IsOpen()).WillOnce(Return(true));
+  EXPECT_CALL(file_reader, Read(sizeof(Header))).WillOnce(Return(buffer));
+  EXPECT_CALL(file_reader, Close());
+  TraceFileReader trace_file_reader{{
+      .file_system = &file_system,
+      .file_reader = &file_reader,
+  }};
+  const auto result = trace_file_reader.ReadHeader(file_path);
+  ASSERT_TRUE(result.IsErr());
+  const auto& error = result.Err();
+  ASSERT_EQ(error, Error::kCorruptData);
+}
+
+TEST(TraceFileReader, ReadHeaderHandlesBadVersion) {  // NOLINT
+  const std::filesystem::path file_path{"/path/to/trace.spoor_trace"};
+  const Header header{
+      .magic_number = kMagicNumber,
+      .endianness = kEndianness,
+      .compression_strategy = CompressionStrategy::kNone,
+      .version = std::numeric_limits<TraceFileVersion>::max(),
+      .session_id = 1,
+      .process_id = 2,
+      .thread_id = 3,
+      .system_clock_timestamp = 4,
+      .steady_clock_timestamp = 5,
+      .event_count = 0,
+      .padding = {},
+  };
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+  const std::string buffer{reinterpret_cast<const char*>(&header),
+                           sizeof(header)};
+  FileSystemMock file_system{};
+  FileReaderMock file_reader{};
+  EXPECT_CALL(file_reader, Open(file_path, std::ios::binary));
+  EXPECT_CALL(file_reader, IsOpen()).WillOnce(Return(true));
+  EXPECT_CALL(file_reader, Read(sizeof(Header))).WillOnce(Return(buffer));
+  EXPECT_CALL(file_reader, Close());
+  TraceFileReader trace_file_reader{{
+      .file_system = &file_system,
+      .file_reader = &file_reader,
+  }};
+  const auto result = trace_file_reader.ReadHeader(file_path);
+  ASSERT_TRUE(result.IsErr());
+  const auto& error = result.Err();
+  ASSERT_EQ(error, Error::kUnknownVersion);
+}
+
+TEST(TraceFileReader, ReadParsesGoodDataUncompressed) {  // NOLINT
+  const std::filesystem::path file_path{"/path/to/trace.spoor_trace"};
+  const TraceFile trace_file{
+      .header =
+          {
+              .magic_number = kMagicNumber,
+              .endianness = kEndianness,
+              .compression_strategy = CompressionStrategy::kNone,
+              .version = kTraceFileVersion,
+              .session_id = 1,
+              .process_id = 2,
+              .thread_id = 3,
+              .system_clock_timestamp = 4,
+              .steady_clock_timestamp = 5,
+              .event_count = 3,
+              .padding = {},
+          },
+      .events =
+          {
+              {.steady_clock_timestamp = 0,
+               .payload_1 = 0,
+               .type = 0,
+               .payload_2 = 0},
+              {.steady_clock_timestamp = 1,
+               .payload_1 = 1,
+               .type = 1,
+               .payload_2 = 1},
+              {.steady_clock_timestamp = 2,
+               .payload_1 = 2,
+               .type = 2,
+               .payload_2 = 2},
+          },
+  };
+  ASSERT_EQ(trace_file.header.event_count, trace_file.events.size());
+  const std::string buffer = [&] {
+    const std::string header_buffer{
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+        reinterpret_cast<const char*>(&trace_file.header), sizeof(Header)};
+    const std::string events_buffer{
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+        reinterpret_cast<const char*>(trace_file.events.data()),
+        trace_file.header.event_count * sizeof(Event)};
+    return absl::StrCat(header_buffer, events_buffer);
+  }();
+  ASSERT_EQ(buffer.size(),
+            sizeof(Header) + trace_file.events.size() * sizeof(Event));
+  FileSystemMock file_system{};
+  FileReaderMock file_reader{};
+  EXPECT_CALL(file_reader, Open(file_path, std::ios::binary));
+  EXPECT_CALL(file_reader, IsOpen()).WillOnce(Return(true));
+  EXPECT_CALL(file_reader, Read()).WillOnce(Return(buffer));
+  EXPECT_CALL(file_reader, Close());
+  TraceFileReader trace_file_reader{{
+      .file_system = &file_system,
+      .file_reader = &file_reader,
+  }};
+  const auto result = trace_file_reader.Read(file_path);
+  ASSERT_TRUE(result.IsOk());
+  const auto& retrieved_trace_file = result.Ok();
+  ASSERT_EQ(retrieved_trace_file, trace_file);
+}
+
+TEST(TraceFileReader, ReadParsesGoodDataCompressed) {  // NOLINT
+  const std::filesystem::path file_path{"/path/to/trace.spoor_trace"};
+  constexpr auto compression_strategy = CompressionStrategy::kSnappy;
+  const TraceFile trace_file{
+      .header =
+          {
+              .magic_number = kMagicNumber,
+              .endianness = kEndianness,
+              .compression_strategy = compression_strategy,
+              .version = kTraceFileVersion,
+              .session_id = 1,
+              .process_id = 2,
+              .thread_id = 3,
+              .system_clock_timestamp = 4,
+              .steady_clock_timestamp = 5,
+              .event_count = 3,
+              .padding = {},
+          },
+      .events =
+          {
+              {.steady_clock_timestamp = 0,
+               .payload_1 = 0,
+               .type = 0,
+               .payload_2 = 0},
+              {.steady_clock_timestamp = 1,
+               .payload_1 = 1,
+               .type = 1,
+               .payload_2 = 1},
+              {.steady_clock_timestamp = 2,
+               .payload_1 = 2,
+               .type = 2,
+               .payload_2 = 2},
+          },
+  };
+  ASSERT_EQ(trace_file.header.event_count, trace_file.events.size());
+  const std::string buffer = [&] {
+    const std::string header_buffer{
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+        reinterpret_cast<const char*>(&trace_file.header), sizeof(Header)};
+    auto compressor = util::compression::MakeCompressor(
+        compression_strategy, trace_file.events.size() * sizeof(Event));
+    const auto events_buffer_view =
+        compressor
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+            ->Compress({reinterpret_cast<const char*>(trace_file.events.data()),
+                        trace_file.events.size() * sizeof(Event)})
+            .Ok();
+    const std::string events_buffer{events_buffer_view.data(),
+                                    events_buffer_view.size()};
+    return absl::StrCat(header_buffer, events_buffer);
+  }();
+  ASSERT_LE(buffer.size(),
+            sizeof(Header) + trace_file.events.size() * sizeof(Event));
+  FileSystemMock file_system{};
+  FileReaderMock file_reader{};
+  EXPECT_CALL(file_reader, Open(file_path, std::ios::binary));
+  EXPECT_CALL(file_reader, IsOpen()).WillOnce(Return(true));
+  EXPECT_CALL(file_reader, Read()).WillOnce(Return(buffer));
+  EXPECT_CALL(file_reader, Close());
+  TraceFileReader trace_file_reader{{
+      .file_system = &file_system,
+      .file_reader = &file_reader,
+  }};
+  const auto result = trace_file_reader.Read(file_path);
+  ASSERT_TRUE(result.IsOk());
+  const auto& retrieved_trace_file = result.Ok();
+  ASSERT_EQ(retrieved_trace_file, trace_file);
+}
+
+TEST(TraceFileReader, ReadParsesGoodDataDifferentEndian) {  // NOLINT
+  constexpr auto other_endianness{
+      kEndianness == Endian::kLittle ? Endian::kBig : Endian::kLittle};
+  const std::filesystem::path file_path{"/path/to/trace.spoor_trace"};
+  const TraceFile expected_trace_file{
+      .header =
+          {
+              .magic_number = kMagicNumber,
+              .endianness = other_endianness,
+              .compression_strategy = CompressionStrategy::kNone,
+              .version = kTraceFileVersion,
+              .session_id = 0x0011223344556677,
+              .process_id = 0x0011223344556677,
+              .thread_id = 0x0011223344556677,
+              .system_clock_timestamp = 0x0011223344556677,
+              .steady_clock_timestamp = 0x0011223344556677,
+              .event_count = gsl::narrow_cast<EventCount>(1),
+              .padding = {},
+          },
+      .events = {{
+          .steady_clock_timestamp = 0x0011223344556677,
+          .payload_1 = 0x0011223344556677,
+          .type = 0x00112233,
+          .payload_2 = 0x00112233,
+      }},
+  };
+  ASSERT_EQ(expected_trace_file.header.event_count,
+            expected_trace_file.events.size());
+  const TraceFile trace_file_other_endian{
+      .header =
+          {
+              .magic_number = kMagicNumber,
+              .endianness = other_endianness,
+              .compression_strategy = CompressionStrategy::kNone,
+              .version = absl::gbswap_32(kTraceFileVersion),
+              .session_id = 0x7766554433221100,
+              .process_id = 0x7766554433221100,
+              .thread_id = 0x7766554433221100,
+              .system_clock_timestamp = 0x7766554433221100,
+              .steady_clock_timestamp = 0x7766554433221100,
+              .event_count = static_cast<EventCount>(absl::gbswap_32(1)),
+              .padding = {},
+          },
+      .events = {{
+          .steady_clock_timestamp = 0x7766554433221100,
+          .payload_1 = 0x7766554433221100,
+          .type = 0x33221100,
+          .payload_2 = 0x33221100,
+      }},
+  };
+  ASSERT_EQ(expected_trace_file.events.size(),
+            trace_file_other_endian.events.size());
+  const std::string buffer = [&] {
+    const std::string header_buffer{
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+        reinterpret_cast<const char*>(&trace_file_other_endian.header),
+        sizeof(Header)};
+    const std::string events_buffer{
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+        reinterpret_cast<const char*>(trace_file_other_endian.events.data()),
+        trace_file_other_endian.events.size() * sizeof(Event)};
+    return absl::StrCat(header_buffer, events_buffer);
+  }();
+  ASSERT_EQ(
+      buffer.size(),
+      sizeof(Header) + trace_file_other_endian.events.size() * sizeof(Event));
+  FileSystemMock file_system{};
+  FileReaderMock file_reader{};
+  EXPECT_CALL(file_reader, Open(file_path, std::ios::binary));
+  EXPECT_CALL(file_reader, IsOpen()).WillOnce(Return(true));
+  EXPECT_CALL(file_reader, Read()).WillOnce(Return(buffer));
+  EXPECT_CALL(file_reader, Close());
+  TraceFileReader trace_file_reader{{
+      .file_system = &file_system,
+      .file_reader = &file_reader,
+  }};
+  const auto result = trace_file_reader.Read(file_path);
+  ASSERT_TRUE(result.IsOk());
+  const auto& retrieved_trace_file = result.Ok();
+  ASSERT_EQ(retrieved_trace_file.header, expected_trace_file.header);
+}
+
+TEST(TraceFileReader, ReadHandlesFailedToOpenFile) {  // NOLINT
+  const std::filesystem::path file_path{"/path/to/trace.spoor_trace"};
+  FileSystemMock file_system{};
+  FileReaderMock file_reader{};
+  EXPECT_CALL(file_reader, Open(file_path, std::ios::binary));
+  EXPECT_CALL(file_reader, IsOpen()).WillOnce(Return(false));
+  TraceFileReader trace_file_reader{{
+      .file_system = &file_system,
+      .file_reader = &file_reader,
+  }};
+  const auto result = trace_file_reader.Read(file_path);
+  ASSERT_TRUE(result.IsErr());
+  const auto& error = result.Err();
+  ASSERT_EQ(error, Error::kFailedToOpenFile);
+}
+
+TEST(TraceFileReader, ReadHandlesFileTooSmall) {  // NOLINT
+  const std::filesystem::path file_path{"/path/to/trace.spoor_trace"};
+  const Header header{
+      .magic_number = kMagicNumber,
+      .endianness = kEndianness,
+      .compression_strategy = CompressionStrategy::kNone,
+      .version = kTraceFileVersion,
+      .session_id = 1,
+      .process_id = 2,
+      .thread_id = 3,
+      .system_clock_timestamp = 4,
+      .steady_clock_timestamp = 5,
+      .event_count = 0,
+      .padding = {},
+  };
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+  const std::string buffer{reinterpret_cast<const char*>(&header),
+                           sizeof(header) - 1};
+  FileSystemMock file_system{};
+  FileReaderMock file_reader{};
+  EXPECT_CALL(file_reader, Open(file_path, std::ios::binary));
+  EXPECT_CALL(file_reader, IsOpen()).WillOnce(Return(true));
+  EXPECT_CALL(file_reader, Read()).WillOnce(Return(buffer));
+  EXPECT_CALL(file_reader, Close());
+  TraceFileReader trace_file_reader{{
+      .file_system = &file_system,
+      .file_reader = &file_reader,
+  }};
+  const auto result = trace_file_reader.Read(file_path);
+  ASSERT_TRUE(result.IsErr());
+  const auto& error = result.Err();
+  ASSERT_EQ(error, Error::kCorruptData);
+}
+
+TEST(TraceFileReader, ReadHandlesBadMagicNumber) {  // NOLINT
+  const std::filesystem::path file_path{"/path/to/trace.spoor_trace"};
+  const Header header{
+      .magic_number = {},
+      .endianness = kEndianness,
+      .compression_strategy = CompressionStrategy::kNone,
+      .version = kTraceFileVersion,
+      .session_id = 1,
+      .process_id = 2,
+      .thread_id = 3,
+      .system_clock_timestamp = 4,
+      .steady_clock_timestamp = 5,
+      .event_count = 0,
+      .padding = {},
+  };
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+  const std::string buffer{reinterpret_cast<const char*>(&header),
+                           sizeof(header)};
+  FileSystemMock file_system{};
+  FileReaderMock file_reader{};
+  EXPECT_CALL(file_reader, Open(file_path, std::ios::binary));
+  EXPECT_CALL(file_reader, IsOpen()).WillOnce(Return(true));
+  EXPECT_CALL(file_reader, Read()).WillOnce(Return(buffer));
+  EXPECT_CALL(file_reader, Close());
+  TraceFileReader trace_file_reader{{
+      .file_system = &file_system,
+      .file_reader = &file_reader,
+  }};
+  const auto result = trace_file_reader.Read(file_path);
+  ASSERT_TRUE(result.IsErr());
+  const auto& error = result.Err();
+  ASSERT_EQ(error, Error::kCorruptData);
+}
+
+TEST(TraceFileReader, ReadHandlesBadVersion) {  // NOLINT
+  const std::filesystem::path file_path{"/path/to/trace.spoor_trace"};
+  const Header header{
+      .magic_number = kMagicNumber,
+      .endianness = kEndianness,
+      .compression_strategy = CompressionStrategy::kNone,
+      .version = std::numeric_limits<TraceFileVersion>::max(),
+      .session_id = 1,
+      .process_id = 2,
+      .thread_id = 3,
+      .system_clock_timestamp = 4,
+      .steady_clock_timestamp = 5,
+      .event_count = 0,
+      .padding = {},
+  };
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+  const std::string buffer{reinterpret_cast<const char*>(&header),
+                           sizeof(header)};
+  FileSystemMock file_system{};
+  FileReaderMock file_reader{};
+  EXPECT_CALL(file_reader, Open(file_path, std::ios::binary));
+  EXPECT_CALL(file_reader, IsOpen()).WillOnce(Return(true));
+  EXPECT_CALL(file_reader, Read()).WillOnce(Return(buffer));
+  EXPECT_CALL(file_reader, Close());
+  TraceFileReader trace_file_reader{{
+      .file_system = &file_system,
+      .file_reader = &file_reader,
+  }};
+  const auto result = trace_file_reader.Read(file_path);
+  ASSERT_TRUE(result.IsErr());
+  const auto& error = result.Err();
+  ASSERT_EQ(error, Error::kUnknownVersion);
+}
+
+TEST(TraceFileReader, ReadHandlesBadCompression) {  // NOLINT
+  const std::filesystem::path file_path{"/path/to/trace.spoor_trace"};
+  constexpr Header header{
+      .magic_number = kMagicNumber,
+      .endianness = kEndianness,
+      .compression_strategy = CompressionStrategy::kSnappy,
+      .version = kTraceFileVersion,
+      .session_id = 1,
+      .process_id = 2,
+      .thread_id = 3,
+      .system_clock_timestamp = 4,
+      .steady_clock_timestamp = 5,
+      .event_count = 6,
+      .padding = {},
+  };
+  const std::string buffer = [&] {
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    const std::string header_buffer{reinterpret_cast<const char*>(&header),
+                                    sizeof(Header)};
+    return absl::StrCat(header_buffer, "bad compression");
+  }();
+  FileSystemMock file_system{};
+  FileReaderMock file_reader{};
+  EXPECT_CALL(file_reader, Open(file_path, std::ios::binary));
+  EXPECT_CALL(file_reader, IsOpen()).WillOnce(Return(true));
+  EXPECT_CALL(file_reader, Read()).WillOnce(Return(buffer));
+  EXPECT_CALL(file_reader, Close());
+  TraceFileReader trace_file_reader{{
+      .file_system = &file_system,
+      .file_reader = &file_reader,
+  }};
+  const auto result = trace_file_reader.Read(file_path);
+  ASSERT_TRUE(result.IsErr());
+  const auto& error = result.Err();
+  ASSERT_EQ(error, Error::kCorruptData);
+}
+
+TEST(TraceFileReader, ReadHandlesWrongNumberOfEvents) {  // NOLINT
+  const std::filesystem::path file_path{"/path/to/trace.spoor_trace"};
+  std::vector<Event> events{
+      {.steady_clock_timestamp = 0, .payload_1 = 0, .type = 0, .payload_2 = 0},
+      {.steady_clock_timestamp = 1, .payload_1 = 1, .type = 1, .payload_2 = 1},
+      {.steady_clock_timestamp = 2, .payload_1 = 2, .type = 2, .payload_2 = 2},
+  };
+  for (const auto event_count : {events.size() - 1, events.size() + 1}) {
+    const TraceFile trace_file{
+        .header =
+            {
+                .magic_number = kMagicNumber,
+                .endianness = kEndianness,
+                .compression_strategy = CompressionStrategy::kNone,
+                .version = kTraceFileVersion,
+                .session_id = 1,
+                .process_id = 2,
+                .thread_id = 3,
+                .system_clock_timestamp = 4,
+                .steady_clock_timestamp = 5,
+                .event_count = gsl::narrow_cast<EventCount>(event_count),
+                .padding = {},
+            },
+        .events = events,
+    };
+    const std::string buffer = [&] {
+      const std::string header_buffer{
+          // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+          reinterpret_cast<const char*>(&trace_file.header), sizeof(Header)};
+      const std::string events_buffer{
+          // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+          reinterpret_cast<const char*>(trace_file.events.data()),
+          trace_file.events.size() * sizeof(Event)};
+      return absl::StrCat(header_buffer, events_buffer);
+    }();
+    ASSERT_EQ(buffer.size(),
+              sizeof(Header) + trace_file.events.size() * sizeof(Event));
+    FileSystemMock file_system{};
+    FileReaderMock file_reader{};
+    EXPECT_CALL(file_reader, Open(file_path, std::ios::binary));
+    EXPECT_CALL(file_reader, IsOpen()).WillOnce(Return(true));
+    EXPECT_CALL(file_reader, Read()).WillOnce(Return(buffer));
+    EXPECT_CALL(file_reader, Close());
+    TraceFileReader trace_file_reader{{
+        .file_system = &file_system,
+        .file_reader = &file_reader,
+    }};
+    const auto result = trace_file_reader.Read(file_path);
+    ASSERT_TRUE(result.IsErr());
+    const auto& error = result.Err();
+    ASSERT_EQ(error, Error::kCorruptData);
+  }
+}
+
+}  // namespace

--- a/spoor/runtime/trace/trace_file_writer.h
+++ b/spoor/runtime/trace/trace_file_writer.h
@@ -23,7 +23,7 @@ class TraceFileWriter final : public TraceWriter {
   };
 
   explicit TraceFileWriter(Options options);
-  auto Write(const std::filesystem::path& file, Header header,
+  auto Write(const std::filesystem::path& file_path, Header header,
              gsl::not_null<Events*> events) -> Result override;
 
  private:

--- a/spoor/runtime/trace/trace_reader.h
+++ b/spoor/runtime/trace/trace_reader.h
@@ -15,11 +15,9 @@ class TraceReader {
  public:
   enum class Error {
     kFailedToOpenFile,
-    kMagicNumberDoesNotMatch,
     kUnknownVersion,
+    kCorruptData,
   };
-
-  using Result = util::result::Result<Header, Error>;
 
   constexpr TraceReader() = default;
   constexpr TraceReader(const TraceReader&) = default;
@@ -29,9 +27,11 @@ class TraceReader {
   virtual ~TraceReader() = default;
 
   [[nodiscard]] virtual auto MatchesTraceFileConvention(
-      const std::filesystem::path& file) const -> bool = 0;
-  [[nodiscard]] virtual auto ReadHeader(const std::filesystem::path& file) const
-      -> Result = 0;
+      const std::filesystem::path& file_path) const -> bool = 0;
+  [[nodiscard]] virtual auto ReadHeader(const std::filesystem::path& file_path)
+      const -> util::result::Result<Header, Error> = 0;
+  [[nodiscard]] virtual auto Read(const std::filesystem::path& file_path) const
+      -> util::result::Result<TraceFile, Error> = 0;
 };
 
 }  // namespace spoor::runtime::trace

--- a/spoor/runtime/trace/trace_reader_mock.h
+++ b/spoor/runtime/trace/trace_reader_mock.h
@@ -6,18 +6,23 @@
 #include <filesystem>
 
 #include "gmock/gmock.h"
+#include "spoor/runtime/trace/trace.h"
 #include "spoor/runtime/trace/trace_reader.h"
+#include "util/result.h"
 
 namespace spoor::runtime::trace::testing {
 
 class TraceReaderMock final : public TraceReader {
  public:
   MOCK_METHOD(  // NOLINT
-      bool, MatchesTraceFileConvention, (const std::filesystem::path& file),
-      (const, override));
+      bool, MatchesTraceFileConvention,
+      (const std::filesystem::path& file_path), (const, override));
   MOCK_METHOD(  // NOLINT
-      Result, ReadHeader, (const std::filesystem::path& file),
-      (const, override));
+      (util::result::Result<Header, Error>), ReadHeader,
+      (const std::filesystem::path& file_path), (const, override));
+  MOCK_METHOD(  // NOLINT
+      (util::result::Result<TraceFile, Error>), Read,
+      (const std::filesystem::path& file_path), (const, override));
 };
 
 }  // namespace spoor::runtime::trace::testing

--- a/spoor/runtime/trace/trace_test.cc
+++ b/spoor/runtime/trace/trace_test.cc
@@ -13,29 +13,34 @@ using spoor::runtime::trace::Event;
 using spoor::runtime::trace::EventType;
 using spoor::runtime::trace::Header;
 using spoor::runtime::trace::kMagicNumber;
+using spoor::runtime::trace::TraceFile;
 using Type = spoor::runtime::trace::Event::Type;
 
 TEST(Header, Equality) {  // NOLINT
-  constexpr Header header_a{.magic_number = kMagicNumber,
-                            .endianness = Endian::kLittle,
-                            .compression_strategy = CompressionStrategy::kNone,
-                            .version = 0,
-                            .session_id = 1,
-                            .process_id = 2,
-                            .thread_id = 3,
-                            .system_clock_timestamp = 4,
-                            .steady_clock_timestamp = 5,
-                            .event_count = 6};
-  constexpr Header header_b{.magic_number = kMagicNumber,
-                            .endianness = Endian::kLittle,
-                            .compression_strategy = CompressionStrategy::kNone,
-                            .version = 0,
-                            .session_id = 1,
-                            .process_id = 2,
-                            .thread_id = 3,
-                            .system_clock_timestamp = 4,
-                            .steady_clock_timestamp = 5,
-                            .event_count = 6};
+  constexpr Header header_a{
+      .magic_number = kMagicNumber,
+      .endianness = Endian::kLittle,
+      .compression_strategy = CompressionStrategy::kNone,
+      .version = 0,
+      .session_id = 1,
+      .process_id = 2,
+      .thread_id = 3,
+      .system_clock_timestamp = 4,
+      .steady_clock_timestamp = 5,
+      .event_count = 6,
+  };
+  constexpr Header header_b{
+      .magic_number = kMagicNumber,
+      .endianness = Endian::kLittle,
+      .compression_strategy = CompressionStrategy::kNone,
+      .version = 0,
+      .session_id = 1,
+      .process_id = 2,
+      .thread_id = 3,
+      .system_clock_timestamp = 4,
+      .steady_clock_timestamp = 5,
+      .event_count = 6,
+  };
   constexpr Header header_c{
       .magic_number = kMagicNumber,
       .endianness = Endian::kBig,
@@ -46,7 +51,8 @@ TEST(Header, Equality) {  // NOLINT
       .thread_id = 13,
       .system_clock_timestamp = 14,
       .steady_clock_timestamp = 15,
-      .event_count = 16};
+      .event_count = 16,
+  };
   ASSERT_EQ(header_a, header_b);
   ASSERT_NE(header_a, header_c);
 }
@@ -62,6 +68,74 @@ TEST(Event, Equality) {  // NOLINT
                           .payload_2 = 13};
   ASSERT_EQ(event_a, event_b);
   ASSERT_NE(event_a, event_c);
+}
+
+TEST(TraceFile, Equality) {  // NOLINT
+  const TraceFile trace_file_a{
+      .header =
+          {
+              .magic_number = kMagicNumber,
+              .endianness = Endian::kLittle,
+              .compression_strategy = CompressionStrategy::kNone,
+              .version = 0,
+              .session_id = 1,
+              .process_id = 2,
+              .thread_id = 3,
+              .system_clock_timestamp = 4,
+              .steady_clock_timestamp = 5,
+              .event_count = 1,
+          },
+      .events = {{
+          .steady_clock_timestamp = 0,
+          .payload_1 = 0,
+          .type = 0,
+          .payload_2 = 0,
+      }},
+  };
+  const TraceFile trace_file_b{
+      .header =
+          {
+              .magic_number = kMagicNumber,
+              .endianness = Endian::kLittle,
+              .compression_strategy = CompressionStrategy::kNone,
+              .version = 0,
+              .session_id = 1,
+              .process_id = 2,
+              .thread_id = 3,
+              .system_clock_timestamp = 4,
+              .steady_clock_timestamp = 5,
+              .event_count = 1,
+          },
+      .events = {{
+          .steady_clock_timestamp = 0,
+          .payload_1 = 0,
+          .type = 0,
+          .payload_2 = 0,
+      }},
+  };
+  const TraceFile trace_file_c{
+      .header =
+          {
+              .magic_number = kMagicNumber,
+              .endianness = Endian::kBig,
+              .compression_strategy = CompressionStrategy::kSnappy,
+              .version = 10,
+              .session_id = 11,
+              .process_id = 12,
+              .thread_id = 13,
+              .system_clock_timestamp = 14,
+              .steady_clock_timestamp = 15,
+              .event_count = 1,
+          },
+      .events = {{
+          .steady_clock_timestamp = 1,
+          .payload_1 = 1,
+          .type = 1,
+          .payload_2 = 1,
+      }},
+  };
+  ASSERT_EQ(trace_file_a, trace_file_b);
+  ASSERT_NE(trace_file_a, trace_file_c);
 }
 
 }  // namespace

--- a/spoor/runtime/trace/trace_writer.h
+++ b/spoor/runtime/trace/trace_writer.h
@@ -28,7 +28,7 @@ class TraceWriter {
   constexpr auto operator=(TraceWriter&&) -> TraceWriter& = default;
   virtual ~TraceWriter() = default;
 
-  virtual auto Write(const std::filesystem::path& file, Header header,
+  virtual auto Write(const std::filesystem::path& file_path, Header header,
                      gsl::not_null<Events*> events) -> Result = 0;
 };
 

--- a/spoor/runtime/trace/trace_writer_mock.h
+++ b/spoor/runtime/trace/trace_writer_mock.h
@@ -13,7 +13,7 @@ class TraceWriterMock final : public TraceWriter {
  public:
   MOCK_METHOD(  // NOLINT
       Result, Write,
-      (const std::filesystem::path& file, Header header,
+      (const std::filesystem::path& file_path, Header header,
        gsl::not_null<Events*> events),
       (override));
 };

--- a/util/file_system/BUILD
+++ b/util/file_system/BUILD
@@ -13,12 +13,15 @@ load(
 cc_library(
     name = "file_system",
     srcs = [
+        "local_file_reader.cc",
         "local_file_system.cc",
         "local_file_writer.cc",
     ],
     hdrs = [
+        "file_reader.h",
         "file_system.h",
         "file_writer.h",
+        "local_file_reader.h",
         "local_file_system.h",
         "local_file_writer.h",
     ],
@@ -36,6 +39,7 @@ cc_library(
     srcs = ["directory_entry_mock.cc"],
     hdrs = [
         "directory_entry_mock.h",
+        "file_reader_mock.h",
         "file_system_mock.h",
         "file_writer_mock.h",
     ],

--- a/util/file_system/file_reader.h
+++ b/util/file_system/file_reader.h
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <filesystem>
+#include <ios>
+#include <istream>
+#include <string>
+
+#include "gsl/gsl"
+
+namespace util::file_system {
+
+class FileReader {
+ public:
+  FileReader() = default;
+  FileReader(const FileReader&) = default;
+  FileReader(FileReader&&) noexcept = default;
+  auto operator=(const FileReader&) -> FileReader& = default;
+  auto operator=(FileReader&&) noexcept -> FileReader& = default;
+  virtual ~FileReader() = default;
+
+  virtual auto Open(const std::filesystem::path& path,
+                    std::ios_base::openmode mode) -> void = 0;
+  [[nodiscard]] virtual auto IsOpen() const -> bool = 0;
+  virtual auto Read() -> std::string = 0;
+  virtual auto Read(std::streamsize max_bytes) -> std::string = 0;
+  virtual auto Istream() -> std::istream& = 0;
+  virtual auto Close() -> void = 0;
+};
+
+}  // namespace util::file_system

--- a/util/file_system/file_reader_mock.h
+++ b/util/file_system/file_reader_mock.h
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <filesystem>
+#include <ios>
+
+#include "gmock/gmock.h"
+#include "util/file_system/file_reader.h"
+
+namespace util::file_system::testing {
+
+class FileReaderMock final : public FileReader {
+ public:
+  MOCK_METHOD(  // NOLINT
+      (void), Open,
+      (const std::filesystem::path& path, std::ios_base::openmode mode),
+      (override));
+  MOCK_METHOD(  // NOLINT
+      (bool), IsOpen, (), (const, override));
+  MOCK_METHOD(  // NOLINT
+      (std::string), Read, (), (override));
+  MOCK_METHOD(  // NOLINT
+      (std::string), Read, (std::streamsize max_bytes), (override));
+  MOCK_METHOD(  // NOLINT
+      (std::istream&), Istream, (), (override));
+  MOCK_METHOD(  // NOLINT
+      (void), Close, (), (override));
+};
+
+}  // namespace util::file_system::testing

--- a/util/file_system/local_file_reader.cc
+++ b/util/file_system/local_file_reader.cc
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "util/file_system/local_file_reader.h"
+
+#include <filesystem>
+#include <ios>
+
+#include "gsl/gsl"
+
+namespace util::file_system {
+
+auto LocalFileReader::Open(const std::filesystem::path& path,
+                           std::ios_base::openmode mode) -> void {
+  ifstream_.open(path.c_str(), mode);
+}
+
+auto LocalFileReader::IsOpen() const -> bool { return ifstream_.is_open(); }
+
+auto LocalFileReader::Read() -> std::string {
+  std::string buffer{};
+  ifstream_.seekg(0, std::ios::end);
+  buffer.reserve(ifstream_.tellg());
+  ifstream_.seekg(0, std::ios::beg);
+  buffer.assign(std::istreambuf_iterator<char>{ifstream_},
+                std::istreambuf_iterator<char>{});
+  return buffer;
+}
+
+auto LocalFileReader::Read(const std::streamsize max_bytes) -> std::string {
+  std::string buffer{};
+  buffer.reserve(max_bytes);
+  ifstream_.read(buffer.data(),
+                 gsl::narrow_cast<std::streamsize>(buffer.size()));
+  buffer.resize(ifstream_.gcount());
+  return buffer;
+}
+
+auto LocalFileReader::Istream() -> std::istream& { return ifstream_; }
+
+auto LocalFileReader::Close() -> void { ifstream_.close(); }
+
+}  // namespace util::file_system

--- a/util/file_system/local_file_reader.h
+++ b/util/file_system/local_file_reader.h
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <filesystem>
+#include <fstream>
+#include <ios>
+
+#include "util/file_system/file_reader.h"
+
+namespace util::file_system {
+
+class LocalFileReader final : public FileReader {
+ public:
+  LocalFileReader() = default;
+  LocalFileReader(const LocalFileReader&) = delete;
+  LocalFileReader(LocalFileReader&&) noexcept = default;
+  auto operator=(const LocalFileReader&) -> LocalFileReader& = delete;
+  auto operator=(LocalFileReader&&) noexcept -> LocalFileReader& = default;
+  ~LocalFileReader() override = default;
+
+  auto Open(const std::filesystem::path& path, std::ios_base::openmode mode)
+      -> void override;
+  [[nodiscard]] auto IsOpen() const -> bool override;
+  auto Read() -> std::string override;
+  auto Read(std::streamsize max_bytes) -> std::string override;
+  auto Istream() -> std::istream& override;
+  auto Close() -> void override;
+
+ private:
+  std::ifstream ifstream_;
+};
+
+}  // namespace util::file_system

--- a/util/file_system/local_file_writer.h
+++ b/util/file_system/local_file_writer.h
@@ -13,6 +13,13 @@ namespace util::file_system {
 
 class LocalFileWriter final : public FileWriter {
  public:
+  LocalFileWriter() = default;
+  LocalFileWriter(const LocalFileWriter&) = delete;
+  LocalFileWriter(LocalFileWriter&&) noexcept = default;
+  auto operator=(const LocalFileWriter&) -> LocalFileWriter& = delete;
+  auto operator=(LocalFileWriter&&) noexcept -> LocalFileWriter& = default;
+  ~LocalFileWriter() override = default;
+
   auto Open(const std::filesystem::path& path, std::ios_base::openmode mode)
       -> void override;
   [[nodiscard]] auto IsOpen() const -> bool override;


### PR DESCRIPTION
Implements a file reader interface and disk file reader to retrieve data from local files. Additionally, implements a trace file reader to parse Spoor's binary trace files.

There are definitely optimization opportunities that we can explore later. For example, we could create a compressor pool instead of allocating a new one for each read. The goal for now is to unblock the parsing tool which is the trace file reader's primary consumer.