### PR TITLE
Skip build for documentation-only changes

### DIFF
--- a/.build/azure-pipelines.yml
+++ b/.build/azure-pipelines.yml
@@ -19,10 +19,13 @@ jobs:
   steps:
   - template: ./templates/install-common.yml
   - script: bazel build //...
+    condition: and(succeeded(), eq(variables['Changes.DocumentationOnly'], 'false'))
     displayName: Build
   - script: bazel test //...
+    condition: and(succeeded(), eq(variables['Changes.DocumentationOnly'], 'false'))
     displayName: Test
   - script: ./toolchain/benchmark/run_benchmarks.sh
+    condition: and(succeeded(), eq(variables['Changes.DocumentationOnly'], 'false'))
     displayName: Benchmark
   - script: mkdocs build
     displayName: Build documentation
@@ -36,11 +39,11 @@ jobs:
     vmImage: $(imageName)
   steps:
   - template: ./templates/install-common.yml
-  - script: |
-      bazel build //... --crosstool_top=//toolchain/crosstool:llvm_toolchain
+  - script: bazel build //... --crosstool_top=//toolchain/crosstool:llvm_toolchain
+    condition: and(succeeded(), eq(variables['Changes.DocumentationOnly'], 'false'))
     displayName: Build (LLVM toolchain)
-  - script: |
-      bazel test //... --crosstool_top=//toolchain/crosstool:llvm_toolchain
+  - script: bazel test //... --crosstool_top=//toolchain/crosstool:llvm_toolchain
+    condition: and(succeeded(), eq(variables['Changes.DocumentationOnly'], 'false'))
     displayName: Test (LLVM toolchain)
 - job: address_sanitizer
   timeoutInMinutes: 90
@@ -53,6 +56,7 @@ jobs:
   steps:
   - template: ./templates/install-common.yml
   - script: bazel test --config=asan $(bazel query 'kind(cc_.*, tests(//...))')
+    condition: and(succeeded(), eq(variables['Changes.DocumentationOnly'], 'false'))
     displayName: Address sanitizer
 - job: thread_sanitizer
   timeoutInMinutes: 90
@@ -65,6 +69,7 @@ jobs:
   steps:
   - template: ./templates/install-common.yml
   - script: bazel test --config=tsan $(bazel query 'kind(cc_.*, tests(//...))')
+    condition: and(succeeded(), eq(variables['Changes.DocumentationOnly'], 'false'))
     displayName: Thread sanitizer
 - job: style_and_lint
   timeoutInMinutes: 90
@@ -79,6 +84,7 @@ jobs:
   - script: |
       ./toolchain/copyright_header/add_copyright_header.sh
       git diff --exit-code
+    condition: and(succeeded(), eq(variables['Changes.DocumentationOnly'], 'false'))
     displayName: Copyright header
   - script: |
       bazel build //... \
@@ -87,6 +93,7 @@ jobs:
           --keep_going
       bazel run //toolchain/style:buildifier
       git diff --exit-code
+    condition: and(succeeded(), eq(variables['Changes.DocumentationOnly'], 'false'))
     displayName: Format
   - script: |
       bazel build //... \
@@ -94,6 +101,7 @@ jobs:
           --aspects toolchain/style/style.bzl%lint \
           --output_groups=report \
           --keep_going
+    condition: and(succeeded(), eq(variables['Changes.DocumentationOnly'], 'false'))
     displayName: Lint
 - job: publish_documentation
   pool:
@@ -113,4 +121,4 @@ jobs:
     displayName: Install Material for MkDocs
   - script: mkdocs gh-deploy --force
     displayName: Publish
-  condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
+  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))

--- a/.build/templates/install-common.yml
+++ b/.build/templates/install-common.yml
@@ -3,27 +3,52 @@
 
 steps:
 - script: |
+    set -e
+    if [ "$(Build.Reason)" != "PullRequest" ]; then
+      echo "##vso[task.setvariable variable=Changes.DocumentationOnly]false"
+    fi
+    if [ "$(Build.SourceBranch)" == "refs/heads/master" ]; then
+      echo "##vso[task.setvariable variable=Changes.DocumentationOnly]false"
+    fi
+    echo "version = $(Build.SourceVersion)"
+    FILES="$(git diff-tree --no-commit-id --name-only -r $(Build.SourceVersion))"
+    CHANGED_FILE_COUNT="$(echo "$FILES" | wc -l)"
+    CHANGED_DOCUMENTATION_FILE_COUNT="$(echo "$FILES" | grep -E "^docs\/.*$" | wc -l)"
+    echo "Changed files:"
+    echo "$FILES"
+    echo "Count: $CHANGED_FILE_COUNT"
+    if [ "$CHANGED_FILE_COUNT" -eq "0" ]; then
+      echo "##vso[task.setvariable variable=Changes.DocumentationOnly]false"
+    fi
+    if [ "$CHANGED_FILE_COUNT" -eq "$CHANGED_DOCUMENTATION_FILE_COUNT" ]; then
+      echo "##vso[task.setvariable variable=Changes.DocumentationOnly]true"
+    else
+      echo "##vso[task.setvariable variable=Changes.DocumentationOnly]false"
+    fi
+  name: Changes
+  displayName: Detect documentation-only changes
+- script: |
     sudo xcode-select --switch /Applications/Xcode_13.0.app
     ln -sfn /Applications/Xcode_13.0.app /Applications/Xcode.app
   displayName: Set Xcode version
-  condition: eq(variables['Agent.OS'], 'Darwin')
+  condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))
 - script: |
     wget https://apt.llvm.org/llvm.sh
     chmod +x llvm.sh
     sudo ./llvm.sh 12
   displayName: Install LLVM (Linux)
-  condition: eq(variables['Agent.OS'], 'Linux')
+  condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'), eq(variables['Changes.DocumentationOnly'], 'false'))
 - script: |
     brew install llvm@12
     ln -sfn /usr/local/Cellar/llvm /usr/local/Cellar/llvm@12
     echo '##vso[task.prependpath]/usr/local/opt/llvm@12/bin'
   displayName: Install LLVM (macOS)
-  condition: eq(variables['Agent.OS'], 'Darwin')
+  condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'), eq(variables['Changes.DocumentationOnly'], 'false'))
 - script: pip3 install pylint yapf mkdocs-material
   displayName: Install pip dependencies
 - script: cat .build/macos-ci.bazelrc .build/ci.bazelrc > .bazelrc
   displayName: Create .bazelrc (macOS)
-  condition: eq(variables['Agent.OS'], 'Darwin')
+  condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))
 - script: |
     set -x
     bazel --version
@@ -42,4 +67,4 @@ steps:
     ls -lhai /usr/local/opt
     ls -lhai /usr/local/Cellar
   displayName: Print environment (macOS)
-  condition: eq(variables['Agent.OS'], 'Darwin')
+  condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))


### PR DESCRIPTION
Skip building and testing source code if there are only documentation changes in the repo. This is achieved with a heuristic that checks if there are only modifications in the `docs` folder.