### PR TITLE
Add IR instruction count to symbols

### DIFF
--- a/spoor/instrumentation/inject_instrumentation/inject_instrumentation.cc
+++ b/spoor/instrumentation/inject_instrumentation/inject_instrumentation.cc
@@ -174,6 +174,9 @@ auto InjectInstrumentation::InstrumentModule(
     }();
     function_info.set_demangled_name(demangled_name);
 
+    const auto ir_instruction_count = function.getInstructionCount();
+    function_info.set_ir_instruction_count(ir_instruction_count);
+
     const auto* subprogram = function.getSubprogram();
     const auto directory =
         [subprogram]() -> std::optional<std::filesystem::path> {
@@ -223,7 +226,6 @@ auto InjectInstrumentation::InstrumentModule(
       return TimeUtil::NanosecondsToTimestamp(nanoseconds);
     }();
 
-    const auto ir_instruction_count = function.getInstructionCount();
     const auto is_main = function_name == kMainFunctionName;
 
     const auto [instrument_function,

--- a/spoor/instrumentation/inject_instrumentation/inject_instrumentation_test.cc
+++ b/spoor/instrumentation/inject_instrumentation/inject_instrumentation_test.cc
@@ -213,6 +213,7 @@ TEST(InjectInstrumentation, OutputsInstrumentedSymbols) {  // NOLINT
                 fibonacci_function_info.set_module_id(module_id);
                 fibonacci_function_info.set_linkage_name("_Z9Fibonaccii");
                 fibonacci_function_info.set_demangled_name("Fibonacci(int)");
+                fibonacci_function_info.set_ir_instruction_count(9);
                 fibonacci_function_info.set_instrumented(true);
                 *fibonacci_function_info.mutable_created_at() =
                     TimeUtil::NanosecondsToTimestamp(timestamp_0);
@@ -224,6 +225,7 @@ TEST(InjectInstrumentation, OutputsInstrumentedSymbols) {  // NOLINT
                 main_function_info.set_module_id(module_id);
                 main_function_info.set_linkage_name("main");
                 main_function_info.set_demangled_name("main");
+                main_function_info.set_ir_instruction_count(2);
                 main_function_info.set_instrumented(true);
                 *main_function_info.mutable_created_at() =
                     TimeUtil::NanosecondsToTimestamp(timestamp_1);
@@ -270,6 +272,7 @@ TEST(InjectInstrumentation, OutputsInstrumentedSymbols) {  // NOLINT
                 fibonacci_function_info.set_module_id(module_id);
                 fibonacci_function_info.set_linkage_name("_Z9Fibonaccii");
                 fibonacci_function_info.set_demangled_name("Fibonacci(int)");
+                fibonacci_function_info.set_ir_instruction_count(9);
                 fibonacci_function_info.set_instrumented(false);
                 fibonacci_function_info.set_instrumented_reason(
                     "Block everything");
@@ -283,6 +286,7 @@ TEST(InjectInstrumentation, OutputsInstrumentedSymbols) {  // NOLINT
                 main_function_info.set_module_id(module_id);
                 main_function_info.set_linkage_name("main");
                 main_function_info.set_demangled_name("main");
+                main_function_info.set_ir_instruction_count(2);
                 main_function_info.set_instrumented(true);
                 main_function_info.set_instrumented_reason(
                     "Always instrument `main`");
@@ -315,6 +319,7 @@ TEST(InjectInstrumentation, OutputsInstrumentedSymbols) {  // NOLINT
                 fibonacci_function_info.set_file_name("fibonacci.c");
                 fibonacci_function_info.set_directory("/path/to/file");
                 fibonacci_function_info.set_line(1);
+                fibonacci_function_info.set_ir_instruction_count(20);
                 fibonacci_function_info.set_instrumented(true);
                 *fibonacci_function_info.mutable_created_at() =
                     TimeUtil::NanosecondsToTimestamp(timestamp_0);
@@ -329,6 +334,7 @@ TEST(InjectInstrumentation, OutputsInstrumentedSymbols) {  // NOLINT
                 main_function_info.set_file_name("fibonacci.c");
                 main_function_info.set_directory("/path/to/file");
                 main_function_info.set_line(6);
+                main_function_info.set_ir_instruction_count(4);
                 main_function_info.set_instrumented(true);
                 *main_function_info.mutable_created_at() =
                     TimeUtil::NanosecondsToTimestamp(timestamp_1);
@@ -359,6 +365,7 @@ TEST(InjectInstrumentation, OutputsInstrumentedSymbols) {  // NOLINT
                 fibonacci_function_info.set_file_name("fibonacci.cc");
                 fibonacci_function_info.set_directory("/path/to/file");
                 fibonacci_function_info.set_line(1);
+                fibonacci_function_info.set_ir_instruction_count(20);
                 fibonacci_function_info.set_instrumented(true);
                 *fibonacci_function_info.mutable_created_at() =
                     TimeUtil::NanosecondsToTimestamp(timestamp_0);
@@ -373,7 +380,7 @@ TEST(InjectInstrumentation, OutputsInstrumentedSymbols) {  // NOLINT
                 main_function_info.set_file_name("fibonacci.cc");
                 main_function_info.set_directory("/path/to/file");
                 main_function_info.set_line(6);
-                fibonacci_function_info.set_instrumented(true);
+                main_function_info.set_ir_instruction_count(4);
                 main_function_info.set_instrumented(true);
                 *main_function_info.mutable_created_at() =
                     TimeUtil::NanosecondsToTimestamp(timestamp_1);
@@ -406,6 +413,7 @@ TEST(InjectInstrumentation, OutputsInstrumentedSymbols) {  // NOLINT
                 fibonacci_function_info.set_file_name("fibonacci.m");
                 fibonacci_function_info.set_directory("/path/to/file");
                 fibonacci_function_info.set_line(6);
+                fibonacci_function_info.set_ir_instruction_count(30);
                 fibonacci_function_info.set_instrumented(true);
                 *fibonacci_function_info.mutable_created_at() =
                     TimeUtil::NanosecondsToTimestamp(timestamp_0);
@@ -420,6 +428,7 @@ TEST(InjectInstrumentation, OutputsInstrumentedSymbols) {  // NOLINT
                 main_function_info.set_file_name("fibonacci.m");
                 main_function_info.set_directory("/path/to/file");
                 main_function_info.set_line(12);
+                main_function_info.set_ir_instruction_count(7);
                 main_function_info.set_instrumented(true);
                 *main_function_info.mutable_created_at() =
                     TimeUtil::NanosecondsToTimestamp(timestamp_1);
@@ -452,6 +461,7 @@ TEST(InjectInstrumentation, OutputsInstrumentedSymbols) {  // NOLINT
                 // Swift automatically adds a `main` function and picks the line
                 // number.
                 main_function_info.set_line(1);
+                main_function_info.set_ir_instruction_count(2);
                 main_function_info.set_instrumented(true);
                 *main_function_info.mutable_created_at() =
                     TimeUtil::NanosecondsToTimestamp(timestamp_0);
@@ -467,6 +477,7 @@ TEST(InjectInstrumentation, OutputsInstrumentedSymbols) {  // NOLINT
                 fibonacci_function_info.set_file_name("fibonacci.swift");
                 fibonacci_function_info.set_directory("/path/to/file");
                 fibonacci_function_info.set_line(1);
+                fibonacci_function_info.set_ir_instruction_count(15);
                 fibonacci_function_info.set_instrumented(true);
                 *fibonacci_function_info.mutable_created_at() =
                     TimeUtil::NanosecondsToTimestamp(timestamp_1);
@@ -494,6 +505,7 @@ TEST(InjectInstrumentation, OutputsInstrumentedSymbols) {  // NOLINT
                 main_function_info.set_linkage_name("main");
                 main_function_info.set_demangled_name("main");
                 main_function_info.set_file_name("<compiler-generated>");
+                main_function_info.set_ir_instruction_count(1);
                 main_function_info.set_instrumented(true);
                 *main_function_info.mutable_created_at() =
                     TimeUtil::NanosecondsToTimestamp(timestamp_0);
@@ -521,6 +533,7 @@ TEST(InjectInstrumentation, OutputsInstrumentedSymbols) {  // NOLINT
                 main_function_info.set_demangled_name("main");
                 main_function_info.set_file_name("/path/to/file/main.c");
                 main_function_info.set_line(1);
+                main_function_info.set_ir_instruction_count(1);
                 main_function_info.set_instrumented(true);
                 *main_function_info.mutable_created_at() =
                     TimeUtil::NanosecondsToTimestamp(timestamp_0);
@@ -550,6 +563,7 @@ TEST(InjectInstrumentation, OutputsInstrumentedSymbols) {  // NOLINT
                 main_function_info.set_file_name("file/main.c");
                 main_function_info.set_directory("/path/to");
                 main_function_info.set_line(1);
+                main_function_info.set_ir_instruction_count(1);
                 main_function_info.set_instrumented(true);
                 *main_function_info.mutable_created_at() =
                     TimeUtil::NanosecondsToTimestamp(timestamp_0);
@@ -577,6 +591,7 @@ TEST(InjectInstrumentation, OutputsInstrumentedSymbols) {  // NOLINT
                 main_function_info.set_demangled_name("main");
                 main_function_info.set_file_name("main.c");
                 main_function_info.set_directory("/path/to/file");
+                main_function_info.set_ir_instruction_count(1);
                 main_function_info.set_instrumented(true);
                 *main_function_info.mutable_created_at() =
                     TimeUtil::NanosecondsToTimestamp(timestamp_0);

--- a/spoor/instrumentation/symbols/symbols.proto
+++ b/spoor/instrumentation/symbols/symbols.proto
@@ -14,7 +14,8 @@ message FunctionInfo {
   optional string file_name = 4;
   optional string directory = 5;
   optional int32 line = 6;
-  optional bool instrumented = 7;
+  optional int32 ir_instruction_count = 7;
+  optional bool instrumented = 8;
   optional string instrumented_reason = 9;
   optional google.protobuf.Timestamp created_at = 10;
 }

--- a/spoor/instrumentation/symbols/symbols_file_reader_test.cc
+++ b/spoor/instrumentation/symbols/symbols_file_reader_test.cc
@@ -40,6 +40,7 @@ TEST(SymbolsFileReader, Read) {  // NOLINT
     function_info.set_file_name("file.source");
     function_info.set_directory("/path/to/directory");
     function_info.set_line(42);
+    function_info.set_ir_instruction_count(100);
     function_info.set_instrumented(true);
     *function_info.mutable_created_at() = TimeUtil::NanosecondsToTimestamp(42);
     return symbols;

--- a/spoor/tools/adapters/perfetto/perfetto_adapter_test.cc
+++ b/spoor/tools/adapters/perfetto/perfetto_adapter_test.cc
@@ -367,6 +367,8 @@ TEST(PerfettoAdapter, AdaptsSymbolsToInternedData) {  // NOLINT
   const std::string function_b_directory{"/path/to/b/"};
   constexpr int32 function_a_line_number{1};
   constexpr int32 function_b_line_number{2};
+  constexpr int32 function_a_ir_instruction_count{100};
+  constexpr int32 function_b_ir_instruction_count{200};
 
   const auto symbols = [&] {
     std::vector<std::pair<FunctionId, FunctionInfo>> function_infos{
@@ -380,6 +382,8 @@ TEST(PerfettoAdapter, AdaptsSymbolsToInternedData) {  // NOLINT
               function_info.set_file_name(function_a_file_name);
               function_info.set_directory(function_a_directory);
               function_info.set_line(function_a_line_number);
+              function_info.set_ir_instruction_count(
+                  function_a_ir_instruction_count);
               function_info.set_instrumented(true);
               *function_info.mutable_created_at() =
                   TimeUtil::NanosecondsToTimestamp(1);
@@ -396,6 +400,8 @@ TEST(PerfettoAdapter, AdaptsSymbolsToInternedData) {  // NOLINT
               function_info.set_file_name(function_b_file_name);
               function_info.set_directory(function_b_directory);
               function_info.set_line(function_b_line_number);
+              function_info.set_ir_instruction_count(
+                  function_b_ir_instruction_count);
               function_info.set_instrumented(true);
               *function_info.mutable_created_at() =
                   TimeUtil::NanosecondsToTimestamp(2);
@@ -535,6 +541,8 @@ TEST(PerfettoAdapter, DoesNotAddUnusedFunctionsToInternedData) {  // NOLINT
   const std::string function_b_directory{"/path/to/b/"};
   constexpr int32 function_a_line_number{1};
   constexpr int32 function_b_line_number{2};
+  constexpr int32 function_a_ir_instruction_count{100};
+  constexpr int32 function_b_ir_instruction_count{200};
 
   const auto symbols = [&] {
     std::vector<std::pair<FunctionId, FunctionInfo>> function_infos{
@@ -548,6 +556,8 @@ TEST(PerfettoAdapter, DoesNotAddUnusedFunctionsToInternedData) {  // NOLINT
               function_info.set_file_name(function_a_file_name);
               function_info.set_directory(function_a_directory);
               function_info.set_line(function_a_line_number);
+              function_info.set_ir_instruction_count(
+                  function_a_ir_instruction_count);
               function_info.set_instrumented(true);
               *function_info.mutable_created_at() =
                   TimeUtil::NanosecondsToTimestamp(1);
@@ -564,6 +574,8 @@ TEST(PerfettoAdapter, DoesNotAddUnusedFunctionsToInternedData) {  // NOLINT
               function_info.set_file_name(function_b_file_name);
               function_info.set_directory(function_b_directory);
               function_info.set_line(function_b_line_number);
+              function_info.set_ir_instruction_count(
+                  function_b_ir_instruction_count);
               function_info.set_instrumented(true);
               *function_info.mutable_created_at() =
                   TimeUtil::NanosecondsToTimestamp(2);
@@ -665,6 +677,8 @@ TEST(PerfettoAdapter, HandlesMultipleFunctionInfosForSingleFunctionId) {
   const std::string function_b_directory{"/path/to/b/"};
   constexpr int32 function_a_line_number{1};
   constexpr int32 function_b_line_number{2};
+  constexpr int32 function_a_ir_instruction_count{100};
+  constexpr int32 function_b_ir_instruction_count{200};
 
   const auto symbols = [&] {
     std::vector<std::pair<FunctionId, FunctionInfo>> function_infos{
@@ -678,6 +692,8 @@ TEST(PerfettoAdapter, HandlesMultipleFunctionInfosForSingleFunctionId) {
               function_info.set_file_name(function_a_file_name);
               function_info.set_directory(function_a_directory);
               function_info.set_line(function_a_line_number);
+              function_info.set_ir_instruction_count(
+                  function_a_ir_instruction_count);
               function_info.set_instrumented(true);
               *function_info.mutable_created_at() =
                   TimeUtil::NanosecondsToTimestamp(1);
@@ -694,6 +710,8 @@ TEST(PerfettoAdapter, HandlesMultipleFunctionInfosForSingleFunctionId) {
               function_info.set_file_name(function_b_file_name);
               function_info.set_directory(function_b_directory);
               function_info.set_line(function_b_line_number);
+              function_info.set_ir_instruction_count(
+                  function_b_ir_instruction_count);
               function_info.set_instrumented(true);
               *function_info.mutable_created_at() =
                   TimeUtil::NanosecondsToTimestamp(2);
@@ -799,6 +817,8 @@ TEST(PerfettoAdapter, HandlesFunctionNameFallback) {  // NOLINT
   const std::string function_b_directory{"/path/to/b/"};
   constexpr int32 function_a_line_number{1};
   constexpr int32 function_b_line_number{2};
+  constexpr int32 function_a_ir_instruction_count{100};
+  constexpr int32 function_b_ir_instruction_count{200};
 
   const auto symbols = [&] {
     std::vector<std::pair<FunctionId, FunctionInfo>> function_infos{
@@ -811,6 +831,8 @@ TEST(PerfettoAdapter, HandlesFunctionNameFallback) {  // NOLINT
               function_info.set_file_name(function_a_file_name);
               function_info.set_directory(function_a_directory);
               function_info.set_line(function_a_line_number);
+              function_info.set_ir_instruction_count(
+                  function_a_ir_instruction_count);
               function_info.set_instrumented(true);
               *function_info.mutable_created_at() =
                   TimeUtil::NanosecondsToTimestamp(1);
@@ -825,6 +847,8 @@ TEST(PerfettoAdapter, HandlesFunctionNameFallback) {  // NOLINT
               function_info.set_file_name(function_b_file_name);
               function_info.set_directory(function_b_directory);
               function_info.set_line(function_b_line_number);
+              function_info.set_ir_instruction_count(
+                  function_b_ir_instruction_count);
               function_info.set_instrumented(true);
               *function_info.mutable_created_at() =
                   TimeUtil::NanosecondsToTimestamp(2);
@@ -963,6 +987,7 @@ TEST(PerfettoAdapter, TruncatesLongNames) {  // NOLINT
   const auto expected_file_name = absl::StrCat(
       directory, std::string(1'024 - directory.size() - 3, 'x'), "...");
   constexpr int32 line_number{1};
+  constexpr int32 ir_instruction_count{100};
 
   const auto symbols = [&] {
     std::vector<std::pair<FunctionId, FunctionInfo>> function_infos{{
@@ -975,6 +1000,7 @@ TEST(PerfettoAdapter, TruncatesLongNames) {  // NOLINT
           function_info.set_file_name(file_name);
           function_info.set_directory(directory);
           function_info.set_line(line_number);
+          function_info.set_ir_instruction_count(ir_instruction_count);
           function_info.set_instrumented(true);
           *function_info.mutable_created_at() =
               TimeUtil::NanosecondsToTimestamp(1);

--- a/spoor/tools/serialization/csv/csv.cc
+++ b/spoor/tools/serialization/csv/csv.cc
@@ -27,7 +27,7 @@ using instrumentation::symbols::Symbols;
 using spoor::runtime::trace::FunctionId;
 using Result = util::result::Result<util::result::None, util::result::None>;
 
-constexpr std::array<std::string_view, 10> kSpoorSymbolsColumns{{
+constexpr std::array<std::string_view, 11> kSpoorSymbolsColumns{{
     "function_id",
     "module_id",
     "linkage_name",
@@ -35,6 +35,7 @@ constexpr std::array<std::string_view, 10> kSpoorSymbolsColumns{{
     "file_name",
     "directory",
     "line",
+    "ir_instruction_count",
     "instrumented",
     "instrumented_reason",
     "created_at",
@@ -66,6 +67,7 @@ auto SerializeSymbolsToOstreamAsCsv(const Symbols& symbols,
           function_info.file_name(),
           function_info.directory(),
           function_info.line() < 1 ? "" : absl::StrCat(function_info.line()),
+          absl::StrCat(function_info.ir_instruction_count()),
           function_info.instrumented() ? "true" : "false",
           function_info.instrumented_reason(),
           TimeUtil::ToString(function_info.created_at()),

--- a/spoor/tools/serialization/csv/csv_test.cc
+++ b/spoor/tools/serialization/csv/csv_test.cc
@@ -30,6 +30,7 @@ TEST(SerializeSymbolsToOstreamAsCsv, SerializesToCsv) {  // NOLINT
     function_a_info->set_file_name("file_a.source");
     function_a_info->set_directory("/path/to/a");
     function_a_info->set_line(1);
+    function_a_info->set_ir_instruction_count(100);
     function_a_info->set_instrumented(true);
     function_a_info->set_instrumented_reason("Rule A");
     *function_a_info->mutable_created_at() =
@@ -45,6 +46,7 @@ TEST(SerializeSymbolsToOstreamAsCsv, SerializesToCsv) {  // NOLINT
     function_c_info->set_file_name("file_c.source");
     function_c_info->set_directory("/path/to/c");
     function_c_info->set_line(42);
+    function_c_info->set_ir_instruction_count(200);
     function_c_info->set_instrumented(false);
     function_c_info->set_instrumented_reason("Rule C");
     *function_c_info->mutable_created_at() =
@@ -54,12 +56,13 @@ TEST(SerializeSymbolsToOstreamAsCsv, SerializesToCsv) {  // NOLINT
   }();
   const std::string expected_csv{
       "function_id;module_id;linkage_name;demangled_name;file_name;directory;"
-      "line;instrumented;instrumented_reason;created_at\n"
+      "line;ir_instruction_count;instrumented;instrumented_reason;created_at\n"
       "0x0000000000000f;module_a;function_a;FunctionA(int x, int y);"
-      "file_a.source;/path/to/a;1;true;Rule A;1970-01-01T00:00:00.000000001Z\n"
-      "0x0000000000000f;;;;;;;false;;1970-01-01T00:00:00Z\n"
+      "file_a.source;/path/to/a;1;100;true;Rule "
+      "A;1970-01-01T00:00:00.000000001Z\n"
+      "0x0000000000000f;;;;;;;0;false;;1970-01-01T00:00:00Z\n"
       "0x00000000000010;module_c;function_c;FunctionC();file_c.source;"
-      "/path/to/c;42;false;Rule C;1970-01-01T00:00:00.000000042Z"};
+      "/path/to/c;42;200;false;Rule C;1970-01-01T00:00:00.000000042Z"};
   std::stringstream buffer{};
   const auto result = SerializeSymbolsToOstreamAsCsv(symbols, &buffer);
   ASSERT_TRUE(result.IsOk());

--- a/spoor/tools/serialization/serialize_test.cc
+++ b/spoor/tools/serialization/serialize_test.cc
@@ -150,6 +150,7 @@ TEST(SerializeToOstream, SerializesToOstream) {  // NOLINT
     function_info->set_file_name("file_a.source");
     function_info->set_directory("/path/to/a/");
     function_info->set_line(1);
+    function_info->set_ir_instruction_count(100);
     function_info->set_instrumented(true);
     *function_info->mutable_created_at() = TimeUtil::NanosecondsToTimestamp(0);
     return symbols;


### PR DESCRIPTION
Adds the IR instruction count for each function to its Spoor symbols data. This is useful during offline analysis, for example, to determine a function filtering threshold based on the instruction count distribution.