### PR TITLE
Fix runtime `DeleteFlushedTraceFilesOlderThan`

### DIFF
--- a/spoor/runtime/runtime.cc
+++ b/spoor/runtime/runtime.cc
@@ -63,6 +63,8 @@ util::time::SystemClock system_clock_{};
 // clang-format off NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables, fuchsia-statically-constructed-objects) clang-format on
 util::time::SteadyClock steady_clock_{};
 // clang-format off NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables, fuchsia-statically-constructed-objects) clang-format on
+util::file_system::LocalFileSystem file_system_{};
+// clang-format off NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables, fuchsia-statically-constructed-objects) clang-format on
 spoor::runtime::trace::TraceFileReader trace_reader_{{
     .file_system{std::make_unique<util::file_system::LocalFileSystem>()},
     .file_reader{std::make_unique<util::file_system::LocalFileReader>()},
@@ -176,10 +178,9 @@ auto DeleteFlushedTraceFilesOlderThan(
   const auto system_timestamp =
       std::chrono::time_point<std::chrono::system_clock>{
           std::chrono::seconds{system_timestamp_seconds}};
-  util::file_system::LocalFileSystem file_system{};
   RuntimeManager::DeleteFlushedTraceFilesOlderThan(
       system_timestamp, std::filesystem::begin(directory),
-      std::filesystem::end(directory), &file_system, &trace_reader_,
+      std::filesystem::end(directory), &file_system_, &trace_reader_,
       std::move(callback_adapter));
 }
 
@@ -322,10 +323,9 @@ auto _spoor_runtime_DeleteFlushedTraceFilesOlderThan(
   const auto system_timestamp =
       std::chrono::time_point<std::chrono::system_clock>{
           std::chrono::seconds{system_timestamp_seconds}};
-  util::file_system::LocalFileSystem file_system{};
   RuntimeManager::DeleteFlushedTraceFilesOlderThan(
       system_timestamp, std::filesystem::begin(directory),
-      std::filesystem::end(directory), &file_system, &trace_reader_,
+      std::filesystem::end(directory), &file_system_, &trace_reader_,
       std::move(callback_adapter));
 }
 

--- a/util/file_system/local_file_reader.cc
+++ b/util/file_system/local_file_reader.cc
@@ -3,6 +3,7 @@
 
 #include "util/file_system/local_file_reader.h"
 
+#include <algorithm>
 #include <filesystem>
 #include <ios>
 
@@ -33,10 +34,12 @@ auto LocalFileReader::Read() -> std::string {
 
 auto LocalFileReader::Read(const std::streamsize max_bytes) -> std::string {
   std::string buffer{};
-  buffer.reserve(max_bytes);
-  ifstream_.read(buffer.data(),
-                 gsl::narrow_cast<std::streamsize>(buffer.size()));
-  buffer.resize(ifstream_.gcount());
+  if (ifstream_.good()) {
+    buffer.reserve(max_bytes);
+    ifstream_.seekg(0, std::ios::beg);
+    std::copy_n(std::istreambuf_iterator(ifstream_), max_bytes,
+                std::back_inserter(buffer));
+  }
   return buffer;
 }
 


### PR DESCRIPTION
Fixes the runtime's `DeleteFlushedTraceFilesOlderThan` function. The file system's lifetime was shorter than the spawned thread resulting in an `EXC_BAD_ACCESS` and the files never getting deleted.

Additionally, this PR refactors the `DeleteFlushedTraceFilesOlderThan` runtime manager test to improve readability and uses a new technique for retrieving the first n bytes of a file.