### PR TITLE
`util::env::GetEnv`

### DIFF
--- a/spoor/instrumentation/config/command_line_config.cc
+++ b/spoor/instrumentation/config/command_line_config.cc
@@ -68,7 +68,7 @@ namespace spoor::instrumentation::config {
 using util::file_system::ExpandTilde;
 
 auto ConfigFromCommandLineOrEnv(const int argc, char** argv,
-                                const util::env::GetEnv& get_env)
+                                const util::env::StdGetEnv& get_env)
     -> std::pair<Config, std::vector<char*>> {
   const auto env_config = ConfigFromEnv(get_env);
   absl::SetFlag(&FLAGS_enable_runtime, env_config.enable_runtime);

--- a/spoor/instrumentation/config/command_line_config.h
+++ b/spoor/instrumentation/config/command_line_config.h
@@ -29,8 +29,8 @@ ABSL_DECLARE_FLAG(                                                    // NOLINT
 
 namespace spoor::instrumentation::config {
 
-auto ConfigFromCommandLineOrEnv(int argc, char** argv,
-                                const util::env::GetEnv& get_env = std::getenv)
+auto ConfigFromCommandLineOrEnv(
+    int argc, char** argv, const util::env::StdGetEnv& get_env = std::getenv)
     -> std::pair<Config, std::vector<char*>>;
 
 auto AbslParseFlag(absl::string_view user_key, OutputLanguage* language,

--- a/spoor/instrumentation/config/env_config.cc
+++ b/spoor/instrumentation/config/env_config.cc
@@ -11,39 +11,39 @@
 
 namespace spoor::instrumentation::config {
 
-using util::env::GetEnvOrDefault;
+using util::env::GetEnv;
 using util::file_system::ExpandTilde;
 
-auto ConfigFromEnv(const util::env::GetEnv& get_env) -> Config {
-  auto filters_file = GetEnvOrDefault(kFiltersFileKey.data(),
-                                      kFiltersFileDefaultValue, true, get_env);
+auto ConfigFromEnv(const util::env::StdGetEnv& get_env) -> Config {
+  constexpr auto empty_string_is_nullopt{true};
+  auto filters_file = GetEnv(kFiltersFileKey, empty_string_is_nullopt, get_env);
   if (filters_file.has_value()) {
     filters_file = ExpandTilde(filters_file.value(), get_env);
   }
-  const auto output_file = GetEnvOrDefault(
-      kOutputFileKey.data(), std::string{kOutputFileDefaultValue}, get_env);
+  const auto output_file =
+      GetEnv(kOutputFileKey, empty_string_is_nullopt, get_env)
+          .value_or(std::string{kOutputFileDefaultValue});
   const auto output_symbols_file =
-      GetEnvOrDefault(kOutputSymbolsFileKey.data(),
-                      std::string{kOutputSymbolsFileDefaultValue}, get_env);
-  return {.enable_runtime = GetEnvOrDefault(
-              kEnableRuntimeKey.data(), kEnableRuntimeDefaultValue, get_env),
-          .filters_file = filters_file,
-          .force_binary_output =
-              GetEnvOrDefault(kForceBinaryOutputKey.data(),
-                              kForceBinaryOutputDefaultValue, get_env),
-          .initialize_runtime =
-              GetEnvOrDefault(kInitializeRuntimeKey.data(),
-                              kInitializeRuntimeDefaultValue, get_env),
-          .inject_instrumentation =
-              GetEnvOrDefault(kInjectInstrumentationKey.data(),
-                              kInjectInstrumentationDefaultValue, get_env),
-          .module_id = GetEnvOrDefault(kModuleIdKey.data(),
-                                       kModuleIdDefaultValue, true, get_env),
-          .output_file = ExpandTilde(output_file, get_env),
-          .output_symbols_file = ExpandTilde(output_symbols_file, get_env),
-          .output_language = GetEnvOrDefault(kOutputLanguageKey.data(),
-                                             kOutputLanguageDefaultValue,
-                                             kOutputLanguages, true, get_env)};
+      GetEnv(kOutputSymbolsFileKey, empty_string_is_nullopt, get_env)
+          .value_or(std::string{kOutputSymbolsFileDefaultValue});
+  return {
+      .enable_runtime = GetEnv<bool>(kEnableRuntimeKey, get_env)
+                            .value_or(kEnableRuntimeDefaultValue),
+      .filters_file = filters_file,
+      .force_binary_output = GetEnv<bool>(kForceBinaryOutputKey, get_env)
+                                 .value_or(kForceBinaryOutputDefaultValue),
+      .initialize_runtime = GetEnv<bool>(kInitializeRuntimeKey, get_env)
+                                .value_or(kInitializeRuntimeDefaultValue),
+      .inject_instrumentation =
+          GetEnv<bool>(kInjectInstrumentationKey, get_env)
+              .value_or(kInjectInstrumentationDefaultValue),
+      .module_id = GetEnv(kModuleIdKey, empty_string_is_nullopt, get_env),
+      .output_file = ExpandTilde(output_file, get_env),
+      .output_symbols_file = ExpandTilde(output_symbols_file, get_env),
+      .output_language =
+          GetEnv(kOutputLanguageKey, kOutputLanguages, true, get_env)
+              .value_or(kOutputLanguageDefaultValue),
+  };
 }
 
 }  // namespace spoor::instrumentation::config

--- a/spoor/instrumentation/config/env_config.h
+++ b/spoor/instrumentation/config/env_config.h
@@ -27,6 +27,6 @@ constexpr std::string_view kOutputSymbolsFileKey{
 constexpr std::string_view kOutputLanguageKey{
     "SPOOR_INSTRUMENTATION_OUTPUT_LANGUAGE"};
 
-auto ConfigFromEnv(const util::env::GetEnv& get_env = std::getenv) -> Config;
+auto ConfigFromEnv(const util::env::StdGetEnv& get_env = std::getenv) -> Config;
 
 }  // namespace spoor::instrumentation::config

--- a/spoor/instrumentation/config/env_config_test.cc
+++ b/spoor/instrumentation/config/env_config_test.cc
@@ -92,7 +92,7 @@ TEST(EnvConfig, UsesDefaultValueForEmptyStringValues) {  // NOLINT
                                .initialize_runtime = true,
                                .inject_instrumentation = true,
                                .module_id = {},
-                               .output_file = "",
+                               .output_file = "-",
                                .output_symbols_file = "",
                                .output_language = OutputLanguage::kBitcode};
   ASSERT_EQ(ConfigFromEnv(get_env), expected_config);

--- a/spoor/runtime/config/config.h
+++ b/spoor/runtime/config/config.h
@@ -74,7 +74,8 @@ constexpr bool kFlushAllEventsDefaultValue{true};
 struct alignas(128) Config {
   using SizeType = buffer::CircularBuffer<trace::Event>::SizeType;
 
-  static auto FromEnv(const util::env::GetEnv& get_env = std::getenv) -> Config;
+  static auto FromEnv(const util::env::StdGetEnv& get_env = std::getenv)
+      -> Config;
 
   std::filesystem::path trace_file_path;
   CompressionStrategy compression_strategy;

--- a/spoor/tools/config/command_line_config.cc
+++ b/spoor/tools/config/command_line_config.cc
@@ -53,7 +53,7 @@ auto AbslUnparseFlag(const OutputFormat output_format) -> std::string {
 }
 
 auto ConfigFromCommandLine(int argc, char** argv,
-                           const util::env::GetEnv& get_env)
+                           const util::env::StdGetEnv& get_env)
     -> std::pair<Config, std::vector<char*>> {
   absl::SetFlag(&FLAGS_output_file, kOutputFileDefaultValue);
   absl::SetFlag(&FLAGS_output_format, kOutputFormatDefaultValue);

--- a/spoor/tools/config/command_line_config.h
+++ b/spoor/tools/config/command_line_config.h
@@ -21,7 +21,7 @@ auto AbslParseFlag(absl::string_view user_key, OutputFormat* output_format,
 auto AbslUnparseFlag(OutputFormat output_format) -> std::string;
 
 auto ConfigFromCommandLine(int argc, char** argv,
-                           const util::env::GetEnv& get_env = std::getenv)
+                           const util::env::StdGetEnv& get_env = std::getenv)
     -> std::pair<Config, std::vector<char*>>;
 
 }  // namespace spoor::tools::config

--- a/util/env/env.cc
+++ b/util/env/env.cc
@@ -3,43 +3,22 @@
 
 #include "util/env/env.h"
 
-#include <algorithm>
-#include <cctype>
 #include <optional>
 #include <string>
+#include <string_view>
 
 #include "absl/strings/ascii.h"
 #include "absl/strings/numbers.h"
 
 namespace util::env {
 
-auto GetEnvOrDefault(const char* key, std::string default_value,
-                     const GetEnv& get_env) -> std::string {
-  const auto* user_value = get_env(key);
-  if (user_value == nullptr) return default_value;
-  return user_value;
-}
-
-auto GetEnvOrDefault(const char* key, std::optional<std::string> default_value,
-                     const bool empty_string_is_nullopt, const GetEnv& get_env)
-    -> std::optional<std::string> {
-  const auto* user_value = get_env(key);
-  if (user_value == nullptr) return default_value;
+auto GetEnv(std::string_view key, const bool empty_string_is_nullopt,
+            const StdGetEnv& get_env) -> std::optional<std::string> {
+  const auto* user_value = get_env(key.data());
+  if (user_value == nullptr) return {};
   std::string user_value_string{user_value};
   if (user_value_string.empty() && empty_string_is_nullopt) return {};
   return user_value_string;
-}
-
-auto GetEnvOrDefault(const char* key, const bool default_value,
-                     const GetEnv& get_env) -> bool {
-  const auto* user_value = get_env(key);
-  if (user_value == nullptr) return default_value;
-  std::string value{user_value};
-  absl::StripAsciiWhitespace(&value);
-  absl::AsciiStrToLower(&value);
-  bool result{};
-  const auto success = absl::SimpleAtob(value, &result);
-  return success ? result : default_value;
 }
 
 }  // namespace util::env

--- a/util/env/env.h
+++ b/util/env/env.h
@@ -15,53 +15,64 @@
 
 namespace util::env {
 
-using GetEnv = std::function<const char*(const char*)>;
-
 constexpr std::string_view kHomeKey{"HOME"};
 
-auto GetEnvOrDefault(const char* key, std::string default_value,
-                     const GetEnv& get_env) -> std::string;
-
-auto GetEnvOrDefault(const char* key, std::optional<std::string> default_value,
-                     bool empty_string_is_nullopt, const GetEnv& get_env)
-    -> std::optional<std::string>;
-
-auto GetEnvOrDefault(const char* key, bool default_value, const GetEnv& get_env)
-    -> bool;
+using StdGetEnv = std::function<const char*(const char*)>;
 
 template <class T>
-auto GetEnvOrDefault(const char* key, T default_value, const GetEnv& get_env)
-    -> T requires(std::is_integral_v<T> && !std::is_same_v<T, bool>);
+auto GetEnv(std::string_view key, const StdGetEnv& get_env)
+    -> std::optional<bool>
+requires(std::is_same_v<T, bool>);
+
+template <class T>
+auto GetEnv(std::string_view key, const StdGetEnv& get_env) -> std::optional<T>
+requires(std::is_integral_v<T> && !std::is_same_v<T, bool>);
+
+auto GetEnv(std::string_view key, bool empty_string_is_nullopt,
+            const StdGetEnv& get_env) -> std::optional<std::string>;
 
 template <class T, std::size_t Size>
-auto GetEnvOrDefault(
-    const char* key, const T& default_value,
-    const util::flat_map::FlatMap<std::string_view, T, Size>& value_map,
-    bool normalize, const GetEnv& get_env) -> T;
+auto GetEnv(std::string_view key,
+            const util::flat_map::FlatMap<std::string_view, T, Size>& value_map,
+            bool normalize, const StdGetEnv& get_env) -> std::optional<T>;
 
 template <class T>
-auto GetEnvOrDefault(const char* key, T default_value, const GetEnv& get_env)
-    -> T requires(std::is_integral_v<T> && !std::is_same_v<T, bool>) {
-  const auto* user_value = get_env(key);
-  if (user_value == nullptr) return default_value;
+auto GetEnv(std::string_view key, const StdGetEnv& get_env)
+    -> std::optional<bool>
+requires(std::is_same_v<T, bool>) {
+  const auto* user_value = get_env(key.data());
+  if (user_value == nullptr) return {};
+  std::string value{user_value};
+  absl::StripAsciiWhitespace(&value);
+  absl::AsciiStrToLower(&value);
+  bool result{};
+  const auto success = absl::SimpleAtob(value, &result);
+  return success ? std::optional{result} : std::nullopt;
+}
+
+template <class T>
+auto GetEnv(std::string_view key, const StdGetEnv& get_env) -> std::optional<T>
+requires(std::is_integral_v<T> && !std::is_same_v<T, bool>) {
+  const auto* user_value = get_env(key.data());
+  if (user_value == nullptr) return {};
   T value{};
   const auto success = absl::SimpleAtoi(user_value, &value);
-  return success ? value : default_value;
+  return success ? std::optional{value} : std::nullopt;
 }
 
 template <class T, std::size_t Size>
-auto GetEnvOrDefault(
-    const char* key, const T& default_value,
-    const util::flat_map::FlatMap<std::string_view, T, Size>& value_map,
-    const bool normalize, const GetEnv& get_env) -> T {
-  const auto* user_key = get_env(key);
-  if (user_key == nullptr) return default_value;
+auto GetEnv(std::string_view key,
+            const util::flat_map::FlatMap<std::string_view, T, Size>& value_map,
+            const bool normalize, const StdGetEnv& get_env)
+    -> std::optional<T> {
+  const auto* user_key = get_env(key.data());
+  if (user_key == nullptr) return {};
   auto normalized_key = std::string{user_key};
   if (normalize) {
     absl::StripAsciiWhitespace(&normalized_key);
     absl::AsciiStrToLower(&normalized_key);
   }
-  return value_map.FirstValueForKey(normalized_key).value_or(default_value);
+  return value_map.FirstValueForKey(normalized_key);
 }
 
 }  // namespace util::env

--- a/util/file_system/util.cc
+++ b/util/file_system/util.cc
@@ -10,12 +10,11 @@
 
 namespace util::file_system {
 
-using std::literals::string_literals::operator""s;
-
-auto ExpandTilde(std::string path, const env::GetEnv& get_env) -> std::string {
+auto ExpandTilde(std::string path, const env::StdGetEnv& get_env)
+    -> std::string {
   if (!absl::StartsWith(path, "~/")) return path;
-  path.replace(std::cbegin(path), std::next(std::cbegin(path)),
-               env::GetEnvOrDefault(env::kHomeKey.data(), "~"s, get_env));
+  const auto home = env::GetEnv(env::kHomeKey, true, get_env).value_or("~");
+  path.replace(std::cbegin(path), std::next(std::cbegin(path)), home);
   return path;
 }
 

--- a/util/file_system/util.h
+++ b/util/file_system/util.h
@@ -10,6 +10,7 @@
 
 namespace util::file_system {
 
-auto ExpandTilde(std::string path, const env::GetEnv& get_env) -> std::string;
+auto ExpandTilde(std::string path, const env::StdGetEnv& get_env)
+    -> std::string;
 
 }  // namespace util::file_system


### PR DESCRIPTION
Refactors `util::env::GetEnvOrDefault` to `util::env::GetEnv` which returns a `std::optional`. Callers can use `std::optional`'s `value_or` to fall back to a default value.