### PR TITLE
Upgrade Xcode to 12.5 in CI

### DIFF
--- a/.build/macos-ci.bazelrc
+++ b/.build/macos-ci.bazelrc
@@ -1,5 +1,5 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-build --cxxopt="-std=c++2a"
-build --host_cxxopt="-std=c++2a" 
+build --cxxopt="-std=c++20"
+build --host_cxxopt="-std=c++20"

--- a/.build/templates/install-common.yml
+++ b/.build/templates/install-common.yml
@@ -11,6 +11,9 @@ steps:
 - script: echo '##vso[task.prependpath]/usr/local/opt/llvm/bin'
   displayName: Install LLVM (macOS)
   condition: eq(variables['Agent.OS'], 'Darwin')
+- script: sudo xcode-select --switch /Applications/Xcode_12.5.app/Contents/Developer
+  displayName: Set Xcode version
+  condition: eq(variables['Agent.OS'], 'Darwin')
 - script: pip3 install pylint yapf
   displayName: Install Pylint and YAPF
 - script: cat .build/macos-ci.bazelrc .build/ci.bazelrc > .bazelrc

--- a/toolchain/config.bzl
+++ b/toolchain/config.bzl
@@ -2,6 +2,7 @@
 # Licensed under the MIT License.
 
 SPOOR_DEFAULT_COPTS = [
+    "-std=c++20",
     "-fno-exceptions",
     "-fno-rtti",
     "-Wall",


### PR DESCRIPTION
Upgrade Xcode to 12.5 in CI.

Xcode 12.5 includes Apple Clang 12.0.5 which is based on LLVM 11.1.0 (whereas Xcode 12.4 is includes an Apple Clang based on 10.0.0).

LLVM 11.1.0 supports compiling code with `-std=c++20` (instead of 2a) which is now specified as an explicit build option.