### PR TITLE
Fix spoor crash happened during pre-main stage.

### DIFF
--- a/spoor/runtime/runtime_manager/runtime_manager.cc
+++ b/spoor/runtime/runtime_manager/runtime_manager.cc
@@ -92,6 +92,8 @@ auto RuntimeManager::Unsubscribe(
 }
 
 auto RuntimeManager::LogEvent(const trace::Event event) -> void {
+  if (!enabled_) return;
+
   thread_local event_logger::EventLogger event_logger{
       {.flush_queue = options_.flush_queue,
        .preferred_capacity = options_.thread_event_buffer_capacity,

--- a/spoor/runtime/runtime_manager/runtime_manager.h
+++ b/spoor/runtime/runtime_manager/runtime_manager.h
@@ -101,11 +101,10 @@ class RuntimeManager final : public event_logger::EventLoggerNotifier {
   std::unordered_set<event_logger::EventLogger*> event_loggers_;
   bool initialized_;
 
-  // During pre-main stage, when LogEvent functions get called before
-  // Spoor is finishing the default initialization, it will lead
-  // to a crash when accessing some variables. By giving atomic_bool, with its
-  // zero value, those two functions can bypass this crash. The atomic will make
-  // sure it's thread-safe after the pre-main stage.
+  // std::atomic_bool's zero-initialization value ensures that the runtime
+  // library is not enabled pre-main. The flag guards the logging methods
+  // against pre-main calls and prevents a crash where they might otherwise
+  // operate on uninitialized data.
   std::atomic_bool enabled_;
 };
 


### PR DESCRIPTION
With spoor's instrumentation, functions in pre-main stage will call into LogFunctionEntry and LogFunctionExit. But during this stage, spoor is not finished the default initialization yet, some early access will lead to crash. 

In this PR, just added a check of initialized_ to those two method, with the zero initialized value, those functions can bypass this crash. And with atomic, it is thread safe after the pre-main stage.

This PR just fixes the crash in a hacky way, we'll have more discussion in Phase II.

This PR is tested with a Test Application. It is a simple iOS app, with Object-c code. During the pre-main stage, the load() method will be called of Object-C classes, which will call into LogFunctionEntry() and LogFunctionExit().

Added a unit test for this change. By leveraging the C/C++ static initializer, the LogEvent functions can be call before run into main function.