### PR TITLE
Trace parsing tool

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -130,6 +130,21 @@ http_archive(
 )
 
 http_archive(
+    # Perfetto's build config requires deviating from the naming convention.
+    name = "perfetto",
+    sha256 = "9f7f64733eac7021c71742635dba8db888f668af236f62dcf76742318b682c47",
+    strip_prefix = "perfetto-15.0",
+    urls = ["https://github.com/google/perfetto/archive/v15.0.tar.gz"],
+)
+
+new_local_repository(
+    # Perfetto's build config requires deviating from the naming convention.
+    name = "perfetto_cfg",
+    build_file_content = "",
+    path = "toolchain/perfetto_overrides",
+)
+
+http_archive(
     name = "com_google_googletest",
     sha256 = "9dc9157a9a1551ec7a7e43daea9a694a0bb5fb8bec81235d8a1e6ef64c716dcb",
     strip_prefix = "googletest-release-1.10.0",
@@ -218,6 +233,14 @@ http_archive(
     sha256 = "dec60361d82b7d551ffe0f3e3d8d381047f91550c635accf2ec7b858483358ba",
     strip_prefix = "wikipedia-ios-releases-6.8.1",
     url = "https://github.com/wikimedia/wikipedia-ios/archive/refs/tags/releases/6.8.1.tar.gz",
+)
+
+http_file(
+    name = "dev_perfetto_trace_processor",
+    downloaded_file_path = "trace_processor",
+    executable = True,
+    sha256 = "1e5371913f51e65cc3679c00ab818e82acd48b9dbdd4321d59e55355a40eac66",
+    urls = ["https://get.perfetto.dev/trace_processor"],
 )
 
 http_file(

--- a/spoor/BUILD
+++ b/spoor/BUILD
@@ -9,6 +9,8 @@ sh_test(
         "//spoor/instrumentation:spoor_opt",
         "//spoor/runtime:spoor_runtime",
         "//spoor/test_data",
+        "//spoor/tools:spoor",
+        "@dev_perfetto_trace_processor//file:trace_processor",
     ],
     visibility = ["//visibility:private"],
 )

--- a/spoor/instrumentation/config/command_line_config.h
+++ b/spoor/instrumentation/config/command_line_config.h
@@ -32,6 +32,7 @@ ABSL_DECLARE_FLAG(                                                 // NOLINT
     spoor::instrumentation::config::OutputLanguage, output_language);
 
 namespace spoor::instrumentation::config {
+
 auto ConfigFromCommandLineOrEnv(int argc, char** argv,
                                 const util::env::GetEnv& get_env = std::getenv)
     -> std::pair<Config, std::vector<char*>>;

--- a/spoor/instrumentation/config/command_line_config_test.cc
+++ b/spoor/instrumentation/config/command_line_config_test.cc
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#include "command_line_config.h"
+#include "spoor/instrumentation/config/command_line_config.h"
 
 #include <algorithm>
 #include <cstddef>
@@ -37,11 +37,13 @@ using spoor::instrumentation::config::OutputLanguage;
 auto MakeArgv(const std::vector<std::string_view>& args) -> std::vector<char*> {
   std::vector<char*> argv{};
   argv.reserve(args.size());
-  std::transform(
-      std::begin(args), std::end(args), std::back_inserter(argv),
-      // `absl::ParseCommandLine` requires a (non-const) char** as an argument.
-      // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
-      [](auto string_view) { return const_cast<char*>(string_view.data()); });
+  std::transform(std::cbegin(args), std::cend(args), std::back_inserter(argv),
+                 [](const auto string_view) {
+                   // `absl::ParseCommandLine` requires a (non-const) char** as
+                   // an argument.
+                   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+                   return const_cast<char*>(string_view.data());
+                 });
   return argv;
 }
 
@@ -223,7 +225,7 @@ TEST(CommandLineConfig, UnknownFlag) {  // NOLINT
       "Unknown command line flag 'unknown_flag'");
 }
 
-TEST(CommandLineconfig, AbslParseFlag) {  // NOLINT
+TEST(CommandLineConfig, AbslParseFlag) {  // NOLINT
   for (const auto& [key, value] : kOutputLanguages) {
     OutputLanguage language{};
     std::string error{};
@@ -240,7 +242,7 @@ TEST(CommandLineconfig, AbslParseFlag) {  // NOLINT
   ASSERT_EQ(error, "Unknown language 'invalid'. Options: bitcode, ir.");
 }
 
-TEST(CommandLineconfig, AbslUnparseFlag) {  // NOLINT
+TEST(CommandLineConfig, AbslUnparseFlag) {  // NOLINT
   for (const auto& [key, value] : kOutputLanguages) {
     const auto result = AbslUnparseFlag(value);
     ASSERT_EQ(result, key);

--- a/spoor/instrumentation/config/config.h
+++ b/spoor/instrumentation/config/config.h
@@ -38,11 +38,11 @@ constexpr util::flat_map::FlatMap<std::string_view, OutputLanguage, 2>
 
 constexpr std::string_view kEnableRuntimeDoc{
     "Automatically enable Spoor's runtime."};
-constexpr bool kEnableRuntimeDefaultValue{true};
+constexpr auto kEnableRuntimeDefaultValue{true};
 
 constexpr std::string_view kForceBinaryOutputDoc{
     "Force printing binary data to the console."};
-constexpr bool kForceBinaryOutputDefaultValue{false};
+constexpr auto kForceBinaryOutputDefaultValue{false};
 
 constexpr std::string_view kFunctionAllowListFileDoc{
     "File path to the function allow list."};
@@ -60,7 +60,7 @@ const std::optional<std::string> kFunctionBlocklistFileDefaultValue{};
 
 constexpr std::string_view kInitializeRuntimeDoc{
     "Automatically initialize Spoor's runtime."};
-constexpr bool kInitializeRuntimeDefaultValue{true};
+constexpr auto kInitializeRuntimeDefaultValue{true};
 
 constexpr std::string_view kInjectInstrumentationDoc{
     "Inject Spoor instrumentation."};
@@ -82,10 +82,7 @@ constexpr std::string_view kModuleIdDoc{"Override the LLVM module's ID."};
 const std::optional<std::string> kModuleIdDefaultValue{};
 
 constexpr std::string_view kOutputFileDoc{"Output file."};
-// This statically-constructed object is safe because its value is the type's
-// default.
-// NOLINTNEXTLINE(fuchsia-statically-constructed-objects)
-const std::string_view kOutputFileDefaultValue{"-"};
+constexpr std::string_view kOutputFileDefaultValue{"-"};
 
 constexpr std::string_view kOutputLanguageDoc{
     "Language in which to output the transformed code. Options: %s."};

--- a/spoor/instrumentation/instrumentation.h
+++ b/spoor/instrumentation/instrumentation.h
@@ -13,5 +13,6 @@ using FunctionId = uint64;
 
 constexpr std::string_view kPluginName{"inject-spoor-instrumentation"};
 constexpr std::string_view kVersion{"0.0.0"};
+constexpr std::string_view kSymbolsFileExtension{"spoor_symbols"};
 
 }  // namespace spoor::instrumentation

--- a/spoor/instrumentation/spoor_opt.cc
+++ b/spoor/instrumentation/spoor_opt.cc
@@ -48,7 +48,7 @@ constexpr std::string_view kStdinFileName{"-"};
 constexpr std::string_view kVersion{"%s %s\nBased on LLVM %d.%d.%d\n"};
 constexpr std::string_view kUsage{
     "Transform LLVM Bitcode/IR by injecting Spoor instrumentation.\n\n"
-    "USAGE: %1$s [options] [input_file]\n\n"
+    "USAGE: %1$s [options...] [input_file]\n\n"
     "EXAMPLES\n"
     "$ %1$s source.bc --output_file=instrumented_source.bc\n"
     "$ clang++ source.cc -c -emit-llvm -o - | %1$s | "

--- a/spoor/instrumentation/symbols/BUILD
+++ b/spoor/instrumentation/symbols/BUILD
@@ -109,3 +109,31 @@ cc_library(
         "@com_google_googletest//:gtest",
     ],
 )
+
+cc_library(
+    name = "symbols_utility",
+    srcs = ["symbols_utility.cc"],
+    hdrs = ["symbols_utility.h"],
+    copts = SPOOR_DEFAULT_COPTS,
+    linkopts = SPOOR_DEFAULT_LINKOPTS,
+    visibility = ["//visibility:public"],
+    deps = [
+        ":symbols_cc_proto",
+        "@com_microsoft_gsl//:gsl",
+    ],
+)
+
+cc_test(
+    name = "symbols_utility_test",
+    size = "small",
+    srcs = ["symbols_utility_test.cc"],
+    copts = SPOOR_DEFAULT_TEST_COPTS,
+    linkopts = SPOOR_DEFAULT_TEST_LINKOPTS,
+    visibility = ["//visibility:private"],
+    deps = [
+        ":symbols_cc_proto",
+        ":symbols_utility",
+        "@com_google_googletest//:gtest_main",
+        "@com_google_protobuf//:protobuf",
+    ],
+)

--- a/spoor/instrumentation/symbols/symbols_file_reader.h
+++ b/spoor/instrumentation/symbols/symbols_file_reader.h
@@ -4,8 +4,8 @@
 #pragma once
 
 #include <filesystem>
+#include <memory>
 
-#include "gsl/gsl"
 #include "spoor/instrumentation/symbols/symbols_reader.h"
 #include "util/file_system/file_reader.h"
 
@@ -14,7 +14,7 @@ namespace spoor::instrumentation::symbols {
 class SymbolsFileReader final : public SymbolsReader {
  public:
   struct Options {
-    gsl::not_null<util::file_system::FileReader*> file_reader;
+    std::unique_ptr<util::file_system::FileReader> file_reader;
   };
 
   explicit SymbolsFileReader(Options options);

--- a/spoor/instrumentation/symbols/symbols_utility.cc
+++ b/spoor/instrumentation/symbols/symbols_utility.cc
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include <utility>
+
+#include "gsl/gsl"
+#include "spoor/instrumentation/symbols/symbols.pb.h"
+
+namespace spoor::instrumentation::symbols {
+
+auto ReduceSymbols(gsl::not_null<Symbols*> source,
+                   gsl::not_null<Symbols*> destination) -> void {
+  auto& source_symbols_table = *source->mutable_function_symbols_table();
+  auto& destination_function_symbols_table =
+      *destination->mutable_function_symbols_table();
+  for (auto& [function_id, source_function_infos] : source_symbols_table) {
+    auto& destination_function_infos =
+        destination_function_symbols_table[function_id];
+    auto* repeated_destination_function_infos =
+        destination_function_infos.mutable_function_infos();
+    auto& repeated_source_function_infos =
+        *source_function_infos.mutable_function_infos();
+    std::move(std::begin(repeated_source_function_infos),
+              std::end(repeated_source_function_infos),
+              RepeatedFieldBackInserter(repeated_destination_function_infos));
+  }
+  source_symbols_table.clear();
+}
+
+}  // namespace spoor::instrumentation::symbols

--- a/spoor/instrumentation/symbols/symbols_utility.h
+++ b/spoor/instrumentation/symbols/symbols_utility.h
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "gsl/gsl"
+#include "spoor/instrumentation/symbols/symbols.pb.h"
+
+namespace spoor::instrumentation::symbols {
+
+auto ReduceSymbols(gsl::not_null<Symbols*> source,
+                   gsl::not_null<Symbols*> destination) -> void;
+
+}  // namespace spoor::instrumentation::symbols

--- a/spoor/instrumentation/symbols/symbols_utility_test.cc
+++ b/spoor/instrumentation/symbols/symbols_utility_test.cc
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "spoor/instrumentation/symbols/symbols_utility.h"
+
+#include "google/protobuf/util/message_differencer.h"
+#include "gsl/gsl"
+#include "gtest/gtest.h"
+#include "spoor/instrumentation/symbols/symbols.pb.h"
+
+namespace {
+
+using google::protobuf::util::MessageDifferencer;
+using spoor::instrumentation::symbols::ReduceSymbols;
+using spoor::instrumentation::symbols::Symbols;
+
+TEST(ReduceSymbols, ReducesUniqueSymbols) {  // NOLINT
+  auto source_symbols = [] {
+    Symbols symbols{};
+    auto& function_symbols_table = *symbols.mutable_function_symbols_table();
+    auto& function_infos_0 = function_symbols_table[0];
+    auto& function_info_a = *function_infos_0.add_function_infos();
+    function_info_a.set_module_id("a");
+    auto& function_infos_1 = function_symbols_table[1];
+    auto& function_info_b = *function_infos_1.add_function_infos();
+    function_info_b.set_module_id("b");
+    return symbols;
+  }();
+  auto destination_symbols = [] {
+    Symbols symbols{};
+    auto& function_symbols_table = *symbols.mutable_function_symbols_table();
+    auto& function_infos_1 = function_symbols_table[1];
+    auto& function_info_b = *function_infos_1.add_function_infos();
+    function_info_b.set_module_id("b");
+    auto& function_info_c = *function_infos_1.add_function_infos();
+    function_info_c.set_module_id("c");
+    auto& function_infos_2 = function_symbols_table[2];
+    auto& function_info_d = *function_infos_2.add_function_infos();
+    function_info_d.set_module_id("d");
+    return symbols;
+  }();
+  const Symbols expected_source_symbols{};
+  const auto expected_destination_symbols = [] {
+    Symbols symbols{};
+    auto& function_symbols_table = *symbols.mutable_function_symbols_table();
+    auto& function_infos_0 = function_symbols_table[0];
+    auto& function_info_a = *function_infos_0.add_function_infos();
+    function_info_a.set_module_id("a");
+    auto& function_infos_1 = function_symbols_table[1];
+    auto& function_info_b0 = *function_infos_1.add_function_infos();
+    function_info_b0.set_module_id("b");
+    auto& function_info_c = *function_infos_1.add_function_infos();
+    function_info_c.set_module_id("c");
+    auto& function_info_b1 = *function_infos_1.add_function_infos();
+    function_info_b1.set_module_id("b");
+    auto& function_infos_2 = function_symbols_table[2];
+    auto& function_info_d = *function_infos_2.add_function_infos();
+    function_info_d.set_module_id("d");
+    return symbols;
+  }();
+  ReduceSymbols(&source_symbols, &destination_symbols);
+  ASSERT_TRUE(
+      MessageDifferencer::Equals(source_symbols, expected_source_symbols));
+  ASSERT_TRUE(MessageDifferencer::Equals(destination_symbols,
+                                         expected_destination_symbols));
+}
+
+}  // namespace

--- a/spoor/runtime/trace/BUILD
+++ b/spoor/runtime/trace/BUILD
@@ -25,7 +25,7 @@ cc_library(
     ],
     copts = SPOOR_DEFAULT_COPTS,
     linkopts = SPOOR_DEFAULT_LINKOPTS,
-    visibility = ["//spoor/runtime:__subpackages__"],
+    visibility = ["//visibility:public"],
     deps = [
         "//spoor/runtime/buffer",
         "//util:numeric",

--- a/spoor/tools/BUILD
+++ b/spoor/tools/BUILD
@@ -1,0 +1,48 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
+load(
+    "//toolchain:config.bzl",
+    "SPOOR_DEFAULT_COPTS",
+    "SPOOR_DEFAULT_LINKOPTS",
+    "SPOOR_DEFAULT_TEST_COPTS",
+    "SPOOR_DEFAULT_TEST_LINKOPTS",
+)
+
+cc_library(
+    name = "tools_info",
+    hdrs = ["tools.h"],
+    copts = SPOOR_DEFAULT_COPTS,
+    linkopts = SPOOR_DEFAULT_LINKOPTS,
+    visibility = ["//visibility:private"],
+)
+
+cc_binary(
+    name = "spoor",
+    srcs = ["spoor.cc"],
+    copts = SPOOR_DEFAULT_COPTS,
+    linkopts = SPOOR_DEFAULT_LINKOPTS,
+    visibility = ["//visibility:public"],
+    deps = [
+        ":tools_info",
+        "//spoor/instrumentation:instrumentation_info",
+        "//spoor/instrumentation/symbols:symbols_cc_proto",
+        "//spoor/instrumentation/symbols:symbols_reader",
+        "//spoor/instrumentation/symbols:symbols_utility",
+        "//spoor/instrumentation/symbols:symbols_writer",
+        "//spoor/runtime/trace",
+        "//spoor/tools/config",
+        "//spoor/tools/config:command_line_config",
+        "//spoor/tools/serialization:serialize",
+        "//util:numeric",
+        "//util/compression",
+        "//util/env",
+        "@com_google_absl//absl/flags:flag",
+        "@com_google_absl//absl/flags:parse",
+        "@com_google_absl//absl/flags:usage",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:str_format",
+        "@com_microsoft_gsl//:gsl",
+    ],
+)

--- a/spoor/tools/adapters/BUILD
+++ b/spoor/tools/adapters/BUILD
@@ -1,0 +1,2 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.

--- a/spoor/tools/adapters/perfetto/BUILD
+++ b/spoor/tools/adapters/perfetto/BUILD
@@ -1,0 +1,72 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+load(
+    "//toolchain:config.bzl",
+    "SPOOR_DEFAULT_COPTS",
+    "SPOOR_DEFAULT_LINKOPTS",
+    "SPOOR_DEFAULT_TEST_COPTS",
+    "SPOOR_DEFAULT_TEST_LINKOPTS",
+)
+
+cc_proto_library(
+    name = "perfetto_trace_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = ["@perfetto//:protos_perfetto_trace_non_minimal_protos"],
+)
+
+cc_library(
+    name = "perfetto_adapter_private",
+    srcs = ["perfetto_adapter_private.cc"],
+    hdrs = ["perfetto_adapter_private.h"],
+    copts = SPOOR_DEFAULT_COPTS,
+    linkopts = SPOOR_DEFAULT_LINKOPTS,
+    visibility = ["//visibility:private"],
+    deps = [
+        "//spoor/runtime/trace",
+        "//util:numeric",
+        "@com_google_cityhash//:city_hash",
+    ],
+)
+
+cc_library(
+    name = "perfetto_adapter",
+    srcs = ["perfetto_adapter.cc"],
+    hdrs = ["perfetto_adapter.h"],
+    copts = SPOOR_DEFAULT_COPTS,
+    linkopts = SPOOR_DEFAULT_LINKOPTS,
+    visibility = ["//visibility:public"],
+    deps = [
+        ":perfetto_adapter_private",
+        ":perfetto_trace_cc_proto",
+        "//spoor/instrumentation/symbols:symbols_cc_proto",
+        "//spoor/runtime/trace",
+        "//util:numeric",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:str_format",
+        "@com_google_protobuf//:protobuf",
+        "@com_microsoft_gsl//:gsl",
+    ],
+)
+
+cc_test(
+    name = "perfetto_adapter_test",
+    size = "small",
+    srcs = ["perfetto_adapter_test.cc"],
+    copts = SPOOR_DEFAULT_TEST_COPTS,
+    linkopts = SPOOR_DEFAULT_TEST_LINKOPTS,
+    visibility = ["//visibility:private"],
+    deps = [
+        ":perfetto_adapter",
+        ":perfetto_adapter_private",
+        ":perfetto_trace_cc_proto",
+        "//spoor/instrumentation/symbols:symbols_cc_proto",
+        "//spoor/runtime/trace",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:str_format",
+        "@com_google_cityhash//:city_hash",
+        "@com_google_googletest//:gtest_main",
+        "@com_google_protobuf//:protobuf",
+    ],
+)

--- a/spoor/tools/adapters/perfetto/perfetto_adapter.cc
+++ b/spoor/tools/adapters/perfetto/perfetto_adapter.cc
@@ -1,0 +1,289 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "spoor/tools/adapters/perfetto/perfetto_adapter.h"
+
+#include <algorithm>
+#include <filesystem>
+#include <string>
+#include <string_view>
+#include <unordered_set>
+#include <vector>
+
+#include "absl/strings/str_format.h"
+#include "absl/strings/str_join.h"
+#include "google/protobuf/repeated_field.h"
+#include "gsl/gsl"
+#include "protos/perfetto/common/builtin_clock.pb.h"
+#include "protos/perfetto/trace/clock_snapshot.pb.h"
+#include "protos/perfetto/trace/trace.pb.h"
+#include "protos/perfetto/trace/trace_packet.pb.h"
+#include "protos/perfetto/trace/track_event/source_location.pb.h"
+#include "protos/perfetto/trace/track_event/track_event.pb.h"
+#include "spoor/instrumentation/symbols/symbols.pb.h"
+#include "spoor/tools/adapters/perfetto/perfetto_adapter_private.h"
+#include "util/numeric.h"
+
+namespace spoor::tools::adapters::perfetto {
+
+using spoor::runtime::trace::FunctionId;
+using PerfettoBuiltinClock = ::perfetto::protos::BuiltinClock;
+using PerfettoClockSnapshot = ::perfetto::protos::ClockSnapshot;
+using PerfettoEventName = ::perfetto::protos::EventName;
+using PerfettoSourceLocation = ::perfetto::protos::SourceLocation;
+using PerfettoTrace = ::perfetto::protos::Trace;
+using PerfettoTracePacket = ::perfetto::protos::TracePacket;
+using PerfettoTrackEvent = ::perfetto::protos::TrackEvent;
+using SpoorEvent = spoor::runtime::trace::Event;
+using SpoorFunctionInfo = spoor::instrumentation::symbols::FunctionInfo;
+using SpoorHeader = spoor::runtime::trace::Header;
+using SpoorRepeatedFunctionInfos =
+    google::protobuf::RepeatedPtrField<SpoorFunctionInfo>;
+using SpoorSymbols = spoor::instrumentation::symbols::Symbols;
+using SpoorTraceFile = spoor::runtime::trace::TraceFile;
+
+constexpr auto kPrimaryTraceClock{PerfettoBuiltinClock::BUILTIN_CLOCK_REALTIME};
+constexpr std::string_view kSeparator{"; "};
+constexpr std::string_view kUnknown{"unknown"};
+constexpr std::string_view kConflictFormat{
+    "%d-way conflict for function ID %#016x: %s"};
+// Perfetto skips interned data with long strings. The limit is around 50k
+// characters.
+constexpr std::string_view::size_type kMaxNameLength{1'024};
+
+auto Truncate(const std::string& string) -> std::string {
+  constexpr std::string_view ellipsis{"..."};
+  static_assert(ellipsis.size() < kMaxNameLength);
+  if (string.size() <= kMaxNameLength) return string;
+  return absl::StrCat(string.substr(0, kMaxNameLength - ellipsis.size()),
+                      ellipsis);
+}
+
+auto MakeFunctionName(const FunctionId function_id,
+                      const SpoorRepeatedFunctionInfos& function_infos)
+    -> std::string {
+  const auto joined =
+      absl::StrJoin(function_infos, kSeparator,
+                    [function_id](auto* out, const auto& function_info) {
+                      const auto name = [&] {
+                        if (function_info.has_demangled_name()) {
+                          return function_info.demangled_name();
+                        }
+                        if (function_info.has_linkage_name()) {
+                          return function_info.linkage_name();
+                        }
+                        return absl::StrFormat("%#016x", function_id);
+                      }();
+                      out->append(name);
+                    });
+  if (function_infos.size() < 2) return Truncate(joined);
+  const auto formatted = absl::StrFormat(kConflictFormat, function_infos.size(),
+                                         function_id, joined);
+  return Truncate(formatted);
+}
+
+auto MakeFileName(const FunctionId function_id,
+                  const SpoorRepeatedFunctionInfos& function_infos)
+    -> std::string {
+  const auto joined = absl::StrJoin(
+      function_infos, kSeparator, [&](auto* out, const auto& function_info) {
+        const auto path = [&] {
+          const auto append_line = function_infos.size() != 1;
+          std::filesystem::path path{};
+          if (function_info.has_directory()) {
+            path = function_info.directory();
+            path.make_preferred();
+          }
+          if (function_info.has_file_name()) {
+            path /= function_info.file_name();
+            if (append_line && function_info.has_line()) {
+              path += absl::StrFormat(":%d", function_info.line());
+            }
+          }
+          if (path.empty()) return std::string{kUnknown};
+          return path.string();
+        }();
+        out->append(path);
+      });
+  if (function_infos.size() < 2) return Truncate(joined);
+  const auto formatted = absl::StrFormat(kConflictFormat, function_infos.size(),
+                                         function_id, joined);
+  return Truncate(formatted);
+}
+
+auto MakeEventName(const FunctionId function_id,
+                   const SpoorRepeatedFunctionInfos& function_infos)
+    -> PerfettoEventName {
+  PerfettoEventName event_name{};
+  event_name.set_iid(function_id);
+  event_name.set_name(MakeFunctionName(function_id, function_infos));
+  return event_name;
+}
+
+auto MakeSourceLocation(const FunctionId function_id,
+                        const SpoorRepeatedFunctionInfos& function_infos)
+    -> PerfettoSourceLocation {
+  PerfettoSourceLocation source_location{};
+  source_location.set_iid(function_id);
+  source_location.set_file_name(MakeFileName(function_id, function_infos));
+  source_location.set_function_name(
+      MakeFunctionName(function_id, function_infos));
+  if (function_infos.size() == 1) {
+    const auto& function_info = std::cbegin(function_infos);
+    if (function_info->has_line()) {
+      source_location.set_line_number(function_info->line());
+    }
+  }
+  return source_location;
+}
+
+auto MakePerfettoTrackEventTracePacket(const SpoorHeader& spoor_header,
+                                       const SpoorEvent& spoor_event)
+    -> PerfettoTracePacket {
+  PerfettoTracePacket packet{};
+  packet.set_trusted_packet_sequence_id(kTrustedPacketSequenceId);
+  packet.set_timestamp(spoor_event.steady_clock_timestamp);
+  packet.set_timestamp_clock_id(PerfettoBuiltinClock::BUILTIN_CLOCK_MONOTONIC);
+  packet.set_sequence_flags(PerfettoTracePacket::SEQ_NEEDS_INCREMENTAL_STATE);
+
+  auto* track_event = packet.mutable_track_event();
+  const auto track_uuid =
+      internal::TrackUuid(spoor_header.process_id, spoor_header.thread_id);
+  track_event->set_track_uuid(track_uuid);
+
+  switch (static_cast<SpoorEvent::Event::Type>(spoor_event.type)) {
+    case SpoorEvent::Type::kFunctionEntry: {
+      const auto function_id = spoor_event.payload_1;
+      track_event->set_type(PerfettoTrackEvent::TYPE_SLICE_BEGIN);
+      track_event->set_name_iid(function_id);
+      track_event->set_source_location_iid(function_id);
+      break;
+    }
+    case SpoorEvent::Type::kFunctionExit: {
+      track_event->set_type(PerfettoTrackEvent::TYPE_SLICE_END);
+      break;
+    }
+  }
+  return packet;
+}
+
+auto MakePerfettoClockSnapshotTracePacket(const SpoorHeader& spoor_header)
+    -> PerfettoTracePacket {
+  PerfettoClockSnapshot::Clock steady_clock{};
+  steady_clock.set_clock_id(PerfettoBuiltinClock::BUILTIN_CLOCK_MONOTONIC);
+  steady_clock.set_timestamp(spoor_header.steady_clock_timestamp);
+
+  PerfettoClockSnapshot::Clock system_clock{};
+  system_clock.set_clock_id(PerfettoBuiltinClock::BUILTIN_CLOCK_REALTIME);
+  system_clock.set_timestamp(spoor_header.system_clock_timestamp);
+
+  PerfettoTracePacket packet{};
+  packet.set_trusted_packet_sequence_id(kTrustedPacketSequenceId);
+  auto* clock_snapshot = packet.mutable_clock_snapshot();
+  auto* clocks = clock_snapshot->mutable_clocks();
+  clocks->Reserve(2);
+  clocks->Add(std::move(steady_clock));
+  clocks->Add(std::move(system_clock));
+  clock_snapshot->set_primary_trace_clock(kPrimaryTraceClock);
+  return packet;
+}
+
+auto MakePerfettoTrackDescriptorPackets(
+    const std::vector<SpoorTraceFile>& trace_files)
+    -> std::vector<PerfettoTracePacket> {
+  std::unordered_set<uint64> uuids{};
+  std::vector<PerfettoTracePacket> trace_packets{};
+  for (const auto& trace_file : trace_files) {
+    const auto& header = trace_file.header;
+    const auto uuid = internal::TrackUuid(header.process_id, header.thread_id);
+    if (uuids.contains(uuid)) continue;
+    PerfettoTracePacket packet{};
+    auto* track_descriptor = packet.mutable_track_descriptor();
+    track_descriptor->set_uuid(uuid);
+    auto* thread_descriptor = track_descriptor->mutable_thread();
+    thread_descriptor->set_pid(gsl::narrow_cast<int32>(header.process_id));
+    thread_descriptor->set_tid(gsl::narrow_cast<int32>(header.thread_id));
+    trace_packets.emplace_back(std::move(packet));
+  }
+  return trace_packets;
+}
+
+auto SpoorTraceToPerfettoTrace(const std::vector<SpoorTraceFile>& trace_files,
+                               const SpoorSymbols& symbols) -> PerfettoTrace {
+  const auto event_count = std::transform_reduce(
+      std::cbegin(trace_files), std::cend(trace_files), 0,
+      [](const auto size_a, const auto size_b) { return size_a + size_b; },
+      [](const auto& trace_file) { return trace_file.events.size(); });
+  if (event_count < 1) return {};
+
+  std::unordered_set<FunctionId> called_function_ids{};
+  std::for_each(
+      std::cbegin(trace_files), std::cend(trace_files),
+      [&called_function_ids](const auto& trace_file) {
+        std::for_each(
+            std::cbegin(trace_file.events), std::cend(trace_file.events),
+            [&called_function_ids](const auto& event) {
+              switch (static_cast<SpoorEvent::Event::Type>(event.type)) {
+                case SpoorEvent::Type::kFunctionEntry:
+                case SpoorEvent::Type::kFunctionExit: {
+                  called_function_ids.emplace(event.payload_1);
+                  break;
+                }
+              }
+            });
+      });
+
+  auto head_packet = [&] {
+    PerfettoTracePacket packet{};
+    packet.set_trusted_packet_sequence_id(kTrustedPacketSequenceId);
+    packet.set_previous_packet_dropped(true);
+    packet.set_sequence_flags(
+        PerfettoTracePacket::SEQ_INCREMENTAL_STATE_CLEARED);
+    auto* trace_config = packet.mutable_trace_config();
+    auto* data_source = trace_config->mutable_builtin_data_sources();
+    data_source->set_primary_trace_clock(kPrimaryTraceClock);
+    const auto& symbols_table = symbols.function_symbols_table();
+    auto* interned_data = packet.mutable_interned_data();
+    auto* event_names = interned_data->mutable_event_names();
+    event_names->Reserve(called_function_ids.size());
+    auto* source_locations = interned_data->mutable_source_locations();
+    source_locations->Reserve(called_function_ids.size());
+    std::for_each(
+        std::cbegin(symbols_table), std::cend(symbols_table),
+        [&](const auto& key_value) {
+          const auto& [function_id, function_infos] = key_value;
+          const auto& repeated_function_infos = function_infos.function_infos();
+          if (!called_function_ids.contains(function_id)) return;
+          event_names->Add(MakeEventName(function_id, repeated_function_infos));
+          source_locations->Add(
+              MakeSourceLocation(function_id, repeated_function_infos));
+        });
+    return packet;
+  }();
+
+  auto track_descriptor_packets =
+      MakePerfettoTrackDescriptorPackets(trace_files);
+
+  PerfettoTrace trace{};
+  auto* packets = trace.mutable_packet();
+  packets->Reserve(gsl::narrow_cast<int>(1 + track_descriptor_packets.size() +
+                                         trace_files.size() + event_count));
+  packets->Add(std::move(head_packet));
+  std::move(std::begin(track_descriptor_packets),
+            std::end(track_descriptor_packets),
+            RepeatedFieldBackInserter(packets));
+  std::for_each(
+      std::cbegin(trace_files), std::cend(trace_files),
+      [packets](const auto& trace_file) {
+        packets->Add(MakePerfettoClockSnapshotTracePacket(trace_file.header));
+        std::transform(
+            std::cbegin(trace_file.events), std::cend(trace_file.events),
+            RepeatedFieldBackInserter(packets),
+            [&header = trace_file.header](const auto& event) {
+              return MakePerfettoTrackEventTracePacket(header, event);
+            });
+      });
+  return trace;
+}
+
+}  // namespace spoor::tools::adapters::perfetto

--- a/spoor/tools/adapters/perfetto/perfetto_adapter.h
+++ b/spoor/tools/adapters/perfetto/perfetto_adapter.h
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include <string_view>
+#include <vector>
+
+#include "protos/perfetto/trace/trace.pb.h"
+#include "spoor/instrumentation/symbols/symbols.pb.h"
+#include "spoor/runtime/trace/trace.h"
+#include "util/numeric.h"
+
+namespace spoor::tools::adapters::perfetto {
+
+constexpr uint32 kTrustedPacketSequenceId{1};
+constexpr std::string_view kPerfettoFileExtension{"perfetto"};
+
+auto SpoorTraceToPerfettoTrace(
+    const std::vector<runtime::trace::TraceFile>& trace_files,
+    const instrumentation::symbols::Symbols& symbols)
+    -> ::perfetto::protos::Trace;
+
+}  // namespace spoor::tools::adapters::perfetto

--- a/spoor/tools/adapters/perfetto/perfetto_adapter_private.cc
+++ b/spoor/tools/adapters/perfetto/perfetto_adapter_private.cc
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "spoor/tools/adapters/perfetto/perfetto_adapter_private.h"
+
+#include "city_hash/city.h"
+#include "spoor/runtime/trace/trace.h"
+#include "util/numeric.h"
+
+namespace spoor::tools::adapters::perfetto::internal {
+
+using spoor::runtime::trace::ProcessId;
+using spoor::runtime::trace::ThreadId;
+
+auto TrackUuid(const ProcessId process_id, const ThreadId thread_id) -> uint64 {
+  const auto process_id_hash = CityHash64(
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+      reinterpret_cast<const char*>(&process_id), sizeof(process_id));
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+  return CityHash64WithSeed(reinterpret_cast<const char*>(&thread_id),
+                            sizeof(thread_id), process_id_hash);
+}
+
+}  // namespace spoor::tools::adapters::perfetto::internal

--- a/spoor/tools/adapters/perfetto/perfetto_adapter_private.h
+++ b/spoor/tools/adapters/perfetto/perfetto_adapter_private.h
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "city_hash/city.h"
+#include "spoor/runtime/trace/trace.h"
+#include "util/numeric.h"
+
+namespace spoor::tools::adapters::perfetto::internal {
+
+auto TrackUuid(runtime::trace::ProcessId process_id,
+               runtime::trace::ThreadId thread_id) -> uint64;
+
+}  // namespace spoor::tools::adapters::perfetto::internal

--- a/spoor/tools/adapters/perfetto/perfetto_adapter_test.cc
+++ b/spoor/tools/adapters/perfetto/perfetto_adapter_test.cc
@@ -1,0 +1,1060 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "spoor/tools/adapters/perfetto/perfetto_adapter.h"
+
+#include <algorithm>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_format.h"
+#include "city_hash/city.h"
+#include "google/protobuf/repeated_field.h"
+#include "google/protobuf/util/message_differencer.h"
+#include "google/protobuf/util/time_util.h"
+#include "gsl/gsl"
+#include "gtest/gtest.h"
+#include "protos/perfetto/common/builtin_clock.pb.h"
+#include "protos/perfetto/trace/clock_snapshot.pb.h"
+#include "protos/perfetto/trace/trace.pb.h"
+#include "protos/perfetto/trace/trace_packet.pb.h"
+#include "protos/perfetto/trace/track_event/source_location.pb.h"
+#include "protos/perfetto/trace/track_event/track_event.pb.h"
+#include "spoor/instrumentation/symbols/symbols.pb.h"
+#include "spoor/runtime/trace/trace.h"
+#include "spoor/tools/adapters/perfetto/perfetto_adapter_private.h"
+#include "util/numeric.h"
+
+namespace {
+
+using google::protobuf::util::MessageDifferencer;
+using google::protobuf::util::TimeUtil;
+using perfetto::protos::BuiltinClock;
+using perfetto::protos::ClockSnapshot;
+using perfetto::protos::EventName;
+using perfetto::protos::SourceLocation;
+using perfetto::protos::TracePacket;
+using perfetto::protos::TrackEvent;
+using spoor::instrumentation::symbols::FunctionInfo;
+using spoor::instrumentation::symbols::Symbols;
+using spoor::runtime::trace::CompressionStrategy;
+using spoor::runtime::trace::Event;
+using spoor::runtime::trace::EventCount;
+using spoor::runtime::trace::EventType;
+using spoor::runtime::trace::FunctionId;
+using spoor::runtime::trace::kEndianness;
+using spoor::runtime::trace::kMagicNumber;
+using spoor::runtime::trace::kTraceFileVersion;
+using spoor::runtime::trace::ProcessId;
+using spoor::runtime::trace::SessionId;
+using spoor::runtime::trace::ThreadId;
+using spoor::runtime::trace::TraceFile;
+using spoor::tools::adapters::perfetto::kTrustedPacketSequenceId;
+using spoor::tools::adapters::perfetto::SpoorTraceToPerfettoTrace;
+using spoor::tools::adapters::perfetto::internal::TrackUuid;
+using PerfettoTrace = perfetto::protos::Trace;
+
+static_assert(kTrustedPacketSequenceId != 0);  // Perfetto requirement.
+
+TEST(PerfettoAdapter, HandlesZeroEvents) {  // NOLINT
+  const Symbols symbols{};
+  const std::vector<TraceFile> trace_files{};
+  const PerfettoTrace expected_perfetto_trace{};
+  const auto perfetto_trace = SpoorTraceToPerfettoTrace(trace_files, symbols);
+  ASSERT_TRUE(
+      MessageDifferencer::Equals(perfetto_trace, expected_perfetto_trace));
+}
+
+TEST(PerfettoAdapter, AdaptsEntryExitTraces) {  // NOLINT
+  constexpr SessionId session_id{1};
+  constexpr ProcessId process_id{2};
+  constexpr ThreadId thread_a_id{10};
+  constexpr ThreadId thread_b_id{11};
+  constexpr FunctionId function_a_id{0};
+  constexpr FunctionId function_b_id{1};
+  constexpr FunctionId function_c{2};
+  const auto thread_a_track_uuid = TrackUuid(process_id, thread_a_id);
+  const auto thread_b_track_uuid = TrackUuid(process_id, thread_b_id);
+
+  const Symbols symbols{};
+
+  const auto trace_files = [&] {
+    std::vector<Event> thread_a_events{
+        {
+            .steady_clock_timestamp = 0,
+            .payload_1 = function_a_id,
+            .type = static_cast<EventType>(Event::Type::kFunctionEntry),
+            .payload_2 = 0,
+        },
+        {
+            .steady_clock_timestamp = 1,
+            .payload_1 = function_b_id,
+            .type = static_cast<EventType>(Event::Type::kFunctionEntry),
+            .payload_2 = 0,
+        },
+        {
+            .steady_clock_timestamp = 2,
+            .payload_1 = function_b_id,
+            .type = static_cast<EventType>(Event::Type::kFunctionExit),
+            .payload_2 = 0,
+        },
+        {
+            .steady_clock_timestamp = 3,
+            .payload_1 = function_a_id,
+            .type = static_cast<EventType>(Event::Type::kFunctionExit),
+            .payload_2 = 0,
+        },
+        {
+            .steady_clock_timestamp = 4,
+            .payload_1 = function_c,
+            .type = static_cast<EventType>(Event::Type::kFunctionEntry),
+            .payload_2 = 0,
+        },
+        {
+            .steady_clock_timestamp = 5,
+            .payload_1 = function_c,
+            .type = static_cast<EventType>(Event::Type::kFunctionExit),
+            .payload_2 = 0,
+        },
+    };
+    std::vector<Event> thread_b_events{
+        {
+            .steady_clock_timestamp = 2,
+            .payload_1 = function_a_id,
+            .type = static_cast<EventType>(Event::Type::kFunctionEntry),
+            .payload_2 = 0,
+        },
+        {
+            .steady_clock_timestamp = 4,
+            .payload_1 = function_a_id,
+            .type = static_cast<EventType>(Event::Type::kFunctionExit),
+            .payload_2 = 0,
+        },
+    };
+    const auto thread_a_event_count = thread_a_events.size();
+    const auto thread_b_event_count = thread_b_events.size();
+    return std::vector<TraceFile>{
+        {
+            .header =
+                {
+                    .magic_number = kMagicNumber,
+                    .endianness = kEndianness,
+                    .compression_strategy = CompressionStrategy::kNone,
+                    .version = kTraceFileVersion,
+                    .session_id = session_id,
+                    .process_id = process_id,
+                    .thread_id = thread_a_id,
+                    .system_clock_timestamp = 7,
+                    .steady_clock_timestamp = 6,
+                    .event_count =
+                        gsl::narrow_cast<EventCount>(thread_a_event_count),
+                    .padding = {},
+                },
+            .events = std::move(thread_a_events),
+        },
+        {
+            .header =
+                {
+                    .magic_number = kMagicNumber,
+                    .endianness = kEndianness,
+                    .compression_strategy = CompressionStrategy::kNone,
+                    .version = kTraceFileVersion,
+                    .session_id = session_id,
+                    .process_id = process_id,
+                    .thread_id = thread_b_id,
+                    .system_clock_timestamp = 9,
+                    .steady_clock_timestamp = 8,
+                    .event_count =
+                        gsl::narrow_cast<EventCount>(thread_b_event_count),
+                    .padding = {},
+                },
+            .events = std::move(thread_b_events),
+        },
+    };
+  }();
+  const auto expected_perfetto_trace = [&] {
+    std::vector packets{
+        [&] {
+          TracePacket packet{};
+          packet.set_trusted_packet_sequence_id(kTrustedPacketSequenceId);
+          packet.set_previous_packet_dropped(true);
+          packet.set_sequence_flags(TracePacket::SEQ_INCREMENTAL_STATE_CLEARED);
+          auto* trace_config = packet.mutable_trace_config();
+          auto* builtin_data_sources =
+              trace_config->mutable_builtin_data_sources();
+          builtin_data_sources->set_primary_trace_clock(
+              BuiltinClock::BUILTIN_CLOCK_REALTIME);
+          packet.mutable_interned_data();
+          return packet;
+        }(),
+        [&] {
+          TracePacket packet{};
+          auto* track_descriptor = packet.mutable_track_descriptor();
+          track_descriptor->set_uuid(TrackUuid(process_id, thread_a_id));
+          auto* thread_descriptor = track_descriptor->mutable_thread();
+          thread_descriptor->set_pid(process_id);
+          thread_descriptor->set_tid(thread_a_id);
+          return packet;
+        }(),
+        [&] {
+          TracePacket packet{};
+          auto* track_descriptor = packet.mutable_track_descriptor();
+          track_descriptor->set_uuid(TrackUuid(process_id, thread_b_id));
+          auto* thread_descriptor = track_descriptor->mutable_thread();
+          thread_descriptor->set_pid(process_id);
+          thread_descriptor->set_tid(thread_b_id);
+          return packet;
+        }(),
+        [&] {
+          ClockSnapshot::Clock steady_clock{};
+          steady_clock.set_clock_id(BuiltinClock::BUILTIN_CLOCK_MONOTONIC);
+          steady_clock.set_timestamp(6);
+          ClockSnapshot::Clock system_clock{};
+          system_clock.set_clock_id(BuiltinClock::BUILTIN_CLOCK_REALTIME);
+          system_clock.set_timestamp(7);
+          TracePacket packet{};
+          packet.set_trusted_packet_sequence_id(kTrustedPacketSequenceId);
+          auto* clock_snapshot = packet.mutable_clock_snapshot();
+          auto* clocks = clock_snapshot->mutable_clocks();
+          clocks->Add(std::move(steady_clock));
+          clocks->Add(std::move(system_clock));
+          clock_snapshot->set_primary_trace_clock(
+              BuiltinClock::BUILTIN_CLOCK_REALTIME);
+          return packet;
+        }(),
+        [&] {
+          TracePacket packet{};
+          packet.set_trusted_packet_sequence_id(kTrustedPacketSequenceId);
+          packet.set_timestamp(0);
+          packet.set_timestamp_clock_id(BuiltinClock::BUILTIN_CLOCK_MONOTONIC);
+          packet.set_sequence_flags(TracePacket::SEQ_NEEDS_INCREMENTAL_STATE);
+          auto& track_event = *packet.mutable_track_event();
+          track_event.set_track_uuid(thread_a_track_uuid);
+          track_event.set_type(TrackEvent::TYPE_SLICE_BEGIN);
+          track_event.set_name_iid(function_a_id);
+          track_event.set_source_location_iid(function_a_id);
+          return packet;
+        }(),
+        [&] {
+          TracePacket packet{};
+          packet.set_trusted_packet_sequence_id(kTrustedPacketSequenceId);
+          packet.set_timestamp(1);
+          packet.set_timestamp_clock_id(BuiltinClock::BUILTIN_CLOCK_MONOTONIC);
+          packet.set_sequence_flags(TracePacket::SEQ_NEEDS_INCREMENTAL_STATE);
+          auto& track_event = *packet.mutable_track_event();
+          track_event.set_track_uuid(thread_a_track_uuid);
+          track_event.set_type(TrackEvent::TYPE_SLICE_BEGIN);
+          track_event.set_name_iid(function_b_id);
+          track_event.set_source_location_iid(function_b_id);
+          return packet;
+        }(),
+        [&] {
+          TracePacket packet{};
+          packet.set_trusted_packet_sequence_id(kTrustedPacketSequenceId);
+          packet.set_timestamp(2);
+          packet.set_timestamp_clock_id(BuiltinClock::BUILTIN_CLOCK_MONOTONIC);
+          packet.set_sequence_flags(TracePacket::SEQ_NEEDS_INCREMENTAL_STATE);
+          auto& track_event = *packet.mutable_track_event();
+          track_event.set_track_uuid(thread_a_track_uuid);
+          track_event.set_type(TrackEvent::TYPE_SLICE_END);
+          return packet;
+        }(),
+        [&] {
+          TracePacket packet{};
+          packet.set_trusted_packet_sequence_id(kTrustedPacketSequenceId);
+          packet.set_timestamp(3);
+          packet.set_timestamp_clock_id(BuiltinClock::BUILTIN_CLOCK_MONOTONIC);
+          packet.set_sequence_flags(TracePacket::SEQ_NEEDS_INCREMENTAL_STATE);
+          auto& track_event = *packet.mutable_track_event();
+          track_event.set_track_uuid(thread_a_track_uuid);
+          track_event.set_type(TrackEvent::TYPE_SLICE_END);
+          return packet;
+        }(),
+        [&] {
+          TracePacket packet{};
+          packet.set_trusted_packet_sequence_id(kTrustedPacketSequenceId);
+          packet.set_timestamp(4);
+          packet.set_timestamp_clock_id(BuiltinClock::BUILTIN_CLOCK_MONOTONIC);
+          packet.set_sequence_flags(TracePacket::SEQ_NEEDS_INCREMENTAL_STATE);
+          auto& track_event = *packet.mutable_track_event();
+          track_event.set_track_uuid(thread_a_track_uuid);
+          track_event.set_type(TrackEvent::TYPE_SLICE_BEGIN);
+          track_event.set_name_iid(function_c);
+          track_event.set_source_location_iid(function_c);
+          return packet;
+        }(),
+        [&] {
+          TracePacket packet{};
+          packet.set_trusted_packet_sequence_id(kTrustedPacketSequenceId);
+          packet.set_timestamp(5);
+          packet.set_timestamp_clock_id(BuiltinClock::BUILTIN_CLOCK_MONOTONIC);
+          packet.set_sequence_flags(TracePacket::SEQ_NEEDS_INCREMENTAL_STATE);
+          auto& track_event = *packet.mutable_track_event();
+          track_event.set_track_uuid(thread_a_track_uuid);
+          track_event.set_type(TrackEvent::TYPE_SLICE_END);
+          return packet;
+        }(),
+        [&] {
+          ClockSnapshot::Clock steady_clock{};
+          steady_clock.set_clock_id(BuiltinClock::BUILTIN_CLOCK_MONOTONIC);
+          steady_clock.set_timestamp(8);
+          ClockSnapshot::Clock system_clock{};
+          system_clock.set_clock_id(BuiltinClock::BUILTIN_CLOCK_REALTIME);
+          system_clock.set_timestamp(9);
+          TracePacket packet{};
+          packet.set_trusted_packet_sequence_id(kTrustedPacketSequenceId);
+          auto* clock_snapshot = packet.mutable_clock_snapshot();
+          auto* clocks = clock_snapshot->mutable_clocks();
+          clocks->Add(std::move(steady_clock));
+          clocks->Add(std::move(system_clock));
+          clock_snapshot->set_primary_trace_clock(
+              BuiltinClock::BUILTIN_CLOCK_REALTIME);
+          return packet;
+        }(),
+        [&] {
+          TracePacket packet{};
+          packet.set_trusted_packet_sequence_id(kTrustedPacketSequenceId);
+          packet.set_timestamp(2);
+          packet.set_timestamp_clock_id(BuiltinClock::BUILTIN_CLOCK_MONOTONIC);
+          packet.set_sequence_flags(TracePacket::SEQ_NEEDS_INCREMENTAL_STATE);
+          auto& track_event = *packet.mutable_track_event();
+          track_event.set_track_uuid(thread_b_track_uuid);
+          track_event.set_type(TrackEvent::TYPE_SLICE_BEGIN);
+          track_event.set_name_iid(function_a_id);
+          track_event.set_source_location_iid(function_a_id);
+          return packet;
+        }(),
+        [&] {
+          TracePacket packet{};
+          packet.set_trusted_packet_sequence_id(kTrustedPacketSequenceId);
+          packet.set_timestamp(4);
+          packet.set_timestamp_clock_id(BuiltinClock::BUILTIN_CLOCK_MONOTONIC);
+          packet.set_sequence_flags(TracePacket::SEQ_NEEDS_INCREMENTAL_STATE);
+          auto& track_event = *packet.mutable_track_event();
+          track_event.set_track_uuid(thread_b_track_uuid);
+          track_event.set_type(TrackEvent::TYPE_SLICE_END);
+          return packet;
+        }(),
+    };
+
+    PerfettoTrace trace{};
+    auto* repeated_packets = trace.mutable_packet();
+    std::move(std::begin(packets), std::end(packets),
+              RepeatedFieldBackInserter(repeated_packets));
+    return trace;
+  }();
+  const auto perfetto_trace = SpoorTraceToPerfettoTrace(trace_files, symbols);
+  ASSERT_TRUE(
+      MessageDifferencer::Equals(perfetto_trace, expected_perfetto_trace));
+}
+
+TEST(PerfettoAdapter, AdaptsSymbolsToInternedData) {  // NOLINT
+  const std::string module_id{"module_id"};
+  constexpr SessionId session_id{1};
+  constexpr ProcessId process_id{2};
+  constexpr ThreadId thread_id{10};
+  constexpr FunctionId function_a_id{0};
+  constexpr FunctionId function_b_id{1};
+  const std::string function_a_linkage_name{"function_a"};
+  const std::string function_b_linkage_name{"function_b"};
+  const std::string function_a_demangled_name{"FuctionA()"};
+  const std::string function_b_demangled_name{"FunctionB()"};
+  const std::string function_a_file_name{"file_a.source"};
+  const std::string function_b_file_name{"file_b.source"};
+  const std::string function_a_directory{"/path/to/a/"};
+  const std::string function_b_directory{"/path/to/b/"};
+  constexpr int32 function_a_line_number{1};
+  constexpr int32 function_b_line_number{2};
+
+  const auto symbols = [&] {
+    std::vector<std::pair<FunctionId, FunctionInfo>> function_infos{
+        {
+            function_a_id,
+            [&] {
+              FunctionInfo function_info{};
+              function_info.set_module_id(module_id);
+              function_info.set_linkage_name(function_a_linkage_name);
+              function_info.set_demangled_name(function_a_demangled_name);
+              function_info.set_file_name(function_a_file_name);
+              function_info.set_directory(function_a_directory);
+              function_info.set_line(function_a_line_number);
+              function_info.set_instrumented(true);
+              *function_info.mutable_created_at() =
+                  TimeUtil::NanosecondsToTimestamp(1);
+              return function_info;
+            }(),
+        },
+        {
+            function_b_id,
+            [&] {
+              FunctionInfo function_info{};
+              function_info.set_module_id(module_id);
+              function_info.set_linkage_name(function_b_linkage_name);
+              function_info.set_demangled_name(function_b_demangled_name);
+              function_info.set_file_name(function_b_file_name);
+              function_info.set_directory(function_b_directory);
+              function_info.set_line(function_b_line_number);
+              function_info.set_instrumented(true);
+              *function_info.mutable_created_at() =
+                  TimeUtil::NanosecondsToTimestamp(2);
+              return function_info;
+            }(),
+        },
+    };
+
+    Symbols symbols{};
+    auto& function_symbols_table = *symbols.mutable_function_symbols_table();
+    for (auto& [function_id, function_info] : function_infos) {
+      auto& repeated_function_infos = function_symbols_table[function_id];
+      *repeated_function_infos.add_function_infos() = std::move(function_info);
+    }
+    return symbols;
+  }();
+
+  const auto trace_files = [&] {
+    std::vector<Event> events{
+        {
+            .steady_clock_timestamp = 0,
+            .payload_1 = function_a_id,
+            .type = static_cast<EventType>(Event::Type::kFunctionEntry),
+            .payload_2 = 0,
+        },
+        {
+            .steady_clock_timestamp = 1,
+            .payload_1 = function_b_id,
+            .type = static_cast<EventType>(Event::Type::kFunctionEntry),
+            .payload_2 = 0,
+        },
+    };
+    const auto event_count = events.size();
+    return std::vector<TraceFile>{{
+        .header =
+            {
+                .magic_number = kMagicNumber,
+                .endianness = kEndianness,
+                .compression_strategy = CompressionStrategy::kNone,
+                .version = kTraceFileVersion,
+                .session_id = session_id,
+                .process_id = process_id,
+                .thread_id = thread_id,
+                .system_clock_timestamp = 0,
+                .steady_clock_timestamp = 0,
+                .event_count = gsl::narrow_cast<EventCount>(event_count),
+                .padding = {},
+            },
+        .events = std::move(events),
+    }};
+  }();
+
+  const auto expected_head_packet = [&] {
+    std::vector<EventName> event_names{
+        [&] {
+          EventName event_name{};
+          event_name.set_iid(function_a_id);
+          event_name.set_name(function_a_demangled_name);
+          return event_name;
+        }(),
+        [&] {
+          EventName event_name{};
+          event_name.set_iid(function_b_id);
+          event_name.set_name(function_b_demangled_name);
+          return event_name;
+        }(),
+    };
+    std::vector<SourceLocation> source_locations{
+        [&] {
+          SourceLocation source_location{};
+          source_location.set_iid(function_a_id);
+          source_location.set_file_name(
+              absl::StrCat(function_a_directory, function_a_file_name));
+          source_location.set_function_name(function_a_demangled_name);
+          source_location.set_line_number(function_a_line_number);
+          return source_location;
+        }(),
+        [&] {
+          SourceLocation source_location{};
+          source_location.set_iid(function_b_id);
+          source_location.set_file_name(
+              absl::StrCat(function_b_directory, function_b_file_name));
+          source_location.set_function_name(function_b_demangled_name);
+          source_location.set_line_number(function_b_line_number);
+          return source_location;
+        }(),
+    };
+    TracePacket packet{};
+    packet.set_trusted_packet_sequence_id(kTrustedPacketSequenceId);
+    packet.set_previous_packet_dropped(true);
+    packet.set_sequence_flags(TracePacket::SEQ_INCREMENTAL_STATE_CLEARED);
+    auto* trace_config = packet.mutable_trace_config();
+    auto* builtin_data_sources = trace_config->mutable_builtin_data_sources();
+    builtin_data_sources->set_primary_trace_clock(
+        BuiltinClock::BUILTIN_CLOCK_REALTIME);
+    auto* interned_data = packet.mutable_interned_data();
+    std::move(std::begin(event_names), std::end(event_names),
+              RepeatedFieldBackInserter(interned_data->mutable_event_names()));
+    std::move(
+        std::begin(source_locations), std::end(source_locations),
+        RepeatedFieldBackInserter(interned_data->mutable_source_locations()));
+    return packet;
+  }();
+
+  const auto head_packet = [&] {
+    auto perfetto_trace = SpoorTraceToPerfettoTrace(trace_files, symbols);
+    auto head_packet = perfetto_trace.mutable_packet()->begin();
+    auto* interned_data = head_packet->mutable_interned_data();
+    auto& event_names = *interned_data->mutable_event_names();
+    auto& source_locations = *interned_data->mutable_source_locations();
+    // Iteration order through over a Protocol Buffer map is not defined.
+    std::sort(
+        std::begin(event_names), std::end(event_names),
+        [](const auto& lhs, const auto& rhs) { return lhs.iid() < rhs.iid(); });
+    std::sort(
+        std::begin(source_locations), std::end(source_locations),
+        [](const auto& lhs, const auto& rhs) { return lhs.iid() < rhs.iid(); });
+    return *head_packet;
+  }();
+  ASSERT_TRUE(MessageDifferencer::Equals(head_packet, expected_head_packet));
+}
+
+TEST(PerfettoAdapter, DoesNotAddUnusedFunctionsToInternedData) {  // NOLINT
+  const std::string module_id{"module_id"};
+  constexpr SessionId session_id{1};
+  constexpr ProcessId process_id{2};
+  constexpr ThreadId thread_id{10};
+  constexpr FunctionId function_a_id{0};
+  constexpr FunctionId function_b_id{1};
+  const std::string function_a_linkage_name{"function_a"};
+  const std::string function_b_linkage_name{"function_b"};
+  const std::string function_a_demangled_name{"FuctionA()"};
+  const std::string function_b_demangled_name{"FunctionB()"};
+  const std::string function_a_file_name{"file_a.source"};
+  const std::string function_b_file_name{"file_b.source"};
+  const std::string function_a_directory{"/path/to/a/"};
+  const std::string function_b_directory{"/path/to/b/"};
+  constexpr int32 function_a_line_number{1};
+  constexpr int32 function_b_line_number{2};
+
+  const auto symbols = [&] {
+    std::vector<std::pair<FunctionId, FunctionInfo>> function_infos{
+        {
+            function_a_id,
+            [&] {
+              FunctionInfo function_info{};
+              function_info.set_module_id(module_id);
+              function_info.set_linkage_name(function_a_linkage_name);
+              function_info.set_demangled_name(function_a_demangled_name);
+              function_info.set_file_name(function_a_file_name);
+              function_info.set_directory(function_a_directory);
+              function_info.set_line(function_a_line_number);
+              function_info.set_instrumented(true);
+              *function_info.mutable_created_at() =
+                  TimeUtil::NanosecondsToTimestamp(1);
+              return function_info;
+            }(),
+        },
+        {
+            function_b_id,
+            [&] {
+              FunctionInfo function_info{};
+              function_info.set_module_id(module_id);
+              function_info.set_linkage_name(function_b_linkage_name);
+              function_info.set_demangled_name(function_b_demangled_name);
+              function_info.set_file_name(function_b_file_name);
+              function_info.set_directory(function_b_directory);
+              function_info.set_line(function_b_line_number);
+              function_info.set_instrumented(true);
+              *function_info.mutable_created_at() =
+                  TimeUtil::NanosecondsToTimestamp(2);
+              return function_info;
+            }(),
+        },
+    };
+
+    Symbols symbols{};
+    auto& function_symbols_table = *symbols.mutable_function_symbols_table();
+    for (auto& [function_id, function_info] : function_infos) {
+      auto& repeated_function_infos = function_symbols_table[function_id];
+      *repeated_function_infos.add_function_infos() = std::move(function_info);
+    }
+    return symbols;
+  }();
+
+  const auto trace_files = [&] {
+    std::vector<Event> events{
+        {
+            .steady_clock_timestamp = 0,
+            .payload_1 = function_a_id,
+            .type = static_cast<EventType>(Event::Type::kFunctionEntry),
+            .payload_2 = 0,
+        },
+    };
+    const auto event_count = events.size();
+    return std::vector<TraceFile>{{
+        .header =
+            {
+                .magic_number = kMagicNumber,
+                .endianness = kEndianness,
+                .compression_strategy = CompressionStrategy::kNone,
+                .version = kTraceFileVersion,
+                .session_id = session_id,
+                .process_id = process_id,
+                .thread_id = thread_id,
+                .system_clock_timestamp = 0,
+                .steady_clock_timestamp = 0,
+                .event_count = gsl::narrow_cast<EventCount>(event_count),
+                .padding = {},
+            },
+        .events = std::move(events),
+    }};
+  }();
+
+  const auto expected_head_packet = [&] {
+    TracePacket packet{};
+    packet.set_trusted_packet_sequence_id(kTrustedPacketSequenceId);
+    packet.set_previous_packet_dropped(true);
+    packet.set_sequence_flags(TracePacket::SEQ_INCREMENTAL_STATE_CLEARED);
+
+    auto* trace_config = packet.mutable_trace_config();
+    auto* builtin_data_sources = trace_config->mutable_builtin_data_sources();
+    builtin_data_sources->set_primary_trace_clock(
+        BuiltinClock::BUILTIN_CLOCK_REALTIME);
+
+    auto* interned_data = packet.mutable_interned_data();
+
+    auto* event_names = interned_data->mutable_event_names();
+    auto* event_name = event_names->Add();
+    event_name->set_iid(function_a_id);
+    event_name->set_name(function_a_demangled_name);
+
+    auto* source_locations = interned_data->mutable_source_locations();
+    auto* source_location = source_locations->Add();
+    source_location->set_iid(function_a_id);
+    source_location->set_file_name(
+        absl::StrCat(function_a_directory, function_a_file_name));
+    source_location->set_function_name(function_a_demangled_name);
+    source_location->set_line_number(function_a_line_number);
+
+    return packet;
+  }();
+
+  auto perfetto_trace = SpoorTraceToPerfettoTrace(trace_files, symbols);
+  auto* packets = perfetto_trace.mutable_packet();
+  ASSERT_GE(packets->size(), 1);
+  const auto head_packet = *packets->begin();
+  ASSERT_TRUE(MessageDifferencer::Equals(head_packet, expected_head_packet));
+}
+
+// NOLINTNEXTLINE
+TEST(PerfettoAdapter, HandlesMultipleFunctionInfosForSingleFunctionId) {
+  const std::string module_id{"module_id"};
+  constexpr SessionId session_id{1};
+  constexpr ProcessId process_id{2};
+  constexpr ThreadId thread_id{10};
+  constexpr FunctionId function_a_id{0};
+  constexpr FunctionId function_b_id{0};
+  ASSERT_EQ(function_a_id, function_b_id);
+  const std::string function_a_linkage_name{"function_a"};
+  const std::string function_b_linkage_name{"function_b"};
+  const std::string function_a_demangled_name{"FuctionA()"};
+  const std::string function_b_demangled_name{"FunctionB()"};
+  const std::string function_a_file_name{"file_a.source"};
+  const std::string function_b_file_name{"file_b.source"};
+  const std::string function_a_directory{"/path/to/a/"};
+  const std::string function_b_directory{"/path/to/b/"};
+  constexpr int32 function_a_line_number{1};
+  constexpr int32 function_b_line_number{2};
+
+  const auto symbols = [&] {
+    std::vector<std::pair<FunctionId, FunctionInfo>> function_infos{
+        {
+            function_a_id,
+            [&] {
+              FunctionInfo function_info{};
+              function_info.set_module_id(module_id);
+              function_info.set_linkage_name(function_a_linkage_name);
+              function_info.set_demangled_name(function_a_demangled_name);
+              function_info.set_file_name(function_a_file_name);
+              function_info.set_directory(function_a_directory);
+              function_info.set_line(function_a_line_number);
+              function_info.set_instrumented(true);
+              *function_info.mutable_created_at() =
+                  TimeUtil::NanosecondsToTimestamp(1);
+              return function_info;
+            }(),
+        },
+        {
+            function_b_id,
+            [&] {
+              FunctionInfo function_info{};
+              function_info.set_module_id(module_id);
+              function_info.set_linkage_name(function_b_linkage_name);
+              function_info.set_demangled_name(function_b_demangled_name);
+              function_info.set_file_name(function_b_file_name);
+              function_info.set_directory(function_b_directory);
+              function_info.set_line(function_b_line_number);
+              function_info.set_instrumented(true);
+              *function_info.mutable_created_at() =
+                  TimeUtil::NanosecondsToTimestamp(2);
+              return function_info;
+            }(),
+        },
+    };
+
+    Symbols symbols{};
+    auto& function_symbols_table = *symbols.mutable_function_symbols_table();
+    for (auto& [function_id, function_info] : function_infos) {
+      auto& repeated_function_infos = function_symbols_table[function_id];
+      *repeated_function_infos.add_function_infos() = std::move(function_info);
+    }
+    return symbols;
+  }();
+
+  const auto trace_files = [&] {
+    std::vector<Event> events{
+        {
+            .steady_clock_timestamp = 0,
+            .payload_1 = function_a_id,
+            .type = static_cast<EventType>(Event::Type::kFunctionEntry),
+            .payload_2 = 0,
+        },
+    };
+    const auto event_count = events.size();
+    return std::vector<TraceFile>{{
+        .header =
+            {
+                .magic_number = kMagicNumber,
+                .endianness = kEndianness,
+                .compression_strategy = CompressionStrategy::kNone,
+                .version = kTraceFileVersion,
+                .session_id = session_id,
+                .process_id = process_id,
+                .thread_id = thread_id,
+                .system_clock_timestamp = 0,
+                .steady_clock_timestamp = 0,
+                .event_count = gsl::narrow_cast<EventCount>(event_count),
+                .padding = {},
+            },
+        .events = std::move(events),
+    }};
+  }();
+
+  const auto expected_head_packet = [&] {
+    TracePacket packet{};
+    packet.set_trusted_packet_sequence_id(kTrustedPacketSequenceId);
+    packet.set_previous_packet_dropped(true);
+    packet.set_sequence_flags(TracePacket::SEQ_INCREMENTAL_STATE_CLEARED);
+
+    auto* trace_config = packet.mutable_trace_config();
+    auto* builtin_data_sources = trace_config->mutable_builtin_data_sources();
+    builtin_data_sources->set_primary_trace_clock(
+        BuiltinClock::BUILTIN_CLOCK_REALTIME);
+
+    auto* interned_data = packet.mutable_interned_data();
+
+    const auto conflict = absl::StrFormat(
+        "2-way conflict for function ID %#016x: ", function_a_id);
+
+    auto* event_names = interned_data->mutable_event_names();
+    auto* event_name = event_names->Add();
+    event_name->set_iid(function_a_id);
+    event_name->set_name(absl::StrCat(conflict, function_a_demangled_name, "; ",
+                                      function_b_demangled_name));
+
+    auto* source_locations = interned_data->mutable_source_locations();
+    auto* source_location = source_locations->Add();
+    source_location->set_iid(function_a_id);
+    source_location->set_file_name(
+        absl::StrCat(conflict, function_a_directory, function_a_file_name, ":",
+                     function_a_line_number, "; ", function_b_directory,
+                     function_b_file_name, ":", function_b_line_number));
+    source_location->set_function_name(absl::StrCat(
+        conflict, function_a_demangled_name, "; ", function_b_demangled_name));
+
+    return packet;
+  }();
+
+  auto perfetto_trace = SpoorTraceToPerfettoTrace(trace_files, symbols);
+  auto* packets = perfetto_trace.mutable_packet();
+  ASSERT_GE(packets->size(), 1);
+  const auto head_packet = *packets->begin();
+  ASSERT_TRUE(MessageDifferencer::Equals(head_packet, expected_head_packet));
+}
+
+TEST(PerfettoAdapter, HandlesFunctionNameFallback) {  // NOLINT
+  const std::string module_id{"module_id"};
+  constexpr SessionId session_id{1};
+  constexpr ProcessId process_id{2};
+  constexpr ThreadId thread_id{10};
+  constexpr FunctionId function_a_id{0};
+  constexpr FunctionId function_b_id{1};
+  const std::string function_a_linkage_name{"function_a"};
+  const std::string function_a_expected_function_name{function_a_linkage_name};
+  const auto function_b_expected_function_name =
+      absl::StrFormat("%#016x", function_b_id);
+  const std::string function_a_file_name{"file_a.source"};
+  const std::string function_b_file_name{"file_b.source"};
+  const std::string function_a_directory{"/path/to/a/"};
+  const std::string function_b_directory{"/path/to/b/"};
+  constexpr int32 function_a_line_number{1};
+  constexpr int32 function_b_line_number{2};
+
+  const auto symbols = [&] {
+    std::vector<std::pair<FunctionId, FunctionInfo>> function_infos{
+        {
+            function_a_id,
+            [&] {
+              FunctionInfo function_info{};
+              function_info.set_module_id(module_id);
+              function_info.set_linkage_name(function_a_linkage_name);
+              function_info.set_file_name(function_a_file_name);
+              function_info.set_directory(function_a_directory);
+              function_info.set_line(function_a_line_number);
+              function_info.set_instrumented(true);
+              *function_info.mutable_created_at() =
+                  TimeUtil::NanosecondsToTimestamp(1);
+              return function_info;
+            }(),
+        },
+        {
+            function_b_id,
+            [&] {
+              FunctionInfo function_info{};
+              function_info.set_module_id(module_id);
+              function_info.set_file_name(function_b_file_name);
+              function_info.set_directory(function_b_directory);
+              function_info.set_line(function_b_line_number);
+              function_info.set_instrumented(true);
+              *function_info.mutable_created_at() =
+                  TimeUtil::NanosecondsToTimestamp(2);
+              return function_info;
+            }(),
+        },
+    };
+
+    Symbols symbols{};
+    auto& function_symbols_table = *symbols.mutable_function_symbols_table();
+    for (auto& [function_id, function_info] : function_infos) {
+      auto& repeated_function_infos = function_symbols_table[function_id];
+      *repeated_function_infos.add_function_infos() = std::move(function_info);
+    }
+    return symbols;
+  }();
+
+  const auto trace_files = [&] {
+    std::vector<Event> events{
+        {
+            .steady_clock_timestamp = 0,
+            .payload_1 = function_a_id,
+            .type = static_cast<EventType>(Event::Type::kFunctionEntry),
+            .payload_2 = 0,
+        },
+        {
+            .steady_clock_timestamp = 0,
+            .payload_1 = function_b_id,
+            .type = static_cast<EventType>(Event::Type::kFunctionEntry),
+            .payload_2 = 0,
+        },
+    };
+    const auto event_count = events.size();
+    return std::vector<TraceFile>{{
+        .header =
+            {
+                .magic_number = kMagicNumber,
+                .endianness = kEndianness,
+                .compression_strategy = CompressionStrategy::kNone,
+                .version = kTraceFileVersion,
+                .session_id = session_id,
+                .process_id = process_id,
+                .thread_id = thread_id,
+                .system_clock_timestamp = 0,
+                .steady_clock_timestamp = 0,
+                .event_count = gsl::narrow_cast<EventCount>(event_count),
+                .padding = {},
+            },
+        .events = std::move(events),
+    }};
+  }();
+
+  const auto expected_head_packet = [&] {
+    std::vector<EventName> event_names{
+        [&] {
+          EventName event_name{};
+          event_name.set_iid(function_a_id);
+          event_name.set_name(function_a_expected_function_name);
+          return event_name;
+        }(),
+        [&] {
+          EventName event_name{};
+          event_name.set_iid(function_b_id);
+          event_name.set_name(function_b_expected_function_name);
+          return event_name;
+        }(),
+    };
+    std::vector<SourceLocation> source_locations{
+        [&] {
+          SourceLocation source_location{};
+          source_location.set_iid(function_a_id);
+          source_location.set_file_name(
+              absl::StrCat(function_a_directory, function_a_file_name));
+          source_location.set_function_name(function_a_expected_function_name);
+          source_location.set_line_number(function_a_line_number);
+          return source_location;
+        }(),
+        [&] {
+          SourceLocation source_location{};
+          source_location.set_iid(function_b_id);
+          source_location.set_file_name(
+              absl::StrCat(function_b_directory, function_b_file_name));
+          source_location.set_function_name(function_b_expected_function_name);
+          source_location.set_line_number(function_b_line_number);
+          return source_location;
+        }(),
+    };
+    TracePacket packet{};
+    packet.set_trusted_packet_sequence_id(kTrustedPacketSequenceId);
+    packet.set_previous_packet_dropped(true);
+    packet.set_sequence_flags(TracePacket::SEQ_INCREMENTAL_STATE_CLEARED);
+    auto* trace_config = packet.mutable_trace_config();
+    auto* builtin_data_sources = trace_config->mutable_builtin_data_sources();
+    builtin_data_sources->set_primary_trace_clock(
+        BuiltinClock::BUILTIN_CLOCK_REALTIME);
+    auto* interned_data = packet.mutable_interned_data();
+    std::move(std::begin(event_names), std::end(event_names),
+              RepeatedFieldBackInserter(interned_data->mutable_event_names()));
+    std::move(
+        std::begin(source_locations), std::end(source_locations),
+        RepeatedFieldBackInserter(interned_data->mutable_source_locations()));
+    return packet;
+  }();
+
+  const auto head_packet = [&] {
+    auto perfetto_trace = SpoorTraceToPerfettoTrace(trace_files, symbols);
+    auto head_packet = perfetto_trace.mutable_packet()->begin();
+    auto* interned_data = head_packet->mutable_interned_data();
+    auto& event_names = *interned_data->mutable_event_names();
+    auto& source_locations = *interned_data->mutable_source_locations();
+    // Iteration order through over a Protocol Buffer map is not defined.
+    std::sort(
+        std::begin(event_names), std::end(event_names),
+        [](const auto& lhs, const auto& rhs) { return lhs.iid() < rhs.iid(); });
+    std::sort(
+        std::begin(source_locations), std::end(source_locations),
+        [](const auto& lhs, const auto& rhs) { return lhs.iid() < rhs.iid(); });
+    return *head_packet;
+  }();
+
+  ASSERT_TRUE(MessageDifferencer::Equals(head_packet, expected_head_packet));
+}
+
+TEST(PerfettoAdapter, TruncatesLongNames) {  // NOLINT
+  const std::string module_id{"module_id"};
+  constexpr SessionId session_id{1};
+  constexpr ProcessId process_id{2};
+  constexpr ThreadId thread_id{10};
+  constexpr FunctionId function_id{0};
+  const std::string linkage_name{"function_a"};
+  const std::string demangled_name(1'024 + 1, 'x');
+  const auto expected_demangled_name =
+      absl::StrCat(std::string(1'024 - 3, 'x'), "...");
+  const std::string file_name(1'024 + 1, 'x');
+  const std::string directory{"/path/to/a/"};
+  const auto expected_file_name = absl::StrCat(
+      directory, std::string(1'024 - directory.size() - 3, 'x'), "...");
+  constexpr int32 line_number{1};
+
+  const auto symbols = [&] {
+    std::vector<std::pair<FunctionId, FunctionInfo>> function_infos{{
+        function_id,
+        [&] {
+          FunctionInfo function_info{};
+          function_info.set_module_id(module_id);
+          function_info.set_linkage_name(linkage_name);
+          function_info.set_demangled_name(demangled_name);
+          function_info.set_file_name(file_name);
+          function_info.set_directory(directory);
+          function_info.set_line(line_number);
+          function_info.set_instrumented(true);
+          *function_info.mutable_created_at() =
+              TimeUtil::NanosecondsToTimestamp(1);
+          return function_info;
+        }(),
+    }};
+
+    Symbols symbols{};
+    auto& function_symbols_table = *symbols.mutable_function_symbols_table();
+    for (auto& [function_id, function_info] : function_infos) {
+      auto& repeated_function_infos = function_symbols_table[function_id];
+      *repeated_function_infos.add_function_infos() = std::move(function_info);
+    }
+    return symbols;
+  }();
+
+  const auto trace_files = [&] {
+    std::vector<Event> events{{
+        .steady_clock_timestamp = 0,
+        .payload_1 = function_id,
+        .type = static_cast<EventType>(Event::Type::kFunctionEntry),
+        .payload_2 = 0,
+    }};
+    const auto event_count = events.size();
+    return std::vector<TraceFile>{{
+        .header =
+            {
+                .magic_number = kMagicNumber,
+                .endianness = kEndianness,
+                .compression_strategy = CompressionStrategy::kNone,
+                .version = kTraceFileVersion,
+                .session_id = session_id,
+                .process_id = process_id,
+                .thread_id = thread_id,
+                .system_clock_timestamp = 0,
+                .steady_clock_timestamp = 0,
+                .event_count = gsl::narrow_cast<EventCount>(event_count),
+                .padding = {},
+            },
+        .events = std::move(events),
+    }};
+  }();
+
+  const auto expected_head_packet = [&] {
+    std::vector<EventName> event_names{[&] {
+      EventName event_name{};
+      event_name.set_iid(function_id);
+      event_name.set_name(expected_demangled_name);
+      return event_name;
+    }()};
+    std::vector<SourceLocation> source_locations{[&] {
+      SourceLocation source_location{};
+      source_location.set_iid(function_id);
+      source_location.set_file_name(expected_file_name);
+      source_location.set_function_name(expected_demangled_name);
+      source_location.set_line_number(line_number);
+      return source_location;
+    }()};
+    TracePacket packet{};
+    packet.set_trusted_packet_sequence_id(kTrustedPacketSequenceId);
+    packet.set_previous_packet_dropped(true);
+    packet.set_sequence_flags(TracePacket::SEQ_INCREMENTAL_STATE_CLEARED);
+    auto* trace_config = packet.mutable_trace_config();
+    auto* builtin_data_sources = trace_config->mutable_builtin_data_sources();
+    builtin_data_sources->set_primary_trace_clock(
+        BuiltinClock::BUILTIN_CLOCK_REALTIME);
+    auto* interned_data = packet.mutable_interned_data();
+    std::move(std::begin(event_names), std::end(event_names),
+              RepeatedFieldBackInserter(interned_data->mutable_event_names()));
+    std::move(
+        std::begin(source_locations), std::end(source_locations),
+        RepeatedFieldBackInserter(interned_data->mutable_source_locations()));
+    return packet;
+  }();
+
+  auto perfetto_trace = SpoorTraceToPerfettoTrace(trace_files, symbols);
+  auto* packets = perfetto_trace.mutable_packet();
+  ASSERT_GE(packets->size(), 1);
+  const auto head_packet = *packets->begin();
+  ASSERT_TRUE(MessageDifferencer::Equals(head_packet, expected_head_packet));
+}
+
+}  // namespace

--- a/spoor/tools/config/BUILD
+++ b/spoor/tools/config/BUILD
@@ -1,0 +1,65 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+load(
+    "//toolchain:config.bzl",
+    "SPOOR_DEFAULT_COPTS",
+    "SPOOR_DEFAULT_LINKOPTS",
+    "SPOOR_DEFAULT_TEST_COPTS",
+    "SPOOR_DEFAULT_TEST_LINKOPTS",
+)
+
+cc_library(
+    name = "config",
+    srcs = ["config.cc"],
+    hdrs = ["config.h"],
+    copts = SPOOR_DEFAULT_COPTS,
+    linkopts = SPOOR_DEFAULT_LINKOPTS,
+    visibility = ["//spoor/tools:__subpackages__"],
+    deps = [
+        "//util/flat_map",
+    ],
+)
+
+cc_test(
+    name = "config_test",
+    size = "small",
+    srcs = ["config_test.cc"],
+    copts = SPOOR_DEFAULT_TEST_COPTS,
+    linkopts = SPOOR_DEFAULT_TEST_LINKOPTS,
+    visibility = ["//visibility:private"],
+    deps = [
+        ":config",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "command_line_config",
+    srcs = ["command_line_config.cc"],
+    hdrs = ["command_line_config.h"],
+    copts = SPOOR_DEFAULT_COPTS,
+    linkopts = SPOOR_DEFAULT_LINKOPTS,
+    visibility = ["//spoor/tools:__pkg__"],
+    deps = [
+        ":config",
+        "@com_google_absl//absl/flags:flag",
+        "@com_google_absl//absl/flags:parse",
+        "@com_google_absl//absl/strings",
+    ],
+)
+
+cc_test(
+    name = "command_line_config_test",
+    size = "small",
+    srcs = ["command_line_config_test.cc"],
+    copts = SPOOR_DEFAULT_TEST_COPTS,
+    linkopts = SPOOR_DEFAULT_TEST_LINKOPTS,
+    visibility = ["//visibility:private"],
+    deps = [
+        ":command_line_config",
+        "@com_google_googletest//:gtest_main",
+        "@com_microsoft_gsl//:gsl",
+    ],
+)

--- a/spoor/tools/config/command_line_config.cc
+++ b/spoor/tools/config/command_line_config.cc
@@ -1,0 +1,65 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "spoor/tools/config/command_line_config.h"
+
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "absl/flags/flag.h"
+#include "absl/flags/parse.h"
+#include "absl/strings/ascii.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_format.h"
+#include "absl/strings/str_join.h"
+#include "absl/strings/string_view.h"
+#include "spoor/tools/config/config.h"
+
+ABSL_FLAG(  // NOLINT
+    std::string, output_file,
+    std::string{spoor::tools::config::kOutputFileDefaultValue},
+    spoor::tools::config::kOutputFileDoc);
+ABSL_FLAG(  // NOLINT
+    spoor::tools::config::OutputFormat, output_format,
+    spoor::tools::config::kOutputFormatDefaultValue,
+    absl::StrFormat(spoor::tools::config::kOutputFormatDoc,
+                    absl::StrJoin(spoor::tools::config::kOutputFormats.Keys(),
+                                  ", ")));
+
+namespace spoor::tools::config {
+
+auto AbslParseFlag(absl::string_view user_key, OutputFormat* output_format,
+                   std::string* error) -> bool {
+  std::string key{user_key};
+  absl::AsciiStrToLower(&key);
+  const auto option = kOutputFormats.FirstValueForKey(key);
+  if (option.has_value()) {
+    *output_format = option.value();
+    return true;
+  }
+  *error = absl::StrFormat("Unknown output format '%s'. Options: %s.", user_key,
+                           absl::StrJoin(kOutputFormats.Keys(), ", "));
+  return false;
+}
+
+auto AbslUnparseFlag(const OutputFormat output_format) -> std::string {
+  const auto fallback = absl::StrCat(output_format);
+  const auto value =
+      kOutputFormats.FirstKeyForValue(output_format).value_or(fallback);
+  return std::string{value};
+}
+
+auto ConfigFromCommandLine(int argc, char** argv)
+    -> std::pair<Config, std::vector<char*>> {
+  absl::SetFlag(&FLAGS_output_file, kOutputFileDefaultValue);
+  absl::SetFlag(&FLAGS_output_format, kOutputFormatDefaultValue);
+  auto positional_args = absl::ParseCommandLine(argc, argv);
+  Config config{
+      .output_file = absl::GetFlag(FLAGS_output_file),
+      .output_format = absl::GetFlag(FLAGS_output_format),
+  };
+  return std::make_pair(std::move(config), std::move(positional_args));
+}
+
+}  // namespace spoor::tools::config

--- a/spoor/tools/config/command_line_config.h
+++ b/spoor/tools/config/command_line_config.h
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "absl/flags/declare.h"
+#include "absl/flags/parse.h"
+#include "absl/strings/string_view.h"
+#include "spoor/tools/config/config.h"
+
+ABSL_DECLARE_FLAG(std::string, output_file);                           // NOLINT
+ABSL_DECLARE_FLAG(spoor::tools::config::OutputFormat, output_format);  // NOLINT
+
+namespace spoor::tools::config {
+
+auto AbslParseFlag(absl::string_view user_key, OutputFormat* output_format,
+                   std::string* error) -> bool;
+auto AbslUnparseFlag(OutputFormat output_format) -> std::string;
+
+auto ConfigFromCommandLine(int argc, char** argv)
+    -> std::pair<Config, std::vector<char*>>;
+
+}  // namespace spoor::tools::config

--- a/spoor/tools/config/command_line_config_test.cc
+++ b/spoor/tools/config/command_line_config_test.cc
@@ -1,0 +1,118 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "spoor/tools/config/command_line_config.h"
+
+#include <string_view>
+#include <vector>
+
+#include "gsl/gsl"
+#include "gtest/gtest.h"
+#include "spoor/tools/config/config.h"
+
+namespace {
+
+using spoor::tools::config::Config;
+using spoor::tools::config::ConfigFromCommandLine;
+using spoor::tools::config::kOutputFormats;
+using spoor::tools::config::OutputFormat;
+
+auto MakeArgv(const std::vector<std::string_view>& args) -> std::vector<char*> {
+  std::vector<char*> argv{};
+  argv.reserve(args.size());
+  std::transform(std::cbegin(args), std::cend(args), std::back_inserter(argv),
+                 [](const auto string_view) {
+                   // `absl::ParseCommandLine` requires a (non-const) char** as
+                   // an argument.
+                   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+                   return const_cast<char*>(string_view.data());
+                 });
+  return argv;
+}
+
+TEST(CommandLineConfig, ParsesCommandLine) {  // NOLINT
+  const Config expected_config{
+      .output_file = "/path/to/output_file.perfetto",
+      .output_format = OutputFormat::kPerfetto,
+  };
+  auto argv = MakeArgv({"spoor", "--output_file=/path/to/output_file.perfetto",
+                        "--output_format=perfetto"});
+  const auto expected_positional_args = MakeArgv({argv.front()});
+  const auto [config, positional_args] =
+      ConfigFromCommandLine(gsl::narrow_cast<int>(argv.size()), argv.data());
+  ASSERT_EQ(config, expected_config);
+  ASSERT_EQ(positional_args, expected_positional_args);
+}
+
+TEST(CommandLineConfig, UsesDefaultValueWhenNotSpecified) {  // NOLINT
+  const Config expected_config{
+      .output_file = "",
+      .output_format = OutputFormat::kAutomatic,
+  };
+  auto argv = MakeArgv({"spoor"});
+  const auto expected_positional_args = MakeArgv({argv.front()});
+  const auto [config, positional_args] =
+      ConfigFromCommandLine(gsl::narrow_cast<int>(argv.size()), argv.data());
+  ASSERT_EQ(config, expected_config);
+  ASSERT_EQ(positional_args, expected_positional_args);
+}
+
+TEST(CommandLineConfig, PositionalArguments) {  // NOLINT
+  auto argv = MakeArgv({"spoor", "--output_format=spoor_symbols", "-", "--",
+                        "--output_file=/path/to/output_file.spoor_symbols"});
+  auto expected_positional_args = MakeArgv(
+      {"spoor", "-", "--output_file=/path/to/output_file.spoor_symbols"});
+  const auto [_, positional_args] =
+      ConfigFromCommandLine(gsl::narrow_cast<int>(argv.size()), argv.data());
+  ASSERT_EQ(positional_args, expected_positional_args);
+}
+
+TEST(CommandLineConfig, Version) {  // NOLINT
+  auto argv = MakeArgv({"spoor", "--version"});
+  EXPECT_EXIT(  // NOLINT
+      ConfigFromCommandLine(argv.size(), argv.data()),
+      testing::ExitedWithCode(0), "");
+}
+
+TEST(CommandLineConfig, Help) {  // NOLINT
+  auto argv = MakeArgv({"spoor", "--help"});
+  EXPECT_DEATH(  // NOLINT
+      ConfigFromCommandLine(argv.size(), argv.data()), "");
+}
+
+TEST(CommandLineConfig, UnknownFlag) {  // NOLINT
+  auto argv = MakeArgv({"spoor", "--unknown_flag"});
+  EXPECT_DEATH(  // NOLINT
+      ConfigFromCommandLine(argv.size(), argv.data()),
+      "Unknown command line flag 'unknown_flag'");
+}
+
+TEST(CommandLineConfig, AbslParseFlag) {  // NOLINT
+  for (const auto& [key, value] : kOutputFormats) {
+    OutputFormat output_format{};
+    std::string error{};
+    const auto success = AbslParseFlag(key, &output_format, &error);
+    ASSERT_TRUE(success);
+    ASSERT_TRUE(error.empty());
+    ASSERT_EQ(output_format, value);
+  }
+
+  OutputFormat output_format{};
+  std::string error{};
+  const auto success = AbslParseFlag("invalid", &output_format, &error);
+  ASSERT_FALSE(success);
+  ASSERT_EQ(error,
+            "Unknown output format 'invalid'. Options: automatic, perfetto, "
+            "spoor_symbols.");
+}
+
+TEST(CommandLineConfig, AbslUnparseFlag) {  // NOLINT
+  for (const auto& [key, value] : kOutputFormats) {
+    const auto result = AbslUnparseFlag(value);
+    ASSERT_EQ(result, key);
+  }
+  const auto result = AbslUnparseFlag(static_cast<OutputFormat>(100));
+  ASSERT_EQ(result, "100");
+}
+
+}  // namespace

--- a/spoor/tools/config/config.cc
+++ b/spoor/tools/config/config.cc
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "spoor/tools/config/config.h"
+
+namespace spoor::tools::config {
+
+auto operator==(const Config& lhs, const Config& rhs) -> bool {
+  return lhs.output_file == rhs.output_file &&
+         lhs.output_format == rhs.output_format;
+}
+
+}  // namespace spoor::tools::config

--- a/spoor/tools/config/config.h
+++ b/spoor/tools/config/config.h
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <string>
+#include <string_view>
+
+#include "util/flat_map/flat_map.h"
+
+namespace spoor::tools::config {
+
+enum class OutputFormat {
+  kAutomatic,
+  kPerfetto,
+  kSpoorSymbols,
+};
+
+struct Config {
+  // Alphabetized to match the order printed in --help.
+  std::string output_file;
+  OutputFormat output_format;
+};
+
+constexpr util::flat_map::FlatMap<std::string_view, OutputFormat, 3>
+    kOutputFormats{
+        {"automatic", OutputFormat::kAutomatic},
+        {"perfetto", OutputFormat::kPerfetto},
+        {"spoor_symbols", OutputFormat::kSpoorSymbols},
+    };
+
+constexpr std::string_view kOutputFileDoc{"Output file."};
+constexpr std::string_view kOutputFileDefaultValue{""};
+
+constexpr std::string_view kOutputFormatDoc{
+    "Data output format. Options: %s. \"automatic\" detects the format from "
+    "the output file's extension."};
+constexpr auto kOutputFormatDefaultValue{OutputFormat::kAutomatic};
+
+auto operator==(const Config& lhs, const Config& rhs) -> bool;
+
+}  // namespace spoor::tools::config

--- a/spoor/tools/config/config_test.cc
+++ b/spoor/tools/config/config_test.cc
@@ -1,0 +1,2 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.

--- a/spoor/tools/serialization/BUILD
+++ b/spoor/tools/serialization/BUILD
@@ -1,0 +1,48 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+load(
+    "//toolchain:config.bzl",
+    "SPOOR_DEFAULT_COPTS",
+    "SPOOR_DEFAULT_LINKOPTS",
+    "SPOOR_DEFAULT_TEST_COPTS",
+    "SPOOR_DEFAULT_TEST_LINKOPTS",
+)
+
+cc_library(
+    name = "serialize",
+    srcs = ["serialize.cc"],
+    hdrs = ["serialize.h"],
+    copts = SPOOR_DEFAULT_COPTS,
+    linkopts = SPOOR_DEFAULT_LINKOPTS,
+    visibility = ["//visibility:public"],
+    deps = [
+        "//spoor/instrumentation:instrumentation_info",
+        "//spoor/instrumentation/symbols:symbols_cc_proto",
+        "//spoor/runtime/trace",
+        "//spoor/tools/adapters/perfetto:perfetto_adapter",
+        "//spoor/tools/config",
+        "//util:result",
+        "@com_google_absl//absl/strings",
+        "@com_microsoft_gsl//:gsl",
+    ],
+)
+
+cc_test(
+    name = "serialize_test",
+    size = "small",
+    srcs = ["serialize_test.cc"],
+    copts = SPOOR_DEFAULT_TEST_COPTS,
+    linkopts = SPOOR_DEFAULT_TEST_LINKOPTS,
+    visibility = ["//visibility:private"],
+    deps = [
+        ":serialize",
+        "//spoor/instrumentation/symbols:symbols_cc_proto",
+        "//spoor/runtime/trace",
+        "//spoor/tools/adapters/perfetto:perfetto_trace_cc_proto",
+        "//spoor/tools/config",
+        "@com_google_googletest//:gtest_main",
+        "@com_google_protobuf//:protobuf",
+    ],
+)

--- a/spoor/tools/serialization/serialize.cc
+++ b/spoor/tools/serialization/serialize.cc
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "spoor/tools/serialization/serialize.h"
+
+#include <filesystem>
+#include <ostream>
+#include <string>
+#include <vector>
+
+#include "absl/strings/str_cat.h"
+#include "gsl/gsl"
+#include "spoor/instrumentation/instrumentation.h"
+#include "spoor/instrumentation/symbols/symbols.pb.h"
+#include "spoor/runtime/trace/trace.h"
+#include "spoor/tools/adapters/perfetto/perfetto_adapter.h"
+#include "util/result.h"
+
+namespace spoor::tools::serialization {
+
+using adapters::perfetto::kPerfettoFileExtension;
+using adapters::perfetto::SpoorTraceToPerfettoTrace;
+using instrumentation::kSymbolsFileExtension;
+using instrumentation::symbols::Symbols;
+using runtime::trace::TraceFile;
+using Result = util::result::Result<util::result::None, util::result::None>;
+
+auto OutputFormatFromConfig(const config::Config& config)
+    -> util::result::Result<OutputFormat, OutputFormatFromConfigError> {
+  switch (config.output_format) {
+    case config::OutputFormat::kAutomatic: {
+      const std::filesystem::path path{config.output_file};
+      if (path.extension() == absl::StrCat(".", kPerfettoFileExtension)) {
+        return OutputFormat::kPerfetto;
+      }
+      if (path.extension() == absl::StrCat(".", kSymbolsFileExtension)) {
+        return OutputFormat::kSpoorSymbols;
+      }
+      return OutputFormatFromConfigError::kUnknownFileExtension;
+    }
+    case config::OutputFormat::kPerfetto: {
+      return OutputFormat::kPerfetto;
+    }
+    case config::OutputFormat::kSpoorSymbols: {
+      return OutputFormat::kSpoorSymbols;
+    }
+  }
+}
+
+auto SerializeToOstream(const std::vector<TraceFile>& trace_files,
+                        const Symbols& symbols,
+                        const OutputFormat output_format,
+                        gsl::not_null<std::ostream*> ostream)
+    -> util::result::Result<util::result::None, util::result::None> {
+  const auto success = [&] {
+    switch (output_format) {
+      case OutputFormat::kPerfetto: {
+        const auto perfetto_trace =
+            SpoorTraceToPerfettoTrace(trace_files, symbols);
+        return perfetto_trace.SerializeToOstream(ostream);
+      }
+      case OutputFormat::kSpoorSymbols: {
+        return symbols.SerializeToOstream(ostream);
+      }
+    }
+  }();
+  return success ? Result::Ok({}) : Result::Err({});
+}
+
+}  // namespace spoor::tools::serialization

--- a/spoor/tools/serialization/serialize.h
+++ b/spoor/tools/serialization/serialize.h
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include <array>
+#include <ostream>
+#include <string>
+#include <vector>
+
+#include "gsl/gsl"
+#include "spoor/instrumentation/symbols/symbols.pb.h"
+#include "spoor/runtime/trace/trace.h"
+#include "spoor/tools/config/config.h"
+#include "util/result.h"
+
+namespace spoor::tools::serialization {
+
+enum class OutputFormat {
+  kPerfetto,
+  kSpoorSymbols,
+};
+
+constexpr std::array<OutputFormat, 2> kOutputFormats{{
+    OutputFormat::kPerfetto,
+    OutputFormat::kSpoorSymbols,
+}};
+
+enum class OutputFormatFromConfigError {
+  kUnknownFileExtension,
+};
+
+auto OutputFormatFromConfig(const config::Config& config)
+    -> util::result::Result<OutputFormat, OutputFormatFromConfigError>;
+
+auto SerializeToOstream(
+    const std::vector<runtime::trace::TraceFile>& trace_files,
+    const instrumentation::symbols::Symbols& symbols,
+    OutputFormat output_format, gsl::not_null<std::ostream*> ostream)
+    -> util::result::Result<util::result::None, util::result::None>;
+
+}  // namespace spoor::tools::serialization

--- a/spoor/tools/serialization/serialize_test.cc
+++ b/spoor/tools/serialization/serialize_test.cc
@@ -1,0 +1,172 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "spoor/tools/serialization/serialize.h"
+
+#include <ios>
+#include <sstream>
+#include <utility>
+#include <vector>
+
+#include "google/protobuf/util/time_util.h"
+#include "gtest/gtest.h"
+#include "protos/perfetto/trace/trace.pb.h"
+#include "spoor/instrumentation/symbols/symbols.pb.h"
+#include "spoor/runtime/trace/trace.h"
+#include "spoor/tools/config/config.h"
+
+namespace {
+
+using google::protobuf::util::TimeUtil;
+using perfetto::protos::Trace;
+using spoor::instrumentation::symbols::Symbols;
+using spoor::runtime::trace::CompressionStrategy;
+using spoor::runtime::trace::Event;
+using spoor::runtime::trace::EventCount;
+using spoor::runtime::trace::EventType;
+using spoor::runtime::trace::FunctionId;
+using spoor::runtime::trace::kEndianness;
+using spoor::runtime::trace::kMagicNumber;
+using spoor::runtime::trace::kTraceFileVersion;
+using spoor::runtime::trace::TraceFile;
+using spoor::tools::config::Config;
+using spoor::tools::serialization::kOutputFormats;
+using spoor::tools::serialization::OutputFormat;
+using spoor::tools::serialization::OutputFormatFromConfig;
+using spoor::tools::serialization::OutputFormatFromConfigError;
+using spoor::tools::serialization::SerializeToOstream;
+using ConfigOutputFormat = spoor::tools::config::OutputFormat;
+using SerializationOutputFormat = spoor::tools::serialization::OutputFormat;
+
+TEST(OutputFormatFromConfig, ParsesOutputFormat) {  // NOLINT
+  {
+    const Config config{
+        .output_file = "/path/to/file.perfetto",
+        .output_format = ConfigOutputFormat::kAutomatic,
+    };
+    const auto output_format_result = OutputFormatFromConfig(config);
+    ASSERT_TRUE(output_format_result.IsOk());
+    const auto output_format = output_format_result.Ok();
+    ASSERT_EQ(output_format, SerializationOutputFormat::kPerfetto);
+  }
+  {
+    const Config config{
+        .output_file = "/path/to/file.spoor_symbols",
+        .output_format = ConfigOutputFormat::kAutomatic,
+    };
+    const auto output_format_result = OutputFormatFromConfig(config);
+    ASSERT_TRUE(output_format_result.IsOk());
+    const auto output_format = output_format_result.Ok();
+    ASSERT_EQ(output_format, SerializationOutputFormat::kSpoorSymbols);
+  }
+  {
+    const Config config{
+        .output_file = "/path/to/file.unknown_extension",
+        .output_format = ConfigOutputFormat::kAutomatic,
+    };
+    const auto output_format_result = OutputFormatFromConfig(config);
+    ASSERT_TRUE(output_format_result.IsErr());
+    const auto error = output_format_result.Err();
+    ASSERT_EQ(error, OutputFormatFromConfigError::kUnknownFileExtension);
+  }
+  {
+    const Config config{
+        .output_file = "/path/to/file.spoor_symbols",
+        .output_format = ConfigOutputFormat::kPerfetto,
+    };
+    const auto output_format_result = OutputFormatFromConfig(config);
+    ASSERT_TRUE(output_format_result.IsOk());
+    const auto output_format = output_format_result.Ok();
+    ASSERT_EQ(output_format, SerializationOutputFormat::kPerfetto);
+  }
+  {
+    const Config config{
+        .output_file = "/path/to/file.perfetto",
+        .output_format = ConfigOutputFormat::kSpoorSymbols,
+    };
+    const auto output_format_result = OutputFormatFromConfig(config);
+    ASSERT_TRUE(output_format_result.IsOk());
+    const auto output_format = output_format_result.Ok();
+    ASSERT_EQ(output_format, SerializationOutputFormat::kSpoorSymbols);
+  }
+}
+
+TEST(SerializeToOstream, SerializesToOstream) {  // NOLINT
+  constexpr FunctionId function_id{0};
+  const auto trace_files = [&] {
+    std::vector<Event> events{
+        {
+            .steady_clock_timestamp = 0,
+            .payload_1 = function_id,
+            .type = static_cast<EventType>(Event::Type::kFunctionEntry),
+            .payload_2 = 0,
+        },
+        {
+            .steady_clock_timestamp = 1,
+            .payload_1 = function_id,
+            .type = static_cast<EventType>(Event::Type::kFunctionExit),
+            .payload_2 = 0,
+        },
+    };
+    const auto event_count = events.size();
+    return std::vector<TraceFile>{{
+        .header =
+            {
+                .magic_number = kMagicNumber,
+                .endianness = kEndianness,
+                .compression_strategy = CompressionStrategy::kNone,
+                .version = kTraceFileVersion,
+                .session_id = 1,
+                .process_id = 2,
+                .thread_id = 3,
+                .system_clock_timestamp = 0,
+                .steady_clock_timestamp = 0,
+                .event_count = gsl::narrow_cast<EventCount>(event_count),
+                .padding = {},
+            },
+        .events = std::move(events),
+    }};
+  }();
+  const auto symbols = [&] {
+    Symbols symbols{};
+    auto& function_symbols_table = *symbols.mutable_function_symbols_table();
+    auto& repeated_function_infos = function_symbols_table[function_id];
+    auto* function_info = repeated_function_infos.add_function_infos();
+    function_info->set_module_id("module_id");
+    function_info->set_linkage_name("function_a");
+    function_info->set_demangled_name("FunctionA()");
+    function_info->set_file_name("file_a.source");
+    function_info->set_directory("/path/to/a/");
+    function_info->set_line(1);
+    function_info->set_instrumented(true);
+    *function_info->mutable_created_at() = TimeUtil::NanosecondsToTimestamp(0);
+    return symbols;
+  }();
+  {
+    std::stringstream buffer{};
+    const auto result = SerializeToOstream(trace_files, symbols,
+                                           OutputFormat::kPerfetto, &buffer);
+    ASSERT_TRUE(result.IsOk());
+    Trace parsed_trace{};
+    const auto trace_success = parsed_trace.ParseFromIstream(&buffer);
+    ASSERT_TRUE(trace_success);
+  }
+  {
+    std::stringstream buffer{};
+    const auto result = SerializeToOstream(
+        trace_files, symbols, OutputFormat::kSpoorSymbols, &buffer);
+    ASSERT_TRUE(result.IsOk());
+    Symbols parsed_symbols{};
+    const auto symbols_success = parsed_symbols.ParseFromIstream(&buffer);
+    ASSERT_TRUE(symbols_success);
+  }
+  for (const auto output_format : kOutputFormats) {
+    std::stringstream buffer{};
+    buffer.setstate(std::ios::failbit);
+    const auto result =
+        SerializeToOstream(trace_files, symbols, output_format, &buffer);
+    ASSERT_TRUE(result.IsErr());
+  }
+}
+
+}  // namespace

--- a/spoor/tools/spoor.cc
+++ b/spoor/tools/spoor.cc
@@ -1,0 +1,206 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include <cstdlib>
+#include <filesystem>
+#include <iostream>
+#include <istream>
+#include <memory>
+#include <unordered_set>
+#include <vector>
+
+#include "absl/flags/flag.h"
+#include "absl/flags/parse.h"
+#include "absl/flags/usage.h"
+#include "absl/flags/usage_config.h"
+#include "absl/strings/ascii.h"
+#include "absl/strings/match.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_format.h"
+#include "gsl/gsl"
+#include "spoor/instrumentation/instrumentation.h"
+#include "spoor/instrumentation/symbols/symbols_file_reader.h"
+#include "spoor/instrumentation/symbols/symbols_utility.h"
+#include "spoor/runtime/trace/trace.h"
+#include "spoor/runtime/trace/trace_file_reader.h"
+#include "spoor/runtime/trace/trace_reader.h"
+#include "spoor/tools/config/command_line_config.h"
+#include "spoor/tools/config/config.h"
+#include "spoor/tools/serialization/serialize.h"
+#include "spoor/tools/tools.h"
+#include "util/file_system/local_file_reader.h"
+#include "util/file_system/local_file_system.h"
+#include "util/file_system/local_file_writer.h"
+
+namespace {
+
+using spoor::instrumentation::kSymbolsFileExtension;
+using spoor::instrumentation::symbols::ReduceSymbols;
+using spoor::instrumentation::symbols::Symbols;
+using spoor::instrumentation::symbols::SymbolsFileReader;
+using spoor::instrumentation::symbols::SymbolsReader;
+using spoor::runtime::trace::kTraceFileExtension;
+using spoor::runtime::trace::TraceFile;
+using spoor::runtime::trace::TraceFileReader;
+using spoor::runtime::trace::TraceReader;
+using spoor::tools::config::ConfigFromCommandLine;
+using spoor::tools::serialization::OutputFormat;
+using spoor::tools::serialization::OutputFormatFromConfig;
+using spoor::tools::serialization::OutputFormatFromConfigError;
+using spoor::tools::serialization::SerializeToOstream;
+using util::file_system::LocalFileReader;
+using util::file_system::LocalFileSystem;
+using util::file_system::LocalFileWriter;
+
+constexpr std::string_view kVersion{"%s %s\n"};
+constexpr std::string_view kUsage{
+    "Parse and symbolize Spoor traces.\n\n"
+    "USAGE: %1$s [options...] <search_paths...>"};
+
+}  // namespace
+
+auto main(const int argc, char** argv) -> int {
+  const auto short_program_invocation_name = [argc, argv] {
+    const gsl::span<char*> args{argv,
+                                static_cast<gsl::span<char*>::size_type>(argc)};
+    const auto program_invocation_name = std::filesystem::path{args.front()};
+    return program_invocation_name.filename();
+  }();
+  const auto show_help = [](const absl::string_view source) {
+    std::string string{source};
+    absl::AsciiStrToLower(&string);
+    return absl::StrContains(string, "spoor") ||
+           absl::StrContains(string, "usage");
+  };
+  absl::SetFlagsUsageConfig({
+      .contains_helpshort_flags = show_help,
+      .contains_help_flags = show_help,
+      .version_string =
+          [&] {
+            return absl::StrFormat(kVersion, short_program_invocation_name,
+                                   spoor::tools::kVersion);
+          },
+  });
+  absl::SetProgramUsageMessage(
+      absl::StrFormat(kUsage, short_program_invocation_name));
+
+  const auto [config, positional_args] = ConfigFromCommandLine(argc, argv);
+
+  if (positional_args.size() < 2) {
+    std::cerr << "error: Expected at least one input source.\n\n"
+              << absl::ProgramUsageMessage() << "\n\n"
+              << "Try --help to list available flags.\n";
+    return EXIT_FAILURE;
+  }
+  const gsl::span<char* const> input_sources{
+      &(*std::next(std::cbegin(positional_args))),
+      &(*std::cend(positional_args))};
+
+  LocalFileWriter output_file_writer{};
+  output_file_writer.Open(config.output_file);
+  if (!output_file_writer.IsOpen()) {
+    std::cerr << "error: Failed to open the output file \""
+              << config.output_file << "\".\n";
+    return EXIT_FAILURE;
+  }
+
+  const auto output_format_result = OutputFormatFromConfig(config);
+  if (output_format_result.IsErr()) {
+    switch (output_format_result.Err()) {
+      case OutputFormatFromConfigError::kUnknownFileExtension: {
+        std::cerr << "error: Cannot infer the output format from the output "
+                     "file's extension.\n";
+        return EXIT_FAILURE;
+      }
+    }
+  }
+  const auto output_format = output_format_result.Ok();
+
+  LocalFileSystem file_system{};
+  std::vector<std::filesystem::path> trace_file_paths{};
+  std::vector<std::filesystem::path> symbols_file_paths{};
+  {
+    std::unordered_set<std::string> visited{};
+    for (const auto& path : input_sources) {
+      auto visit_file = [&](const std::filesystem::path& path) {
+        auto [_, inserted] = visited.emplace(path.string());
+        if (!inserted || !file_system.IsRegularFile(path).OkOr(false)) return;
+        if (output_format != OutputFormat::kSpoorSymbols &&
+            path.extension() == absl::StrCat(".", kTraceFileExtension)) {
+          trace_file_paths.emplace_back(path);
+        }
+        if (path.extension() == absl::StrCat(".", kSymbolsFileExtension)) {
+          symbols_file_paths.emplace_back(path);
+        }
+      };
+      if (file_system.IsDirectory(path).OkOr(false)) {
+        std::filesystem::recursive_directory_iterator iterator{path};
+        for (const auto& entry : iterator) {
+          visit_file(entry.path());
+        }
+      } else {
+        visit_file(path);
+      }
+    }
+  }
+
+  std::vector<TraceFile> trace_files{};
+  trace_files.reserve(trace_file_paths.size());
+  auto trace_file_reader = TraceFileReader{{
+      .file_system{std::make_unique<LocalFileSystem>()},
+      .file_reader{std::make_unique<LocalFileReader>()},
+  }};
+  for (const auto& trace_file_path : trace_file_paths) {
+    auto result = trace_file_reader.Read(trace_file_path);
+    if (result.IsErr()) {
+      switch (result.Err()) {
+        case TraceReader::Error::kFailedToOpenFile: {
+          std::cerr << "error:: Failed to open the trace file "
+                    << trace_file_path << ".\n";
+        }
+        case TraceReader::Error::kUnknownVersion: {
+          std::cerr << "error: Failed to parse the trace file "
+                    << trace_file_path << ". Unknown version.\n";
+        }
+        case TraceReader::Error::kCorruptData: {
+          std::cerr << "error: Failed to parse the trace file "
+                    << trace_file_path << ". The file is corrupt.\n";
+        }
+      }
+      continue;
+    }
+    trace_files.emplace_back(std::move(result.Ok()));
+  }
+  std::sort(std::begin(trace_files), std::end(trace_files),
+            [](const auto& lhs, const auto& rhs) {
+              return lhs.header.steady_clock_timestamp <
+                     rhs.header.steady_clock_timestamp;
+            });
+
+  Symbols symbols{};
+  SymbolsFileReader symbols_file_reader{{
+      .file_reader{std::make_unique<util::file_system::LocalFileReader>()},
+  }};
+  for (const auto& symbols_file_path : symbols_file_paths) {
+    auto result = symbols_file_reader.Read(symbols_file_path);
+    if (result.IsErr()) {
+      switch (result.Err()) {
+        case SymbolsReader::Error::kFailedToOpenFile: {
+          std::cerr << "error: Failed to open the trace symbols file "
+                    << symbols_file_path << ".\n";
+        }
+        case SymbolsReader::Error::kCorruptData: {
+          std::cerr << "error: Failed to parse the symbols file "
+                    << symbols_file_path << ". The file is corrupt.\n";
+        }
+      }
+      continue;
+    }
+    auto& file_symbols = result.Ok();
+    ReduceSymbols(&file_symbols, &symbols);
+  }
+
+  const auto result = SerializeToOstream(trace_files, symbols, output_format,
+                                         &output_file_writer.Ostream());
+  return result.IsOk() ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/spoor/tools/tools.h
+++ b/spoor/tools/tools.h
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <string_view>
+
+namespace spoor::tools {
+
+constexpr std::string_view kVersion{"0.0.0"};
+
+}  // namespace spoor::tools

--- a/toolchain/perfetto_overrides/perfetto_cfg.bzl
+++ b/toolchain/perfetto_overrides/perfetto_cfg.bzl
@@ -1,0 +1,25 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# Documentation:
+# https://github.com/google/perfetto/tree/master/bazel/standalone
+
+PERFETTO_CONFIG = struct(
+    root = "//",
+    deps = struct(
+        build_config = ["//:build_config_hdr"],
+        version_header = ["//:cc_perfetto_version_header"],
+        zlib = ["@perfetto_dep_zlib//:zlib"],
+        jsoncpp = ["@perfetto_dep_jsoncpp//:jsoncpp"],
+        linenoise = ["@perfetto_dep_linenoise//:linenoise"],
+        sqlite = ["@perfetto_dep_sqlite//:sqlite"],
+        sqlite_ext_percentile = ["@perfetto_dep_sqlite_src//:percentile_ext"],
+        protoc = ["@com_google_protobuf//:protoc"],
+        protoc_lib = ["@com_google_protobuf//:protoc_lib"],
+        protobuf_lite = ["@com_google_protobuf//:protobuf_lite"],
+        protobuf_full = ["@com_google_protobuf//:protobuf"],
+        protobuf_descriptor_proto = ["@com_google_protobuf//:descriptor_proto"],
+    ),
+    public_visibility = ["//visibility:public"],
+    proto_library_visibility = "//visibility:public",
+)

--- a/util/file_system/BUILD
+++ b/util/file_system/BUILD
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+load("@rules_cc//cc:defs.bzl", "cc_library")
 load(
     "//toolchain:config.bzl",
     "SPOOR_DEFAULT_COPTS",

--- a/util/file_system/file_system.h
+++ b/util/file_system/file_system.h
@@ -22,6 +22,8 @@ class FileSystem {
 
   [[nodiscard]] virtual auto IsRegularFile(const std::filesystem::path& path)
       const -> util::result::Result<bool, std::error_code> = 0;
+  [[nodiscard]] virtual auto IsDirectory(const std::filesystem::path& path)
+      const -> util::result::Result<bool, std::error_code> = 0;
   [[nodiscard]] virtual auto FileSize(const std::filesystem::path& path) const
       -> util::result::Result<std::uintmax_t, std::error_code> = 0;
   [[nodiscard]] virtual auto Remove(const std::filesystem::path& path) const

--- a/util/file_system/file_system_mock.h
+++ b/util/file_system/file_system_mock.h
@@ -19,6 +19,9 @@ class FileSystemMock final : public FileSystem {
       (util::result::Result<bool, std::error_code>), IsRegularFile,
       (const std::filesystem::path& path), (const, override));
   MOCK_METHOD(  // NOLINT
+      (util::result::Result<bool, std::error_code>), IsDirectory,
+      (const std::filesystem::path& path), (const, override));
+  MOCK_METHOD(  // NOLINT
       (util::result::Result<std::uintmax_t, std::error_code>), FileSize,
       (const std::filesystem::path& path), (const, override));
   MOCK_METHOD(  // NOLINT

--- a/util/file_system/local_file_system.cc
+++ b/util/file_system/local_file_system.cc
@@ -23,6 +23,15 @@ auto LocalFileSystem::IsRegularFile(const std::filesystem::path& path) const
   return is_regular_file;
 }
 
+auto LocalFileSystem::IsDirectory(const std::filesystem::path& path) const
+    -> util::result::Result<bool, std::error_code> {
+  std::error_code error_code{};
+  const auto is_directory = std::filesystem::is_directory(path, error_code);
+  const auto error = static_cast<bool>(error_code);
+  if (error) return error_code;
+  return is_directory;
+}
+
 auto LocalFileSystem::FileSize(const std::filesystem::path& path) const
     -> util::result::Result<std::uintmax_t, std::error_code> {
   std::error_code error_code{};

--- a/util/file_system/local_file_system.h
+++ b/util/file_system/local_file_system.h
@@ -16,6 +16,8 @@ class LocalFileSystem final : public FileSystem {
  public:
   [[nodiscard]] auto IsRegularFile(const std::filesystem::path& path) const
       -> util::result::Result<bool, std::error_code> override;
+  [[nodiscard]] auto IsDirectory(const std::filesystem::path& path) const
+      -> util::result::Result<bool, std::error_code> override;
   [[nodiscard]] auto FileSize(const std::filesystem::path& path) const
       -> util::result::Result<std::uintmax_t, std::error_code> override;
   [[nodiscard]] auto Remove(const std::filesystem::path& path) const


### PR DESCRIPTION
Implements a command line tool to parse and symbolize trace files.

Features:
* Adapts Spoor trace files and Spoor symbols files to a Perfetto trace viewable in https://ui.perfetto.dev/.
* Aggregates Spoor symbols files to a single symbols file.

### Usage

```
$ spoor /path/to/symbols /path/to/traces --output_file=/Users/path/to/trace.perfetto
```

```
$ spoor --help
spoor: Parse and symbolize Spoor traces.

USAGE: spoor [options...] <search_paths...>

  Flags from external/com_google_absl/absl/flags/internal/usage.cc:
    --help (show help on important flags for this binary [tip: all flags can
      have two dashes]); default: false; currently: true;
    --helpfull (show help on all flags); default: false;
    --helpmatch (show help on modules whose name contains the specified substr);
      default: "";
    --helpon (show help on the modules named by this flag value); default: "";
    --helppackage (show help on all modules in the main package);
      default: false;
    --helpshort (show help on only the main module for this program);
      default: false;
    --only_check_args (exit after checking all flags); default: false;
    --version (show version and build info and exit); default: false;


  Flags from spoor/tools/config/command_line_config.cc:
    --output_file (Output file.); default: "";
    --output_format (Data output format. Options: automatic, perfetto,
      spoor_symbols. "automatic" detects the format from the output file's
      extension.); default: automatic;

Try --helpfull to get a list of all flags.
```