### PR TITLE
Explicit macOS LLVM 12 toolchain paths

### DIFF
--- a/.build/templates/install-common.yml
+++ b/.build/templates/install-common.yml
@@ -13,7 +13,10 @@ steps:
     sudo ./llvm.sh 12
   displayName: Install LLVM (Linux)
   condition: eq(variables['Agent.OS'], 'Linux')
-- script: echo '##vso[task.prependpath]/usr/local/opt/llvm@12/bin'
+- script: |
+    brew install llvm@12
+    ln -sfn /usr/local/Cellar/llvm /usr/local/Cellar/llvm@12
+    echo '##vso[task.prependpath]/usr/local/opt/llvm@12/bin'
   displayName: Install LLVM (macOS)
   condition: eq(variables['Agent.OS'], 'Darwin')
 - script: pip3 install pylint yapf
@@ -33,7 +36,11 @@ steps:
     $(brew --prefix llvm)/bin/clang++ --version
     which clang++
     which swift
+    which clang-tidy
+    which clang-format
     printenv | sort
-    ls -flhair /Applications
+    ls -lhai /Applications
+    ls -lhai /usr/local/opt
+    ls -lhai /usr/local/Cellar
   displayName: Print environment (macOS)
   condition: eq(variables['Agent.OS'], 'Darwin')

--- a/toolchain/crosstool/cc_toolchain_config.bzl
+++ b/toolchain/crosstool/cc_toolchain_config.bzl
@@ -121,45 +121,45 @@ def darwin_llvm_toolchain_impl(ctx):
     tool_paths = [
         tool_path(
             name = "gcc",
-            path = "/usr/local/opt/llvm/bin/clang",
+            path = "/usr/local/opt/llvm@12/bin/clang",
         ),
         tool_path(
             name = "ld",
-            path = "/usr/local/opt/llvm/bin/ld64.lld",
+            path = "/usr/local/opt/llvm@12/bin/ld64.lld",
         ),
         tool_path(
             name = "ar",
-            path = "/usr/local/opt/llvm/bin/llvm-ar",
+            path = "/usr/local/opt/llvm@12/bin/llvm-ar",
         ),
         tool_path(
             name = "cpp",
-            path = "/usr/local/opt/llvm/bin/clang++",
+            path = "/usr/local/opt/llvm@12/bin/clang++",
         ),
         tool_path(
             name = "gcov",
-            path = "/usr/local/opt/llvm/bin/llvm-cov",
+            path = "/usr/local/opt/llvm@12/bin/llvm-cov",
         ),
         tool_path(
             name = "nm",
-            path = "/usr/local/opt/llvm/bin/llvm-nm",
+            path = "/usr/local/opt/llvm@12/bin/llvm-nm",
         ),
         tool_path(
             name = "objdump",
-            path = "/usr/local/opt/llvm/bin/llvm-objdump",
+            path = "/usr/local/opt/llvm@12/bin/llvm-objdump",
         ),
         tool_path(
             name = "strip",
-            path = "/usr/local/opt/llvm/bin/llvm-strip",
+            path = "/usr/local/opt/llvm@12/bin/llvm-strip",
         ),
     ]
     return cc_common.create_cc_toolchain_config_info(
         ctx = ctx,
         features = FEATURES,
         cxx_builtin_include_directories = [
-            "/usr/local/opt/llvm/include/c++/v1",
-            "/usr/local/Cellar/llvm/12.0.1/include/",
-            "/usr/local/Cellar/llvm/12.0.1/lib/clang/12.0.1/include",
-            "/usr/local/Cellar/llvm/12.0.1/lib/clang/12.0.1/share",
+            "/usr/local/opt/llvm@12/include/c++/v1",
+            "/usr/local/Cellar/llvm@12/12.0.1/include/",
+            "/usr/local/Cellar/llvm@12/12.0.1/lib/clang/12.0.1/include",
+            "/usr/local/Cellar/llvm@12/12.0.1/lib/clang/12.0.1/share",
             "/Library/Developer/CommandLineTools/SDKs/MacOSX11.sdk/usr/include",
             "/Library/Developer/CommandLineTools/SDKs/MacOSX11.sdk/System/Library/Frameworks",
         ],


### PR DESCRIPTION
Explicitly use the `@12` suffix in the LLVM toolchain's path to remove its reliance on the `llvm` symlink.