### PR TITLE
Remove -std=c++2a in Apple runtime wrapper

### DIFF
--- a/spoor/runtime/wrappers/apple/BUILD
+++ b/spoor/runtime/wrappers/apple/BUILD
@@ -19,12 +19,9 @@ _MINIMUM_IOS_VERSION = "13.0"
 
 _MINIMUM_MACOS_VERSION = "10.15"
 
-_LIB_COPTS = SPOOR_DEFAULT_COPTS + [
-    "-std=c++2a",
-]
+_LIB_COPTS = SPOOR_DEFAULT_COPTS
 
 _TEST_COPTS = SPOOR_DEFAULT_TEST_COPTS + [
-    "-std=c++2a",
     "-Wno-gnu-statement-expression",
 ]
 


### PR DESCRIPTION
Removes `-std=c++2a` in the Apple runtime wrapper since `-std=c++20` is now specified in `config.bzl`.