### PR TITLE
[Apple] Add plist to framework

### DIFF
--- a/spoor/runtime/wrappers/apple/BUILD
+++ b/spoor/runtime/wrappers/apple/BUILD
@@ -58,6 +58,7 @@ ios_static_framework(
     hdrs = _LIB_HDRS,
     bundle_name = _MODULE_NAME,
     minimum_os_version = _MINIMUM_IOS_VERSION,
+    ipa_post_processor = ":plist_generate",
     visibility = ["//visibility:public"],
     deps = [":runtime_lib"],
 )
@@ -67,6 +68,7 @@ ios_static_framework(
     hdrs = _LIB_HDRS,
     bundle_name = _STUB_MODULE_NAME,
     minimum_os_version = _MINIMUM_IOS_VERSION,
+    ipa_post_processor = ":plist_generate",
     visibility = ["//visibility:public"],
     deps = [":runtime_stub_lib"],
 )
@@ -105,6 +107,12 @@ apple_static_library(
     platform_type = "macos",
     visibility = ["//visibility:public"],
     deps = [":runtime_stub_lib"],
+)
+
+sh_binary(
+    name = "plist_generate",
+    srcs = ["plist_generate.sh"],
+    visibility = ["//visibility:private"],
 )
 
 objc_library(

--- a/spoor/runtime/wrappers/apple/plist_generate.sh
+++ b/spoor/runtime/wrappers/apple/plist_generate.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -euo pipefail
+
+archive_root_path=${1}
+framework_path=$(find ${archive_root_path} -type d -name '*.framework')
+framework_name=$(basename ${framework_path%.framework*})
+
+plutil -convert binary1 -o "${framework_path}/Info.plist" - <<EOF
+{
+    "CFBundleExecutable": "${framework_name}",
+    "CFBundlePackageType": "FMWK",
+    "CFBundleShortVersionString": "0.0.1",
+    "MinimumOSVersion": "13.0",
+    "CFBundleSupportedPlatforms": [
+        "iPhoneOS",
+    ],
+}


### PR DESCRIPTION
Bazel does not add an `Info.plist` file to generated static frameworks, but Xcode seems to require that this file is there in order to generate a xcframework. We can use [the script from this comment](https://github.com/bazelbuild/rules_apple/issues/176#issuecomment-451533167) to add the `Info.plist` file manually.