### PR TITLE
Update the symbol visibility to hidden, and expose all public apis.

### DIFF
--- a/.build/azure-pipelines.yml
+++ b/.build/azure-pipelines.yml
@@ -1,15 +1,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-parameters:
-- name: symbol_visibility
-  displayName: Symbol Visibility
-  type: string
-  default: default
-  values:
-  - default
-  - hidden
-
 trigger:
 - master
 
@@ -26,7 +17,7 @@ jobs:
     vmImage: $(imageName)
   steps:
   - template: ./templates/install-common.yml
-  - script: bazel build //... --copt=-fvisibility=${{ parameters.symbol_visibility }}
+  - script: bazel build //...
     displayName: Build
   - script: bazel test //...
     displayName: Test


### PR DESCRIPTION
The symbol visibility is set to default by clang. But when linking to some libraries that compiled with flag fvisibility=hidden, the linker will issue a warning. In this PR, add the fvisibility=hidden to bazel and expose all public apis explicitly.  