### PR TITLE
Fix documentation broken link

### DIFF
--- a/docs/configuration/runtime-config.md
+++ b/docs/configuration/runtime-config.md
@@ -4,7 +4,7 @@ Configure Spoor's runtime with environment variables.
 
 ## Source code
 
-[spoor/runtime/config/][spoor-instrumentation-config]
+[spoor/runtime/config/][spoor-runtime-config]
 
 ## Calculating memory impact
 


### PR DESCRIPTION
Fixes a broken link on the runtime configuration's documentation page.