### PR TITLE
Explicit CNAME file

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+www.spoor.dev


### PR DESCRIPTION
Each time we publish the documentation to the `gh-pages` branch, GitHub removes the custom domain. Explicitly adding a CNAME file to the root `docs` directory (supposedly) fixes the issue.