### PR TITLE
Upgrade LLVM to 12.0.1

### DIFF
--- a/.build/azure-pipelines.yml
+++ b/.build/azure-pipelines.yml
@@ -13,7 +13,6 @@ jobs:
     matrix:
       mac:
         imageName: 'internal-macos-11'
-        xcodeVersion: 13.0
   pool:
     vmImage: $(imageName)
   steps:

--- a/.build/templates/install-common.yml
+++ b/.build/templates/install-common.yml
@@ -3,18 +3,17 @@
 
 steps:
 - script: |
+    sudo xcode-select --switch /Applications/Xcode_13.0.app
+    ln -sfn /Applications/Xcode_13.0.app /Applications/Xcode.app
+  displayName: Set Xcode version
+  condition: eq(variables['Agent.OS'], 'Darwin')
+- script: |
     wget https://apt.llvm.org/llvm.sh
     chmod +x llvm.sh
     sudo ./llvm.sh 12
-    sudo ./llvm.sh 11
   displayName: Install LLVM (Linux)
   condition: eq(variables['Agent.OS'], 'Linux')
-- script: |
-    brew install llvm@11
-    brew install llvm@12
-    echo '##vso[task.prependpath]/usr/local/opt/llvm@12/bin'
-    # The default compiler is added last.
-    echo '##vso[task.prependpath]/usr/local/opt/llvm@11/bin'
+- script: echo '##vso[task.prependpath]/usr/local/opt/llvm@12/bin'
   displayName: Install LLVM (macOS)
   condition: eq(variables['Agent.OS'], 'Darwin')
 - script: pip3 install pylint yapf

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -38,17 +38,28 @@ pip_install(
 # TODO(#133): Use LLVM's Bazel build configuration when it is checked in.
 http_archive(
     name = "com_google_llvm_bazel",
-    sha256 = "2eb64e813477e8009f4813aae5ae7f95090585a9a06f2437007e387551769dea",
-    strip_prefix = "llvm-bazel-lelandjansen-llvm-11.1.0/llvm-bazel",
-    url = "https://github.com/lelandjansen/llvm-bazel/archive/refs/heads/lelandjansen/llvm-11.1.0.tar.gz",
+    sha256 = "0aafa2c2f8d30d9cc7b88b3dd64137e510a2193003fce220020417b71f8e158e",
+    strip_prefix = "llvm-bazel-lelandjansen-llvm-12.0.1/llvm-bazel",
+    url = "https://github.com/lelandjansen/llvm-bazel/archive/refs/heads/lelandjansen/llvm-12.0.1.tar.gz",
 )
 
 http_archive(
     name = "org_llvm_llvm_project",
     build_file_content = "#empty",
-    sha256 = "d4dbca22c0056847a89d4335c172ecc14db8ef7c60f3a639b3cb91cb82961900",
-    strip_prefix = "llvm-project-1fdec59bffc11ae37eb51a1b9869f0696bfd5312",
-    url = "https://github.com/llvm/llvm-project/archive/1fdec59bffc11ae37eb51a1b9869f0696bfd5312.tar.gz",
+    patch_cmds = [
+        """
+        if [[ "$OSTYPE" == "darwin"* ]]; then
+          sed -i '' 's|#include "llvm/Transforms/HelloNew/HelloWorld.h"||g' llvm/lib/Passes/PassBuilder.cpp
+          sed -i '' 's|FUNCTION_PASS("helloworld", HelloWorldPass())||g' llvm/lib/Passes/PassRegistry.def
+        else
+          sed -i 's|#include "llvm/Transforms/HelloNew/HelloWorld.h"||g' llvm/lib/Passes/PassBuilder.cpp
+          sed -i 's|FUNCTION_PASS("helloworld", HelloWorldPass())||g' llvm/lib/Passes/PassRegistry.def
+        fi
+        """,
+    ],
+    sha256 = "66b64aa301244975a4aea489f402f205cde2f53dd722dad9e7b77a0459b4c8df",
+    strip_prefix = "llvm-project-llvmorg-12.0.1",
+    url = "https://github.com/llvm/llvm-project/archive/refs/tags/llvmorg-12.0.1.tar.gz",
 )
 
 load("@com_google_llvm_bazel//:terminfo.bzl", "llvm_terminfo_disable")

--- a/spoor/instrumentation/config/config.h
+++ b/spoor/instrumentation/config/config.h
@@ -17,7 +17,9 @@ enum class OutputLanguage {
   kIr,
 };
 
-struct Config {
+// Prefer alphabetization readability over optimal struct ordering for this
+// single-use config. NOLINTNEXTLINE(clang-analyzer-optin.performance.Padding)
+struct alignas(128) Config {
   // Alphabetized to match the order printed in --help.
   bool enable_runtime;
   std::optional<std::string> filters_file;

--- a/spoor/instrumentation/filters/filters.h
+++ b/spoor/instrumentation/filters/filters.h
@@ -11,14 +11,14 @@
 
 namespace spoor::instrumentation::filters {
 
-struct FunctionInfo {
+struct alignas(128) FunctionInfo {
   std::string source_file_path;
   std::string demangled_name;
   std::string linkage_name;
   int32 ir_instruction_count;
 };
 
-struct Filter {
+struct alignas(128) Filter {
   enum class Action {
     kAllow,
     kBlock,
@@ -46,7 +46,7 @@ auto operator==(const Filter& lhs, const Filter& rhs) -> bool;
 
 class Filters {
  public:
-  struct InstrumentFunctionResult {
+  struct alignas(64) InstrumentFunctionResult {
     bool instrument;
     std::optional<std::string> active_filter_rule_name;
   };

--- a/spoor/instrumentation/filters/filters_file_reader.cc
+++ b/spoor/instrumentation/filters/filters_file_reader.cc
@@ -13,6 +13,7 @@
 #include "gsl/gsl"
 #include "spoor/instrumentation/filters/filters.h"
 #include "tomlplusplus/toml.h"
+#include "util/result.h"
 
 namespace spoor::instrumentation::filters {
 
@@ -60,84 +61,91 @@ auto FiltersFileReader::Read(const std::filesystem::path& file_path) const
       };
     }
     for (const auto& element : *array) {
-      const auto* table = element.as_table();
-      if (table == nullptr) {
-        return Error{
-            .type = Error::Type::kMalformedNode,
-            .message = absl::StrFormat(
-                "Malformed node \"%s\" is not a list of filters.", key),
-        };
-      }
-
-      for (const auto& [rule, _] : *table) {
-        if (std::find(std::cbegin(kFilterKeys), std::cend(kFilterKeys), rule) ==
-            std::cend(kFilterKeys)) {
-          return Error{
-              .type = Error::Type::kUnknownNode,
-              .message = absl::StrFormat(R"(Unknown rule "%s" in filter "%s".)",
-                                         rule, key),
-          };
-        }
-      }
-
-      std::optional<std::string> rule_name{};
-      const auto* table_rule_name = table->get(kRuleNameKey);
-      if (table_rule_name != nullptr) {
-        rule_name = table_rule_name->value<std::string>();
-      }
-
-      std::optional<std::string> source_file_path{};
-      const auto* table_source_file_path = table->get(kSourceFilePathKey);
-      if (table_source_file_path != nullptr) {
-        source_file_path = table_source_file_path->value<std::string>();
-      }
-
-      std::optional<std::string> function_demangled_name{};
-      const auto* table_function_demangled_name =
-          table->get(kFunctionDemangledNameKey);
-      if (table_function_demangled_name != nullptr) {
-        function_demangled_name =
-            table_function_demangled_name->value<std::string>();
-      }
-
-      std::optional<std::string> function_linkage_name{};
-      const auto* table_function_linkage_name =
-          table->get(kFunctionLinkageNameKey);
-      if (table_function_linkage_name != nullptr) {
-        function_linkage_name =
-            table_function_linkage_name->value<std::string>();
-      }
-
-      std::optional<uint32> function_ir_instruction_count_lt{};
-      const auto* table_function_ir_instruction_count_lt =
-          table->get(kFunctionIrInstructionCountLtKey);
-      if (table_function_ir_instruction_count_lt != nullptr) {
-        function_ir_instruction_count_lt =
-            table_function_ir_instruction_count_lt->value<uint32>();
-      }
-
-      std::optional<uint32> function_ir_instruction_count_gt{};
-      const auto* table_function_ir_instruction_count_gt =
-          table->get(kFunctionIrInstructionCountGtKey);
-      if (table_function_ir_instruction_count_gt != nullptr) {
-        function_ir_instruction_count_gt =
-            table_function_ir_instruction_count_gt->value<uint32>();
-      }
-
-      Filter filter{
-          .action = action.value(),
-          .rule_name = rule_name,
-          .source_file_path = source_file_path,
-          .function_demangled_name = function_demangled_name,
-          .function_linkage_name = function_linkage_name,
-          .function_ir_instruction_count_lt = function_ir_instruction_count_lt,
-          .function_ir_instruction_count_gt = function_ir_instruction_count_gt,
-      };
+      auto result = ParseFilter(action.value(), key, element);
+      if (result.IsErr()) return result.Err();
+      auto& filter = result.Ok();
       filters.emplace_back(std::move(filter));
     }
   }
 
   return Filters{filters};
+}
+
+auto FiltersFileReader::ParseFilter(const Filter::Action action,
+                                    const std::string_view key,
+                                    const toml::node& node)
+    -> util::result::Result<Filter, Error> {
+  const auto* table = node.as_table();
+  if (table == nullptr) {
+    return Error{
+        .type = Error::Type::kMalformedNode,
+        .message = absl::StrFormat(
+            "Malformed node \"%s\" is not a list of filters.", key),
+    };
+  }
+
+  for (const auto& [rule, _] : *table) {
+    if (std::find(std::cbegin(kFilterKeys), std::cend(kFilterKeys), rule) ==
+        std::cend(kFilterKeys)) {
+      return Error{
+          .type = Error::Type::kUnknownNode,
+          .message = absl::StrFormat(R"(Unknown rule "%s" in filter "%s".)",
+                                     rule, key),
+      };
+    }
+  }
+
+  std::optional<std::string> rule_name{};
+  const auto* table_rule_name = table->get(kRuleNameKey);
+  if (table_rule_name != nullptr) {
+    rule_name = table_rule_name->value<std::string>();
+  }
+
+  std::optional<std::string> source_file_path{};
+  const auto* table_source_file_path = table->get(kSourceFilePathKey);
+  if (table_source_file_path != nullptr) {
+    source_file_path = table_source_file_path->value<std::string>();
+  }
+
+  std::optional<std::string> function_demangled_name{};
+  const auto* table_function_demangled_name =
+      table->get(kFunctionDemangledNameKey);
+  if (table_function_demangled_name != nullptr) {
+    function_demangled_name =
+        table_function_demangled_name->value<std::string>();
+  }
+
+  std::optional<std::string> function_linkage_name{};
+  const auto* table_function_linkage_name = table->get(kFunctionLinkageNameKey);
+  if (table_function_linkage_name != nullptr) {
+    function_linkage_name = table_function_linkage_name->value<std::string>();
+  }
+
+  std::optional<uint32> function_ir_instruction_count_lt{};
+  const auto* table_function_ir_instruction_count_lt =
+      table->get(kFunctionIrInstructionCountLtKey);
+  if (table_function_ir_instruction_count_lt != nullptr) {
+    function_ir_instruction_count_lt =
+        table_function_ir_instruction_count_lt->value<uint32>();
+  }
+
+  std::optional<uint32> function_ir_instruction_count_gt{};
+  const auto* table_function_ir_instruction_count_gt =
+      table->get(kFunctionIrInstructionCountGtKey);
+  if (table_function_ir_instruction_count_gt != nullptr) {
+    function_ir_instruction_count_gt =
+        table_function_ir_instruction_count_gt->value<uint32>();
+  }
+
+  return Filter{
+      .action = action,
+      .rule_name = rule_name,
+      .source_file_path = source_file_path,
+      .function_demangled_name = function_demangled_name,
+      .function_linkage_name = function_linkage_name,
+      .function_ir_instruction_count_lt = function_ir_instruction_count_lt,
+      .function_ir_instruction_count_gt = function_ir_instruction_count_gt,
+  };
 }
 
 }  // namespace spoor::instrumentation::filters

--- a/spoor/instrumentation/filters/filters_file_reader.h
+++ b/spoor/instrumentation/filters/filters_file_reader.h
@@ -9,6 +9,7 @@
 
 #include "spoor/instrumentation/filters/filters.h"
 #include "spoor/instrumentation/filters/filters_reader.h"
+#include "tomlplusplus/toml.h"
 #include "util/file_system/file_reader.h"
 #include "util/flat_map/flat_map.h"
 #include "util/result.h"
@@ -53,6 +54,10 @@ class FiltersFileReader : public FiltersReader {
 
  private:
   Options options_;
+
+  static auto ParseFilter(Filter::Action action, std::string_view key,
+                          const toml::node& node)
+      -> util::result::Result<Filter, Error>;
 };
 
 }  // namespace spoor::instrumentation::filters

--- a/spoor/instrumentation/filters/filters_reader.h
+++ b/spoor/instrumentation/filters/filters_reader.h
@@ -13,7 +13,7 @@ namespace spoor::instrumentation::filters {
 
 class FiltersReader {
  public:
-  struct Error {
+  struct alignas(32) Error {
     enum class Type {
       kFailedToOpenFile,
       kMalformedFile,

--- a/spoor/instrumentation/filters/filters_test.cc
+++ b/spoor/instrumentation/filters/filters_test.cc
@@ -16,7 +16,7 @@ using spoor::instrumentation::filters::Filter;
 using spoor::instrumentation::filters::Filters;
 using spoor::instrumentation::filters::FunctionInfo;
 
-struct TestCase {
+struct alignas(128) TestCase {
   FunctionInfo function_info;
   bool instrument;
   std::optional<std::string> active_filter_rule_name;

--- a/spoor/instrumentation/inject_instrumentation/inject_instrumentation.cc
+++ b/spoor/instrumentation/inject_instrumentation/inject_instrumentation.cc
@@ -175,7 +175,8 @@ auto InjectInstrumentation::InstrumentModule(
     function_info.set_demangled_name(demangled_name);
 
     const auto ir_instruction_count = function.getInstructionCount();
-    function_info.set_ir_instruction_count(ir_instruction_count);
+    function_info.set_ir_instruction_count(
+        gsl::narrow_cast<google::protobuf::int32>(ir_instruction_count));
 
     const auto* subprogram = function.getSubprogram();
     const auto directory =

--- a/spoor/instrumentation/inject_instrumentation/inject_instrumentation.h
+++ b/spoor/instrumentation/inject_instrumentation/inject_instrumentation.h
@@ -31,7 +31,7 @@ namespace spoor::instrumentation::inject_instrumentation {
 class InjectInstrumentation
     : public llvm::PassInfoMixin<InjectInstrumentation> {
  public:
-  struct Options {
+  struct alignas(128) Options {
     bool inject_instrumentation;
     std::unique_ptr<filters::FiltersReader> filters_reader;
     std::unique_ptr<symbols::SymbolsWriter> symbols_writer;
@@ -61,7 +61,7 @@ class InjectInstrumentation
       -> llvm::PreservedAnalyses;
 
  private:
-  struct InstrumentModuleResult {
+  struct alignas(128) InstrumentModuleResult {
     symbols::Symbols symbols;
     bool modified;
   };

--- a/spoor/instrumentation/inject_instrumentation/inject_instrumentation_test.cc
+++ b/spoor/instrumentation/inject_instrumentation/inject_instrumentation_test.cc
@@ -124,7 +124,7 @@ MATCHER_P(SymbolsEq, expected, "Symbols are not equal.") {  // NOLINT
 }
 
 TEST(InjectInstrumentation, InstrumentsModule) {  // NOLINT
-  struct TestCase {
+  struct alignas(32) TestCase {
     std::string_view expected_ir_file;
     bool initialize_runtime;
     bool enable_runtime;
@@ -180,7 +180,7 @@ TEST(InjectInstrumentation, InstrumentsModule) {  // NOLINT
 }
 
 TEST(InjectInstrumentation, OutputsInstrumentedSymbols) {  // NOLINT
-  struct TestCase {
+  struct alignas(128) TestCase {
     std::string_view ir_file;
     Filters filters;
     std::function<Symbols(const llvm::Module&)> expected_symbols;
@@ -758,7 +758,7 @@ TEST(InjectInstrumentation, FunctionAllowListOverridesBlocklist) {  // NOLINT
 }
 
 TEST(InjectInstrumentation, InstructionThreshold) {  // NOLINT
-  struct TestCaseConfig {
+  struct alignas(32) TestCaseConfig {
     int32 instruction_threshold;
     std::string_view expected_ir_file;
   };
@@ -886,7 +886,7 @@ TEST(InjectInstrumentation, DoNotInjectInstrumentationConfig) {  // NOLINT
 }
 
 TEST(InjectInstrumentation, ReturnValue) {  // NOLINT
-  struct TestCaseConfig {
+  struct alignas(32) TestCaseConfig {
     Filters filters;
     bool are_all_preserved;
   };

--- a/spoor/instrumentation/instrumentation_test.cc
+++ b/spoor/instrumentation/instrumentation_test.cc
@@ -11,9 +11,9 @@
 
 namespace {
 
-using FunctionSymbolsMapType = std::remove_reference_t<decltype(
-    std::declval<spoor::instrumentation::symbols::Symbols>()
-        .function_symbols_table())>;
+using FunctionSymbolsMapType = std::remove_reference_t<
+    decltype(std::declval<spoor::instrumentation::symbols::Symbols>()
+                 .function_symbols_table())>;
 
 static_assert(std::is_same_v<spoor::instrumentation::FunctionId,
                              FunctionSymbolsMapType::key_type>);

--- a/spoor/instrumentation/test_data/fib_instrumented.ll
+++ b/spoor/instrumentation/test_data/fib_instrumented.ll
@@ -2,7 +2,7 @@
 ; Licensed under the MIT License.
 
 define i32 @_Z9Fibonaccii(i32 %0) {
-  call void @_spoor_runtime_LogFunctionEntry(i64 -166068037236031488)
+  call void @_spoor_runtime_LogFunctionEntry(i64 -5636857539040641024)
   %2 = icmp slt i32 %0, 2
   br i1 %2, label %9, label %3
 3:
@@ -11,17 +11,17 @@ define i32 @_Z9Fibonaccii(i32 %0) {
   %6 = add nsw i32 %0, -2
   %7 = tail call i32 @_Z9Fibonaccii(i32 %6)
   %8 = add nsw i32 %7, %5
-  call void @_spoor_runtime_LogFunctionExit(i64 -166068037236031488)
+  call void @_spoor_runtime_LogFunctionExit(i64 -5636857539040641024)
   ret i32 %8
 9:
-  call void @_spoor_runtime_LogFunctionExit(i64 -166068037236031488)
+  call void @_spoor_runtime_LogFunctionExit(i64 -5636857539040641024)
   ret i32 %0
 }
 
 define i32 @main() {
-  call void @_spoor_runtime_LogFunctionEntry(i64 -166068037236031487)
+  call void @_spoor_runtime_LogFunctionEntry(i64 -5636857539040641023)
   %1 = tail call i32 @_Z9Fibonaccii(i32 7)
-  call void @_spoor_runtime_LogFunctionExit(i64 -166068037236031487)
+  call void @_spoor_runtime_LogFunctionExit(i64 -5636857539040641023)
   call void @_spoor_runtime_Deinitialize()
   ret i32 %1
 }

--- a/spoor/instrumentation/test_data/fib_instrumented_initialized.ll
+++ b/spoor/instrumentation/test_data/fib_instrumented_initialized.ll
@@ -2,7 +2,7 @@
 ; Licensed under the MIT License.
 
 define i32 @_Z9Fibonaccii(i32 %0) {
-  call void @_spoor_runtime_LogFunctionEntry(i64 -166068037236031488)
+  call void @_spoor_runtime_LogFunctionEntry(i64 -5636857539040641024)
   %2 = icmp slt i32 %0, 2
   br i1 %2, label %9, label %3
 3:
@@ -11,18 +11,18 @@ define i32 @_Z9Fibonaccii(i32 %0) {
   %6 = add nsw i32 %0, -2
   %7 = tail call i32 @_Z9Fibonaccii(i32 %6)
   %8 = add nsw i32 %7, %5
-  call void @_spoor_runtime_LogFunctionExit(i64 -166068037236031488)
+  call void @_spoor_runtime_LogFunctionExit(i64 -5636857539040641024)
   ret i32 %8
 9:
-  call void @_spoor_runtime_LogFunctionExit(i64 -166068037236031488)
+  call void @_spoor_runtime_LogFunctionExit(i64 -5636857539040641024)
   ret i32 %0
 }
 
 define i32 @main() {
   call void @_spoor_runtime_Initialize()
-  call void @_spoor_runtime_LogFunctionEntry(i64 -166068037236031487)
+  call void @_spoor_runtime_LogFunctionEntry(i64 -5636857539040641023)
   %1 = tail call i32 @_Z9Fibonaccii(i32 7)
-  call void @_spoor_runtime_LogFunctionExit(i64 -166068037236031487)
+  call void @_spoor_runtime_LogFunctionExit(i64 -5636857539040641023)
   call void @_spoor_runtime_Deinitialize()
   ret i32 %1
 }

--- a/spoor/instrumentation/test_data/fib_instrumented_initialized_enabled.ll
+++ b/spoor/instrumentation/test_data/fib_instrumented_initialized_enabled.ll
@@ -2,7 +2,7 @@
 ; Licensed under the MIT License.
 
 define i32 @_Z9Fibonaccii(i32 %0) {
-  call void @_spoor_runtime_LogFunctionEntry(i64 -166068037236031488)
+  call void @_spoor_runtime_LogFunctionEntry(i64 -5636857539040641024)
   %2 = icmp slt i32 %0, 2
   br i1 %2, label %9, label %3
 3:
@@ -11,19 +11,19 @@ define i32 @_Z9Fibonaccii(i32 %0) {
   %6 = add nsw i32 %0, -2
   %7 = tail call i32 @_Z9Fibonaccii(i32 %6)
   %8 = add nsw i32 %7, %5
-  call void @_spoor_runtime_LogFunctionExit(i64 -166068037236031488)
+  call void @_spoor_runtime_LogFunctionExit(i64 -5636857539040641024)
   ret i32 %8
 9:
-  call void @_spoor_runtime_LogFunctionExit(i64 -166068037236031488)
+  call void @_spoor_runtime_LogFunctionExit(i64 -5636857539040641024)
   ret i32 %0
 }
 
 define i32 @main() {
   call void @_spoor_runtime_Initialize()
   call void @_spoor_runtime_Enable()
-  call void @_spoor_runtime_LogFunctionEntry(i64 -166068037236031487)
+  call void @_spoor_runtime_LogFunctionEntry(i64 -5636857539040641023)
   %1 = tail call i32 @_Z9Fibonaccii(i32 7)
-  call void @_spoor_runtime_LogFunctionExit(i64 -166068037236031487)
+  call void @_spoor_runtime_LogFunctionExit(i64 -5636857539040641023)
   call void @_spoor_runtime_Deinitialize()
   ret i32 %1
 }

--- a/spoor/instrumentation/test_data/fib_only_main_instrumented.ll
+++ b/spoor/instrumentation/test_data/fib_only_main_instrumented.ll
@@ -16,9 +16,9 @@ define i32 @_Z9Fibonaccii(i32 %0) {
 }
 
 define i32 @main() {
-  call void @_spoor_runtime_LogFunctionEntry(i64 -166068037236031487)
+  call void @_spoor_runtime_LogFunctionEntry(i64 -5636857539040641023)
   %1 = tail call i32 @_Z9Fibonaccii(i32 7)
-  call void @_spoor_runtime_LogFunctionExit(i64 -166068037236031487)
+  call void @_spoor_runtime_LogFunctionExit(i64 -5636857539040641023)
   call void @_spoor_runtime_Deinitialize()
   ret i32 %1
 }

--- a/spoor/integration_test.sh
+++ b/spoor/integration_test.sh
@@ -13,8 +13,8 @@ OUTPUT_EXECUTABLE_FILE="fib"
 OUTPUT_PERFETTO_FILE="trace.perfetto"
 TRACE_PROCESSOR_QUERY_FILE="query_result.txt"
 
-if command -v clang++-11 &> /dev/null; then
-  CLANGXX="clang++-11"
+if command -v clang++-12 &> /dev/null; then
+  CLANGXX="clang++-12"
 elif command -v clang++ &> /dev/null; then
   CLANGXX="clang++"
 else

--- a/spoor/runtime/trace/trace_file_writer.h
+++ b/spoor/runtime/trace/trace_file_writer.h
@@ -17,7 +17,7 @@ namespace spoor::runtime::trace {
 
 class TraceFileWriter final : public TraceWriter {
  public:
-  struct Options {
+  struct alignas(32) Options {
     std::unique_ptr<util::file_system::FileWriter> file_writer;
     util::compression::Strategy compression_strategy;
     util::compression::Compressor::SizeType initial_buffer_capacity;

--- a/spoor/tools/adapters/perfetto/perfetto_adapter.cc
+++ b/spoor/tools/adapters/perfetto/perfetto_adapter.cc
@@ -245,9 +245,10 @@ auto SpoorTraceToPerfettoTrace(const std::vector<SpoorTraceFile>& trace_files,
     const auto& symbols_table = symbols.function_symbols_table();
     auto* interned_data = packet.mutable_interned_data();
     auto* event_names = interned_data->mutable_event_names();
-    event_names->Reserve(called_function_ids.size());
+    event_names->Reserve(gsl::narrow_cast<int>(called_function_ids.size()));
     auto* source_locations = interned_data->mutable_source_locations();
-    source_locations->Reserve(called_function_ids.size());
+    source_locations->Reserve(
+        gsl::narrow_cast<int>(called_function_ids.size()));
     std::for_each(
         std::cbegin(symbols_table), std::cend(symbols_table),
         [&](const auto& key_value) {

--- a/spoor/tools/config/config.h
+++ b/spoor/tools/config/config.h
@@ -17,7 +17,7 @@ enum class OutputFormat {
   kSpoorSymbolsCsv,
 };
 
-struct Config {
+struct alignas(32) Config {
   // Alphabetized to match the order printed in --help.
   std::string output_file;
   OutputFormat output_format;
@@ -32,7 +32,7 @@ constexpr util::flat_map::FlatMap<std::string_view, OutputFormat, 4>
     };
 
 constexpr std::string_view kOutputFileDoc{"Output file."};
-constexpr std::string_view kOutputFileDefaultValue{""};
+constexpr std::string_view kOutputFileDefaultValue{};
 
 constexpr std::string_view kOutputFormatDoc{
     "Data output format. Options: %s. \"automatic\" detects the format from "

--- a/spoor/tools/spoor.cc
+++ b/spoor/tools/spoor.cc
@@ -59,6 +59,7 @@ constexpr std::string_view kUsage{
 
 }  // namespace
 
+// Sorry. NOLINTNEXTLINE(readability-function-cognitive-complexity)
 auto main(const int argc, char** argv) -> int {
   const auto short_program_invocation_name = [argc, argv] {
     const gsl::span<char*> args{argv,

--- a/toolchain/xcode/ToolchainInfo.plist
+++ b/toolchain/xcode/ToolchainInfo.plist
@@ -11,7 +11,7 @@
     <key>CompatibilityVersion</key>
     <integer>2</integer>
     <key>CompatibilityVersionDisplayString</key>
-    <string>Xcode 12.5+</string>
+    <string>Xcode 13.0</string>
     <key>DisplayName</key>
     <string>Spoor</string>
     <key>ReportProblemURL</key>

--- a/toolchain/xcode/instrument_ios_app_test.sh
+++ b/toolchain/xcode/instrument_ios_app_test.sh
@@ -8,7 +8,7 @@ export HOME="$(pwd)"
 APP_PATH="$(pwd)/$APP_RELATIVE_PATH"
 DESTINATION="platform=iOS Simulator,name=iPhone 12"
 CONFIGURATION="Debug"
-XCODE_TOOLCHAINS_PATH="$HOME/Library/Developer/Toolchains"
+XCODE_USER_TOOLCHAINS_PATH="$HOME/Library/Developer/Toolchains"
 SPOOR_TOOLCHAIN_PATH="$(pwd)/toolchain/xcode/$TOOLCHAIN_NAME"
 DERIVED_DATA_PATH="$(pwd)/DerivedData"
 OBJECT_FILE_PATH="$DERIVED_DATA_PATH/Build/Intermediates.noindex/$APP_NAME.build/$CONFIGURATION-iphonesimulator/$APP_NAME.build/Objects-normal"
@@ -16,7 +16,7 @@ BINARY_FILE_PATH="$DERIVED_DATA_PATH/Build/Products/$CONFIGURATION-iphonesimulat
 
 function clean_up {
   rm -rf "$DERIVED_DATA_PATH"
-  rm -rf "$XCODE_TOOLCHAINS_PATH"
+  rm -rf "$XCODE_USER_TOOLCHAINS_PATH"
 }
 
 # Manually clean up artifacts because the this test cannot be run in a sandbox.
@@ -33,12 +33,11 @@ find "$APP_PATH" -name '*__SPACE__*' -print0 |
     done
 
 mkdir -p "$DERIVED_DATA_PATH"
-mkdir -p "$XCODE_TOOLCHAINS_PATH"
-ln -s "$SPOOR_TOOLCHAIN_PATH" "$XCODE_TOOLCHAINS_PATH/$TOOLCHAIN_NAME"
+mkdir -p "$XCODE_USER_TOOLCHAINS_PATH"
+ln -s "$SPOOR_TOOLCHAIN_PATH" "$XCODE_USER_TOOLCHAINS_PATH/$TOOLCHAIN_NAME"
 
 xcodebuild \
   clean build \
-  -quiet \
   -configuration "$CONFIGURATION" \
   -destination "$DESTINATION" \
   -derivedDataPath "$DERIVED_DATA_PATH" \


### PR DESCRIPTION
* Upgrades LLVM to 12.0.1 upon which Xcode 13's tools (e.g., Apple Clang) are based.
* Resolves new lint errors.
* Fixes upgrading CI to Xcode 13 (the technique from #187 is incorrect).