### PR TITLE
Module hash

### DIFF
--- a/spoor/instrumentation/BUILD
+++ b/spoor/instrumentation/BUILD
@@ -53,6 +53,7 @@ cc_binary(
         "@com_google_absl//absl/strings",
         "@com_google_protobuf//:protobuf",
         "@com_microsoft_gsl//:gsl",
+        "@llvm-project//llvm:BitWriter",
         "@llvm-project//llvm:Core",
         "@llvm-project//llvm:Passes",
         "@llvm-project//llvm:Support",

--- a/spoor/instrumentation/inject_instrumentation/BUILD
+++ b/spoor/instrumentation/inject_instrumentation/BUILD
@@ -11,6 +11,21 @@ load(
 )
 
 cc_library(
+    name = "inject_instrumentation_private",
+    srcs = ["inject_instrumentation_private.cc"],
+    hdrs = ["inject_instrumentation_private.h"],
+    copts = SPOOR_DEFAULT_COPTS,
+    linkopts = SPOOR_DEFAULT_LINKOPTS,
+    visibility = ["//visibility:private"],
+    deps = [
+        "//util:numeric",
+        "@com_google_cityhash//:city_hash",
+        "@llvm-project//llvm:BitWriter",
+        "@llvm-project//llvm:Core",
+    ],
+)
+
+cc_library(
     name = "inject_instrumentation",
     srcs = ["inject_instrumentation.cc"],
     hdrs = ["inject_instrumentation.h"],
@@ -18,6 +33,7 @@ cc_library(
     linkopts = SPOOR_DEFAULT_LINKOPTS,
     visibility = ["//spoor/instrumentation:__pkg__"],
     deps = [
+        ":inject_instrumentation_private",
         "//spoor/instrumentation:instrumentation_info",
         "//spoor/instrumentation/symbols:symbols_cc_proto",
         "//spoor/instrumentation/symbols:symbols_writer",
@@ -26,7 +42,6 @@ cc_library(
         "//util/time:clock",
         "@com_apple_swift//:demangle",
         "@com_google_absl//absl/strings:str_format",
-        "@com_google_cityhash//:city_hash",
         "@com_microsoft_gsl//:gsl",
         "@llvm-project//llvm:Core",
         "@llvm-project//llvm:Demangle",
@@ -45,6 +60,7 @@ cc_test(
     visibility = ["//visibility:private"],
     deps = [
         ":inject_instrumentation",
+        ":inject_instrumentation_private",
         "//spoor/instrumentation/symbols:symbols_cc_proto",
         "//spoor/instrumentation/symbols:symbols_mock",
         "//util:numeric",
@@ -53,7 +69,6 @@ cc_test(
         "//util/time:clock",
         "//util/time:clock_mock",
         "@com_google_absl//absl/strings",
-        "@com_google_cityhash//:city_hash",
         "@com_google_googletest//:gtest_main",
         "@com_google_protobuf//:protobuf",
         "@com_microsoft_gsl//:gsl",

--- a/spoor/instrumentation/inject_instrumentation/inject_instrumentation_private.cc
+++ b/spoor/instrumentation/inject_instrumentation/inject_instrumentation_private.cc
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "spoor/instrumentation/inject_instrumentation/inject_instrumentation_private.h"
+
+#include "city_hash/city.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Bitcode/BitcodeWriter.h"
+#include "llvm/IR/Module.h"
+#include "util/numeric.h"
+
+namespace spoor::instrumentation::inject_instrumentation::internal {
+
+auto ModuleHash(const llvm::Module& llvm_module) -> uint32 {
+  llvm::SmallVector<char, 0> buffer{};
+  llvm::BitcodeWriter bitcode_writer{buffer};
+  constexpr auto preserve_user_list_order{false};
+  constexpr llvm::ModuleSummaryIndex* index{nullptr};
+  constexpr auto generate_hash{true};
+  llvm::ModuleHash module_hash{};
+  bitcode_writer.writeModule(llvm_module, preserve_user_list_order, index,
+                             generate_hash, &module_hash);
+  // Fulfills `assert(WroteStrtab)` in BitcodeWriter's destructor.
+  bitcode_writer.writeStrtab();
+  return CityHash32(
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+      reinterpret_cast<const char*>(module_hash.data()),
+      sizeof(llvm::ModuleHash::value_type) * module_hash.size());
+}
+
+}  // namespace spoor::instrumentation::inject_instrumentation::internal

--- a/spoor/instrumentation/inject_instrumentation/inject_instrumentation_private.h
+++ b/spoor/instrumentation/inject_instrumentation/inject_instrumentation_private.h
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "llvm/IR/Module.h"
+#include "util/numeric.h"
+
+namespace spoor::instrumentation::inject_instrumentation::internal {
+
+auto ModuleHash(const llvm::Module& llvm_module) -> uint32;
+
+}  // namespace spoor::instrumentation::inject_instrumentation::internal

--- a/spoor/instrumentation/test_data/fib_instrumented.ll
+++ b/spoor/instrumentation/test_data/fib_instrumented.ll
@@ -2,7 +2,7 @@
 ; Licensed under the MIT License.
 
 define i32 @_Z9Fibonaccii(i32 %0) {
-  call void @_spoor_runtime_LogFunctionEntry(i64 7304034947084320768)
+  call void @_spoor_runtime_LogFunctionEntry(i64 -166068037236031488)
   %2 = icmp slt i32 %0, 2
   br i1 %2, label %9, label %3
 3:
@@ -11,17 +11,17 @@ define i32 @_Z9Fibonaccii(i32 %0) {
   %6 = add nsw i32 %0, -2
   %7 = tail call i32 @_Z9Fibonaccii(i32 %6)
   %8 = add nsw i32 %7, %5
-  call void @_spoor_runtime_LogFunctionExit(i64 7304034947084320768)
+  call void @_spoor_runtime_LogFunctionExit(i64 -166068037236031488)
   ret i32 %8
 9:
-  call void @_spoor_runtime_LogFunctionExit(i64 7304034947084320768)
+  call void @_spoor_runtime_LogFunctionExit(i64 -166068037236031488)
   ret i32 %0
 }
 
 define i32 @main() {
-  call void @_spoor_runtime_LogFunctionEntry(i64 7304034947084320769)
+  call void @_spoor_runtime_LogFunctionEntry(i64 -166068037236031487)
   %1 = tail call i32 @_Z9Fibonaccii(i32 7)
-  call void @_spoor_runtime_LogFunctionExit(i64 7304034947084320769)
+  call void @_spoor_runtime_LogFunctionExit(i64 -166068037236031487)
   call void @_spoor_runtime_Deinitialize()
   ret i32 %1
 }

--- a/spoor/instrumentation/test_data/fib_instrumented_initialized.ll
+++ b/spoor/instrumentation/test_data/fib_instrumented_initialized.ll
@@ -2,7 +2,7 @@
 ; Licensed under the MIT License.
 
 define i32 @_Z9Fibonaccii(i32 %0) {
-  call void @_spoor_runtime_LogFunctionEntry(i64 7304034947084320768)
+  call void @_spoor_runtime_LogFunctionEntry(i64 -166068037236031488)
   %2 = icmp slt i32 %0, 2
   br i1 %2, label %9, label %3
 3:
@@ -11,18 +11,18 @@ define i32 @_Z9Fibonaccii(i32 %0) {
   %6 = add nsw i32 %0, -2
   %7 = tail call i32 @_Z9Fibonaccii(i32 %6)
   %8 = add nsw i32 %7, %5
-  call void @_spoor_runtime_LogFunctionExit(i64 7304034947084320768)
+  call void @_spoor_runtime_LogFunctionExit(i64 -166068037236031488)
   ret i32 %8
 9:
-  call void @_spoor_runtime_LogFunctionExit(i64 7304034947084320768)
+  call void @_spoor_runtime_LogFunctionExit(i64 -166068037236031488)
   ret i32 %0
 }
 
 define i32 @main() {
   call void @_spoor_runtime_Initialize()
-  call void @_spoor_runtime_LogFunctionEntry(i64 7304034947084320769)
+  call void @_spoor_runtime_LogFunctionEntry(i64 -166068037236031487)
   %1 = tail call i32 @_Z9Fibonaccii(i32 7)
-  call void @_spoor_runtime_LogFunctionExit(i64 7304034947084320769)
+  call void @_spoor_runtime_LogFunctionExit(i64 -166068037236031487)
   call void @_spoor_runtime_Deinitialize()
   ret i32 %1
 }

--- a/spoor/instrumentation/test_data/fib_instrumented_initialized_enabled.ll
+++ b/spoor/instrumentation/test_data/fib_instrumented_initialized_enabled.ll
@@ -2,7 +2,7 @@
 ; Licensed under the MIT License.
 
 define i32 @_Z9Fibonaccii(i32 %0) {
-  call void @_spoor_runtime_LogFunctionEntry(i64 7304034947084320768)
+  call void @_spoor_runtime_LogFunctionEntry(i64 -166068037236031488)
   %2 = icmp slt i32 %0, 2
   br i1 %2, label %9, label %3
 3:
@@ -11,19 +11,19 @@ define i32 @_Z9Fibonaccii(i32 %0) {
   %6 = add nsw i32 %0, -2
   %7 = tail call i32 @_Z9Fibonaccii(i32 %6)
   %8 = add nsw i32 %7, %5
-  call void @_spoor_runtime_LogFunctionExit(i64 7304034947084320768)
+  call void @_spoor_runtime_LogFunctionExit(i64 -166068037236031488)
   ret i32 %8
 9:
-  call void @_spoor_runtime_LogFunctionExit(i64 7304034947084320768)
+  call void @_spoor_runtime_LogFunctionExit(i64 -166068037236031488)
   ret i32 %0
 }
 
 define i32 @main() {
   call void @_spoor_runtime_Initialize()
   call void @_spoor_runtime_Enable()
-  call void @_spoor_runtime_LogFunctionEntry(i64 7304034947084320769)
+  call void @_spoor_runtime_LogFunctionEntry(i64 -166068037236031487)
   %1 = tail call i32 @_Z9Fibonaccii(i32 7)
-  call void @_spoor_runtime_LogFunctionExit(i64 7304034947084320769)
+  call void @_spoor_runtime_LogFunctionExit(i64 -166068037236031487)
   call void @_spoor_runtime_Deinitialize()
   ret i32 %1
 }

--- a/spoor/instrumentation/test_data/fib_only_main_instrumented.ll
+++ b/spoor/instrumentation/test_data/fib_only_main_instrumented.ll
@@ -16,9 +16,9 @@ define i32 @_Z9Fibonaccii(i32 %0) {
 }
 
 define i32 @main() {
-  call void @_spoor_runtime_LogFunctionEntry(i64 7304034947084320769)
+  call void @_spoor_runtime_LogFunctionEntry(i64 -166068037236031487)
   %1 = tail call i32 @_Z9Fibonaccii(i32 7)
-  call void @_spoor_runtime_LogFunctionExit(i64 7304034947084320769)
+  call void @_spoor_runtime_LogFunctionExit(i64 -166068037236031487)
   call void @_spoor_runtime_Deinitialize()
   ret i32 %1
 }


### PR DESCRIPTION
Hashes the entire module instead of just the module's ID. Module IDs are not necessarily unique and were causing function ID collisions across different modules.