### PR TITLE
Robust source file name and directory handling

### DIFF
--- a/spoor/instrumentation/test_data/BUILD
+++ b/spoor/instrumentation/test_data/BUILD
@@ -15,6 +15,10 @@ filegroup(
         "fib_instrumented_initialized_enabled.ll",
         "fib_no_main.ll",
         "fib_only_main_instrumented.ll",
+        "main_difile_compiler_generated.ll",
+        "main_difile_empty_directory.ll",
+        "main_difile_file_name_contains_directory.ll",
+        "main_disubprogram_zero_line_number.ll",
     ],
     visibility = ["//spoor/instrumentation:__subpackages__"],
 )

--- a/spoor/instrumentation/test_data/main_difile_compiler_generated.ll
+++ b/spoor/instrumentation/test_data/main_difile_compiler_generated.ll
@@ -1,0 +1,23 @@
+; Copyright (c) Microsoft Corporation.
+; Licensed under the MIT License.
+
+define i32 @main() !dbg !8 {
+  ret i32 0
+}
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!3, !4, !5, !6}
+!llvm.ident = !{!7}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1)
+!1 = !DIFile(filename: "<compiler-generated>", directory: "")
+!2 = !{}
+!3 = !{i32 7, !"Dwarf Version", i32 4}
+!4 = !{i32 2, !"Debug Info Version", i32 3}
+!5 = !{i32 1, !"wchar_size", i32 4}
+!6 = !{i32 7, !"PIC Level", i32 2}
+!7 = !{!"clang version 11.1.0"}
+!8 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 0, type: !9, scopeLine: 1, flags: DIFlagAllCallsDescribed, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !0, retainedNodes: !2)
+!9 = !DISubroutineType(types: !10)
+!10 = !{!11}
+!11 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)

--- a/spoor/instrumentation/test_data/main_difile_empty_directory.ll
+++ b/spoor/instrumentation/test_data/main_difile_empty_directory.ll
@@ -1,0 +1,23 @@
+; Copyright (c) Microsoft Corporation.
+; Licensed under the MIT License.
+
+define i32 @main() !dbg !8 {
+  ret i32 0
+}
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!3, !4, !5, !6}
+!llvm.ident = !{!7}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1)
+!1 = !DIFile(filename: "/path/to/file/main.c", directory: "")
+!2 = !{}
+!3 = !{i32 7, !"Dwarf Version", i32 4}
+!4 = !{i32 2, !"Debug Info Version", i32 3}
+!5 = !{i32 1, !"wchar_size", i32 4}
+!6 = !{i32 7, !"PIC Level", i32 2}
+!7 = !{!"clang version 11.1.0"}
+!8 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 1, type: !9, scopeLine: 1, flags: DIFlagAllCallsDescribed, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !0, retainedNodes: !2)
+!9 = !DISubroutineType(types: !10)
+!10 = !{!11}
+!11 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)

--- a/spoor/instrumentation/test_data/main_difile_file_name_contains_directory.ll
+++ b/spoor/instrumentation/test_data/main_difile_file_name_contains_directory.ll
@@ -1,0 +1,23 @@
+; Copyright (c) Microsoft Corporation.
+; Licensed under the MIT License.
+
+define i32 @main() !dbg !8 {
+  ret i32 0
+}
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!3, !4, !5, !6}
+!llvm.ident = !{!7}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1)
+!1 = !DIFile(filename: "/path/to/file/main.c", directory: "/path/to")
+!2 = !{}
+!3 = !{i32 7, !"Dwarf Version", i32 4}
+!4 = !{i32 2, !"Debug Info Version", i32 3}
+!5 = !{i32 1, !"wchar_size", i32 4}
+!6 = !{i32 7, !"PIC Level", i32 2}
+!7 = !{!"clang version 11.1.0"}
+!8 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 1, type: !9, scopeLine: 1, flags: DIFlagAllCallsDescribed, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !0, retainedNodes: !2)
+!9 = !DISubroutineType(types: !10)
+!10 = !{!11}
+!11 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)

--- a/spoor/instrumentation/test_data/main_disubprogram_zero_line_number.ll
+++ b/spoor/instrumentation/test_data/main_disubprogram_zero_line_number.ll
@@ -1,0 +1,23 @@
+; Copyright (c) Microsoft Corporation.
+; Licensed under the MIT License.
+
+define i32 @main() !dbg !8 {
+  ret i32 0
+}
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!3, !4, !5, !6}
+!llvm.ident = !{!7}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1)
+!1 = !DIFile(filename: "main.c", directory: "/path/to/file")
+!2 = !{}
+!3 = !{i32 7, !"Dwarf Version", i32 4}
+!4 = !{i32 2, !"Debug Info Version", i32 3}
+!5 = !{i32 1, !"wchar_size", i32 4}
+!6 = !{i32 7, !"PIC Level", i32 2}
+!7 = !{!"clang version 11.1.0"}
+!8 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 0, type: !9, scopeLine: 1, flags: DIFlagAllCallsDescribed, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !0, retainedNodes: !2)
+!9 = !DISubroutineType(types: !10)
+!10 = !{!11}
+!11 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)


### PR DESCRIPTION
Sometimes the IR's debug info file name is the full file path (from root) and sometimes it's relative to the directory. This PR implements a fix so that the file name is always relative to the directory (if possible).