### PR TITLE
Runtime file config

### DIFF
--- a/spoor/instrumentation/filters/filters_file_reader.cc
+++ b/spoor/instrumentation/filters/filters_file_reader.cc
@@ -37,7 +37,7 @@ auto FiltersFileReader::Read(const std::filesystem::path& file_path) const
   if (!toml_result) {
     return Error{
         .type = Error::Type::kMalformedFile,
-        .message = std::string{toml_result.error().description()},
+        .message{toml_result.error().description()},
     };
   }
   const auto table = std::move(toml_result).table();

--- a/spoor/instrumentation/filters/filters_file_reader.h
+++ b/spoor/instrumentation/filters/filters_file_reader.h
@@ -41,7 +41,7 @@ constexpr std::array<std::string_view, 6> kFilterKeys{{
     kFunctionIrInstructionCountGtKey,
 }};
 
-class FiltersFileReader : public FiltersReader {
+class FiltersFileReader final : public FiltersReader {
  public:
   struct Options {
     std::unique_ptr<util::file_system::FileReader> file_reader;

--- a/spoor/runtime/config/BUILD
+++ b/spoor/runtime/config/BUILD
@@ -11,9 +11,16 @@ load(
 )
 
 cc_library(
-    name = "config",
-    srcs = ["config.cc"],
-    hdrs = ["config.h"],
+    name = "source",
+    srcs = [
+        "env_source.cc",
+        "file_source.cc",
+    ],
+    hdrs = [
+        "env_source.h",
+        "file_source.h",
+        "source.h",
+    ],
     copts = SPOOR_DEFAULT_COPTS,
     linkopts = SPOOR_DEFAULT_LINKOPTS,
     visibility = ["//spoor/runtime:__subpackages__"],
@@ -21,11 +28,67 @@ cc_library(
         "//spoor/runtime/buffer",
         "//spoor/runtime/trace",
         "//util:numeric",
+        "//util:result",
         "//util/compression",
         "//util/env",
         "//util/file_system",
-        "//util/flat_map",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:str_format",
+        "@com_marzer_tomlplusplus//:tomlplusplus",
         "@com_microsoft_gsl//:gsl",
+    ],
+)
+
+cc_library(
+    name = "config",
+    srcs = ["config.cc"],
+    hdrs = ["config.h"],
+    copts = SPOOR_DEFAULT_COPTS,
+    linkopts = SPOOR_DEFAULT_LINKOPTS,
+    visibility = ["//spoor/runtime:__subpackages__"],
+    deps = [
+        ":source",
+        "//spoor/runtime/buffer",
+        "//spoor/runtime/trace",
+        "//util:numeric",
+        "//util/compression",
+    ],
+)
+
+cc_library(
+    name = "source_mock",
+    testonly = True,
+    hdrs = ["source_mock.h"],
+    copts = SPOOR_DEFAULT_COPTS,
+    linkopts = SPOOR_DEFAULT_LINKOPTS,
+    visibility = ["//spoor/runtime:__subpackages__"],
+    deps = [
+        ":source",
+        "//spoor/runtime/trace",
+        "//util:numeric",
+        "//util/compression",
+        "@com_google_googletest//:gtest",
+    ],
+)
+
+cc_test(
+    name = "source_test",
+    size = "small",
+    srcs = [
+        "env_source_test.cc",
+        "file_source_test.cc",
+    ],
+    copts = SPOOR_DEFAULT_TEST_COPTS,
+    linkopts = SPOOR_DEFAULT_TEST_LINKOPTS,
+    visibility = ["//visibility:private"],
+    deps = [
+        ":source",
+        "//spoor/runtime/buffer",
+        "//spoor/runtime/trace",
+        "//util/file_system:file_system_mock",
+        "//util/flat_map",
+        "@com_google_absl//absl/strings:str_format",
+        "@com_google_googletest//:gtest_main",
     ],
 )
 
@@ -38,8 +101,10 @@ cc_test(
     visibility = ["//visibility:private"],
     deps = [
         ":config",
-        "//util/env",
-        "//util/flat_map",
+        ":source",
+        ":source_mock",
+        "//spoor/runtime/trace",
+        "//util/compression",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/spoor/runtime/config/config.cc
+++ b/spoor/runtime/config/config.cc
@@ -3,92 +3,122 @@
 
 #include "spoor/runtime/config/config.h"
 
+#include <functional>
+#include <limits>
+#include <memory>
+#include <random>
+#include <string_view>
+#include <vector>
+
+#include "spoor/runtime/config/source.h"
+#include "spoor/runtime/trace/trace.h"
 #include "util/compression/compressor.h"
-#include "util/env/env.h"
-#include "util/file_system/util.h"
 #include "util/numeric.h"
 
 namespace spoor::runtime::config {
 
-using util::env::GetEnv;
-using util::file_system::ExpandTilde;
-using util::result::None;
+constexpr std::string_view kTraceFilePathDefaultValue{"."};
+constexpr auto kCompressionStrategyDefaultValue{
+    util::compression::Strategy::kSnappy};
+// NOLINTNEXTLINE(fuchsia-statically-constructed-objects)
+constexpr auto kSessionIdDefaultValue = [] {
+  std::random_device seed{};
+  std::default_random_engine engine{seed()};
+  std::uniform_int_distribution<trace::SessionId> distribution{};
+  return distribution(engine);
+};
+constexpr Config::SizeType kThreadEventBufferCapacityDefaultValue{10'000};
+constexpr Config::SizeType kMaxReservedEventBufferSliceCapacityDefaultValue{
+    1'000};
+constexpr Config::SizeType kMaxDynamicEventBufferSliceCapacityDefaultValue{
+    1'000};
+constexpr Config::SizeType kReservedEventPoolCapacityDefaultValue{0};
+constexpr auto kDynamicEventPoolCapacityDefaultValue{
+    std::numeric_limits<Config::SizeType>::max()};
+constexpr Config::SizeType kDynamicEventSliceBorrowCasAttemptsDefaultValue{1};
+constexpr trace::DurationNanoseconds
+    kEventBufferRetentionNanosecondsDefaultValue{0};
+constexpr int32 kMaxFlushBufferToFileAttemptsDefaultValue{2};
+constexpr auto kFlushAllEventsDefaultValue{true};
 
-auto Config::FromEnv(const util::env::StdGetEnv& get_env) -> Config {
-  constexpr auto normalize{true};
-  constexpr auto empty_string_is_nullopt{true};
-  // Temporarily returning an `Err` is okay because it immediately gets
-  // converted to the default value -- the desired behavior if the key doesn't
-  // exist.
-  const auto trace_file_path =
-      GetEnv(kTraceFilePathKey, empty_string_is_nullopt, get_env)
-          .value_or(util::result::Result<std::string, None>::Err({}))
-          .OkOr(std::string{kTraceFilePathDefaultValue});
-  const auto compression_strategy =
-      GetEnv(kCompressionStrategyKey, kCompressionStrategies, normalize,
-             get_env)
-          .value_or(
-              util::result::Result<util::compression::Strategy, None>::Err({}))
-          .OkOr(kCompressionStrategyDefaultValue);
-  const auto session_id =
-      GetEnv<trace::SessionId>(kSessionIdKey, get_env)
-          .value_or(util::result::Result<trace::SessionId, None>::Err({}))
-          .OkOr(kSessionIdDefaultValue());
-  const auto thread_event_buffer_capacity =
-      GetEnv<SizeType>(kThreadEventBufferCapacityKey, get_env)
-          .value_or(util::result::Result<SizeType, None>::Err({}))
-          .OkOr(kThreadEventBufferCapacityDefaultValue);
-  const auto max_reserved_event_buffer_slice_capacity =
-      GetEnv<SizeType>(kMaxReservedEventBufferSliceCapacityKey, get_env)
-          .value_or(util::result::Result<SizeType, None>::Err({}))
-          .OkOr(kMaxReservedEventBufferSliceCapacityDefaultValue);
-  const auto max_dynamic_event_buffer_slice_capacity =
-      GetEnv<SizeType>(kMaxDynamicEventBufferSliceCapacityKey, get_env)
-          .value_or(util::result::Result<SizeType, None>::Err({}))
-          .OkOr(kMaxDynamicEventBufferSliceCapacityDefaultValue);
-  const auto reserved_event_pool_capacity =
-      GetEnv<SizeType>(kReservedEventPoolCapacityKey, get_env)
-          .value_or(util::result::Result<SizeType, None>::Err({}))
-          .OkOr(kReservedEventPoolCapacityDefaultValue);
-  const auto dynamic_event_pool_capacity =
-      GetEnv<SizeType>(kDynamicEventPoolCapacityKey, get_env)
-          .value_or(util::result::Result<SizeType, None>::Err({}))
-          .OkOr(kDynamicEventPoolCapacityDefaultValue);
-  const auto dynamic_event_slice_borrow_cas_attempts =
-      GetEnv<SizeType>(kDynamicEventSliceBorrowCasAttemptsKey, get_env)
-          .value_or(util::result::Result<SizeType, None>::Err({}))
-          .OkOr(kDynamicEventSliceBorrowCasAttemptsDefaultValue);
-  const auto event_buffer_retention_duration_nanoseconds =
-      GetEnv<trace::DurationNanoseconds>(
-          kEventBufferRetentionDurationNanosecondsKey, get_env)
-          .value_or(
-              util::result::Result<trace::DurationNanoseconds, None>::Err({}))
-          .OkOr(kEventBufferRetentionNanosecondsDefaultValue);
-  const auto max_flush_buffer_to_file_attempts =
-      GetEnv<int32>(kMaxFlushBufferToFileAttemptsKey, get_env)
-          .value_or(util::result::Result<int32, None>::Err({}))
-          .OkOr(kMaxFlushBufferToFileAttemptsDefaultValue);
-  const auto flush_all_events =
-      GetEnv<bool>(kFlushAllEventsKey, get_env)
-          .value_or(util::result::Result<bool, None>::Err({}))
-          .OkOr(kFlushAllEventsDefaultValue);
+template <class T, class F>
+auto ValueFromSourceOrDefault(
+    const std::vector<std::unique_ptr<Source>>& sources,
+    const F get_value_from_source, const T& default_value) -> T {
+  for (const auto& source : sources) {
+    if (!source->IsRead()) {
+      const auto errors = source->Read();
+      static_cast<void>(errors);  // Ignored.
+    }
+    // `std::bind` permits a cleaner API. The alternative approach using lambdas
+    // is much more verbose because the compiler cannot infer the type.
+    // NOLINTNEXTLINE(modernize-avoid-bind)
+    const auto source_value = std::bind(get_value_from_source, source.get())();
+    if (source_value.has_value()) return source_value.value();
+  }
+  return default_value;
+}
+
+auto Config::Default() -> Config {
+  static const auto session_id = kSessionIdDefaultValue();
   return {
-      .trace_file_path = ExpandTilde(trace_file_path, get_env),
-      .compression_strategy = compression_strategy,
+      .trace_file_path = kTraceFilePathDefaultValue,
+      .compression_strategy = kCompressionStrategyDefaultValue,
       .session_id = session_id,
-      .thread_event_buffer_capacity = thread_event_buffer_capacity,
+      .thread_event_buffer_capacity = kThreadEventBufferCapacityDefaultValue,
       .max_reserved_event_buffer_slice_capacity =
-          max_reserved_event_buffer_slice_capacity,
+          kMaxReservedEventBufferSliceCapacityDefaultValue,
       .max_dynamic_event_buffer_slice_capacity =
-          max_dynamic_event_buffer_slice_capacity,
-      .reserved_event_pool_capacity = reserved_event_pool_capacity,
-      .dynamic_event_pool_capacity = dynamic_event_pool_capacity,
+          kMaxDynamicEventBufferSliceCapacityDefaultValue,
+      .reserved_event_pool_capacity = kReservedEventPoolCapacityDefaultValue,
+      .dynamic_event_pool_capacity = kDynamicEventPoolCapacityDefaultValue,
       .dynamic_event_slice_borrow_cas_attempts =
-          dynamic_event_slice_borrow_cas_attempts,
+          kDynamicEventSliceBorrowCasAttemptsDefaultValue,
       .event_buffer_retention_duration_nanoseconds =
-          event_buffer_retention_duration_nanoseconds,
-      .max_flush_buffer_to_file_attempts = max_flush_buffer_to_file_attempts,
-      .flush_all_events = flush_all_events,
+          kEventBufferRetentionNanosecondsDefaultValue,
+      .max_flush_buffer_to_file_attempts =
+          kMaxFlushBufferToFileAttemptsDefaultValue,
+      .flush_all_events = kFlushAllEventsDefaultValue,
+  };
+}
+
+auto Config::FromSourcesOrDefault(
+    std::vector<std::unique_ptr<Source>>&& sources,
+    const Config& default_config) -> Config {
+  return {
+      .trace_file_path = ValueFromSourceOrDefault(
+          sources, &Source::TraceFilePath, default_config.trace_file_path),
+      .compression_strategy =
+          ValueFromSourceOrDefault(sources, &Source::CompressionStrategy,
+                                   default_config.compression_strategy),
+      .session_id = ValueFromSourceOrDefault(sources, &Source::SessionId,
+                                             default_config.session_id),
+      .thread_event_buffer_capacity =
+          ValueFromSourceOrDefault(sources, &Source::ThreadEventBufferCapacity,
+                                   default_config.thread_event_buffer_capacity),
+      .max_reserved_event_buffer_slice_capacity = ValueFromSourceOrDefault(
+          sources, &Source::MaxReservedEventBufferSliceCapacity,
+          default_config.max_reserved_event_buffer_slice_capacity),
+      .max_dynamic_event_buffer_slice_capacity = ValueFromSourceOrDefault(
+          sources, &Source::MaxDynamicEventBufferSliceCapacity,
+          default_config.max_dynamic_event_buffer_slice_capacity),
+      .reserved_event_pool_capacity =
+          ValueFromSourceOrDefault(sources, &Source::ReservedEventPoolCapacity,
+                                   default_config.reserved_event_pool_capacity),
+      .dynamic_event_pool_capacity =
+          ValueFromSourceOrDefault(sources, &Source::DynamicEventPoolCapacity,
+                                   default_config.dynamic_event_pool_capacity),
+      .dynamic_event_slice_borrow_cas_attempts = ValueFromSourceOrDefault(
+          sources, &Source::DynamicEventSliceBorrowCasAttempts,
+          default_config.dynamic_event_slice_borrow_cas_attempts),
+      .event_buffer_retention_duration_nanoseconds = ValueFromSourceOrDefault(
+          sources, &Source::EventBufferRetentionDurationNanoseconds,
+          default_config.event_buffer_retention_duration_nanoseconds),
+      .max_flush_buffer_to_file_attempts = ValueFromSourceOrDefault(
+          sources, &Source::MaxFlushBufferToFileAttempts,
+          default_config.max_flush_buffer_to_file_attempts),
+      .flush_all_events = ValueFromSourceOrDefault(
+          sources, &Source::FlushAllEvents, default_config.flush_all_events),
   };
 }
 

--- a/spoor/runtime/config/config_test.cc
+++ b/spoor/runtime/config/config_test.cc
@@ -3,88 +3,328 @@
 
 #include "spoor/runtime/config/config.h"
 
-#include <limits>
-#include <string_view>
+#include <memory>
+#include <optional>
+#include <utility>
+#include <vector>
 
-#include "gtest/gtest.h"
-#include "spoor/runtime/buffer/circular_buffer.h"
-#include "util/env/env.h"
-#include "util/flat_map/flat_map.h"
+#include "spoor/runtime/config/source.h"
+#include "spoor/runtime/config/source_mock.h"
+#include "spoor/runtime/trace/trace.h"
+#include "util/compression/compressor.h"
 
 namespace {
 
-using spoor::runtime::config::CompressionStrategy;
 using spoor::runtime::config::Config;
-using spoor::runtime::config::kCompressionStrategyKey;
-using spoor::runtime::config::kDynamicEventPoolCapacityKey;
-using spoor::runtime::config::kDynamicEventSliceBorrowCasAttemptsKey;
-using spoor::runtime::config::kEventBufferRetentionDurationNanosecondsKey;
-using spoor::runtime::config::kFlushAllEventsKey;
-using spoor::runtime::config::kMaxDynamicEventBufferSliceCapacityKey;
-using spoor::runtime::config::kMaxFlushBufferToFileAttemptsKey;
-using spoor::runtime::config::kMaxReservedEventBufferSliceCapacityKey;
-using spoor::runtime::config::kReservedEventPoolCapacityKey;
-using spoor::runtime::config::kSessionIdKey;
-using spoor::runtime::config::kThreadEventBufferCapacityKey;
-using spoor::runtime::config::kTraceFilePathKey;
-using SizeType = spoor::runtime::buffer::CircularBuffer<
-    spoor::runtime::trace::Event>::SizeType;
+using spoor::runtime::config::Source;
+using spoor::runtime::config::testing::SourceMock;
+using spoor::runtime::trace::SessionId;
+using testing::Return;
 
-TEST(Config, GetsUserProvidedValue) {  // NOLINT
-  const auto get_env = [](const char* key) {
-    constexpr util::flat_map::FlatMap<std::string_view, std::string_view, 13>
-        environment{{util::env::kHomeKey, "/usr/you"},
-                    {kTraceFilePathKey, "~/path/to/file.extension"},
-                    {kCompressionStrategyKey, "   SnApPy   "},
-                    {kSessionIdKey, "42"},
-                    {kThreadEventBufferCapacityKey, "42"},
-                    {kMaxReservedEventBufferSliceCapacityKey, "42"},
-                    {kMaxDynamicEventBufferSliceCapacityKey, "42"},
-                    {kReservedEventPoolCapacityKey, "42"},
-                    {kDynamicEventPoolCapacityKey, "42"},
-                    {kDynamicEventSliceBorrowCasAttemptsKey, "42"},
-                    {kEventBufferRetentionDurationNanosecondsKey, "42"},
-                    {kMaxFlushBufferToFileAttemptsKey, "42"},
-                    {kFlushAllEventsKey, "false"}};
-    return environment.FirstValueForKey(key).value_or(nullptr).data();
-  };
-  const Config expected_options{
-      .trace_file_path = "/usr/you/path/to/file.extension",
-      .compression_strategy = CompressionStrategy::kSnappy,
-      .session_id = 42,
-      .thread_event_buffer_capacity = 42,
-      .max_reserved_event_buffer_slice_capacity = 42,
-      .max_dynamic_event_buffer_slice_capacity = 42,
-      .reserved_event_pool_capacity = 42,
-      .dynamic_event_pool_capacity = 42,
-      .dynamic_event_slice_borrow_cas_attempts = 42,
-      .event_buffer_retention_duration_nanoseconds = 42,
-      .max_flush_buffer_to_file_attempts = 42,
-      .flush_all_events = false};
-  ASSERT_EQ(Config::FromEnv(get_env), expected_options);
-}
-
-TEST(Config, UsesDefaultValueWhenNotSpecified) {  // NOLINT
-  const auto get_env = [](const char* /*unused*/) -> const char* {
-    return nullptr;
-  };
-  Config expected_options{
-      .trace_file_path{"."},
-      .compression_strategy = CompressionStrategy::kSnappy,
-      .session_id = 0,  // Ignored
+TEST(Config, Default) {  // NOLINT
+  constexpr SessionId session_id{42};
+  const auto default_config = [] {
+    auto config = Config::Default();
+    // `session_id` is randomly generated at runtime which is difficult to test.
+    config.session_id = session_id;
+    return config;
+  }();
+  const Config expected_default_config{
+      .trace_file_path = ".",
+      .compression_strategy = util::compression::Strategy::kSnappy,
+      .session_id = session_id,
       .thread_event_buffer_capacity = 10'000,
       .max_reserved_event_buffer_slice_capacity = 1'000,
       .max_dynamic_event_buffer_slice_capacity = 1'000,
       .reserved_event_pool_capacity = 0,
-      .dynamic_event_pool_capacity = std::numeric_limits<SizeType>::max(),
+      .dynamic_event_pool_capacity = 0xffffffffffffffff,
       .dynamic_event_slice_borrow_cas_attempts = 1,
       .event_buffer_retention_duration_nanoseconds = 0,
       .max_flush_buffer_to_file_attempts = 2,
-      .flush_all_events = true};
-  const auto options = Config::FromEnv(get_env);
-  // Ignore `session_id` which is randomly generated.
-  expected_options.session_id = options.session_id;
-  ASSERT_EQ(options, expected_options);
+      .flush_all_events = true,
+  };
+}
+
+TEST(Config, UsesDefaultConfigWithNoSource) {  // NOLINT
+  const auto default_config = Config::Default();
+  const auto config = Config::FromSourcesOrDefault({}, default_config);
+  ASSERT_EQ(config, default_config);
+}
+
+TEST(Config, ConfiguresFromSource) {  // NOLINT
+  const Config default_config{
+      .trace_file_path = "/path/to/trace/",
+      .compression_strategy = util::compression::Strategy::kNone,
+      .session_id = 1,
+      .thread_event_buffer_capacity = 2,
+      .max_reserved_event_buffer_slice_capacity = 3,
+      .max_dynamic_event_buffer_slice_capacity = 4,
+      .reserved_event_pool_capacity = 5,
+      .dynamic_event_pool_capacity = 6,
+      .dynamic_event_slice_borrow_cas_attempts = 7,
+      .event_buffer_retention_duration_nanoseconds = 8,
+      .max_flush_buffer_to_file_attempts = 9,
+      .flush_all_events = false,
+  };
+  const Config expected_config{
+      .trace_file_path = "/path/to/other/trace/",
+      .compression_strategy = util::compression::Strategy::kSnappy,
+      .session_id = 10,
+      .thread_event_buffer_capacity = 20,
+      .max_reserved_event_buffer_slice_capacity = 30,
+      .max_dynamic_event_buffer_slice_capacity = 40,
+      .reserved_event_pool_capacity = 50,
+      .dynamic_event_pool_capacity = 60,
+      .dynamic_event_slice_borrow_cas_attempts = 70,
+      .event_buffer_retention_duration_nanoseconds = 80,
+      .max_flush_buffer_to_file_attempts = 90,
+      .flush_all_events = true,
+  };
+  ASSERT_NE(default_config, expected_config);
+
+  auto source = std::make_unique<SourceMock>();
+  EXPECT_CALL(*source, Read())
+      .WillOnce(Return(std::vector<Source::ReadError>{}));
+  EXPECT_CALL(*source, IsRead())
+      .WillOnce(Return(false))
+      .WillRepeatedly(Return(true));
+  EXPECT_CALL(*source, TraceFilePath())
+      .WillRepeatedly(Return(expected_config.trace_file_path));
+  EXPECT_CALL(*source, CompressionStrategy())
+      .WillRepeatedly(Return(expected_config.compression_strategy));
+  EXPECT_CALL(*source, SessionId())
+      .WillRepeatedly(Return(expected_config.session_id));
+  EXPECT_CALL(*source, ThreadEventBufferCapacity())
+      .WillRepeatedly(Return(expected_config.thread_event_buffer_capacity));
+  EXPECT_CALL(*source, MaxReservedEventBufferSliceCapacity())
+      .WillRepeatedly(
+          Return(expected_config.max_reserved_event_buffer_slice_capacity));
+  EXPECT_CALL(*source, MaxDynamicEventBufferSliceCapacity())
+      .WillRepeatedly(
+          Return(expected_config.max_dynamic_event_buffer_slice_capacity));
+  EXPECT_CALL(*source, ReservedEventPoolCapacity())
+      .WillRepeatedly(Return(expected_config.reserved_event_pool_capacity));
+  EXPECT_CALL(*source, DynamicEventPoolCapacity())
+      .WillRepeatedly(Return(expected_config.dynamic_event_pool_capacity));
+  EXPECT_CALL(*source, DynamicEventSliceBorrowCasAttempts())
+      .WillRepeatedly(
+          Return(expected_config.dynamic_event_slice_borrow_cas_attempts));
+  EXPECT_CALL(*source, EventBufferRetentionDurationNanoseconds())
+      .WillRepeatedly(
+          Return(expected_config.event_buffer_retention_duration_nanoseconds));
+  EXPECT_CALL(*source, MaxFlushBufferToFileAttempts())
+      .WillRepeatedly(
+          Return(expected_config.max_flush_buffer_to_file_attempts));
+  EXPECT_CALL(*source, FlushAllEvents())
+      .WillRepeatedly(Return(expected_config.flush_all_events));
+
+  std::vector<std::unique_ptr<Source>> sources{};
+  sources.reserve(1);
+  sources.emplace_back(std::move(source));
+
+  const auto config =
+      Config::FromSourcesOrDefault(std::move(sources), default_config);
+  ASSERT_EQ(config, expected_config);
+}
+
+// NOLINTNEXTLINE
+TEST(Config, NeverReadsSecondarySourceIfPrimaryContainsAllConfigurations) {
+  const Config default_config{
+      .trace_file_path = "/path/to/trace/",
+      .compression_strategy = util::compression::Strategy::kNone,
+      .session_id = 1,
+      .thread_event_buffer_capacity = 2,
+      .max_reserved_event_buffer_slice_capacity = 3,
+      .max_dynamic_event_buffer_slice_capacity = 4,
+      .reserved_event_pool_capacity = 5,
+      .dynamic_event_pool_capacity = 6,
+      .dynamic_event_slice_borrow_cas_attempts = 7,
+      .event_buffer_retention_duration_nanoseconds = 8,
+      .max_flush_buffer_to_file_attempts = 9,
+      .flush_all_events = false,
+  };
+  const Config expected_config{
+      .trace_file_path = "/path/to/other/trace/",
+      .compression_strategy = util::compression::Strategy::kSnappy,
+      .session_id = 10,
+      .thread_event_buffer_capacity = 20,
+      .max_reserved_event_buffer_slice_capacity = 30,
+      .max_dynamic_event_buffer_slice_capacity = 40,
+      .reserved_event_pool_capacity = 50,
+      .dynamic_event_pool_capacity = 60,
+      .dynamic_event_slice_borrow_cas_attempts = 70,
+      .event_buffer_retention_duration_nanoseconds = 80,
+      .max_flush_buffer_to_file_attempts = 90,
+      .flush_all_events = true,
+  };
+  ASSERT_NE(default_config, expected_config);
+
+  auto source_a = std::make_unique<SourceMock>();
+  EXPECT_CALL(*source_a, Read())
+      .WillOnce(Return(std::vector<Source::ReadError>{}));
+  EXPECT_CALL(*source_a, IsRead())
+      .WillOnce(Return(false))
+      .WillRepeatedly(Return(true));
+  EXPECT_CALL(*source_a, TraceFilePath())
+      .WillRepeatedly(Return(expected_config.trace_file_path));
+  EXPECT_CALL(*source_a, CompressionStrategy())
+      .WillRepeatedly(Return(expected_config.compression_strategy));
+  EXPECT_CALL(*source_a, SessionId())
+      .WillRepeatedly(Return(expected_config.session_id));
+  EXPECT_CALL(*source_a, ThreadEventBufferCapacity())
+      .WillRepeatedly(Return(expected_config.thread_event_buffer_capacity));
+  EXPECT_CALL(*source_a, MaxReservedEventBufferSliceCapacity())
+      .WillRepeatedly(
+          Return(expected_config.max_reserved_event_buffer_slice_capacity));
+  EXPECT_CALL(*source_a, MaxDynamicEventBufferSliceCapacity())
+      .WillRepeatedly(
+          Return(expected_config.max_dynamic_event_buffer_slice_capacity));
+  EXPECT_CALL(*source_a, ReservedEventPoolCapacity())
+      .WillRepeatedly(Return(expected_config.reserved_event_pool_capacity));
+  EXPECT_CALL(*source_a, DynamicEventPoolCapacity())
+      .WillRepeatedly(Return(expected_config.dynamic_event_pool_capacity));
+  EXPECT_CALL(*source_a, DynamicEventSliceBorrowCasAttempts())
+      .WillRepeatedly(
+          Return(expected_config.dynamic_event_slice_borrow_cas_attempts));
+  EXPECT_CALL(*source_a, EventBufferRetentionDurationNanoseconds())
+      .WillRepeatedly(
+          Return(expected_config.event_buffer_retention_duration_nanoseconds));
+  EXPECT_CALL(*source_a, MaxFlushBufferToFileAttempts())
+      .WillRepeatedly(
+          Return(expected_config.max_flush_buffer_to_file_attempts));
+  EXPECT_CALL(*source_a, FlushAllEvents())
+      .WillRepeatedly(Return(expected_config.flush_all_events));
+
+  auto source_b = std::make_unique<SourceMock>();
+  EXPECT_CALL(*source_b, Read()).Times(0);
+  EXPECT_CALL(*source_b, IsRead()).Times(0);
+  EXPECT_CALL(*source_b, TraceFilePath()).Times(0);
+  EXPECT_CALL(*source_b, CompressionStrategy()).Times(0);
+  EXPECT_CALL(*source_b, SessionId()).Times(0);
+  EXPECT_CALL(*source_b, ThreadEventBufferCapacity()).Times(0);
+  EXPECT_CALL(*source_b, MaxReservedEventBufferSliceCapacity()).Times(0);
+  EXPECT_CALL(*source_b, MaxDynamicEventBufferSliceCapacity()).Times(0);
+  EXPECT_CALL(*source_b, ReservedEventPoolCapacity()).Times(0);
+  EXPECT_CALL(*source_b, DynamicEventPoolCapacity()).Times(0);
+  EXPECT_CALL(*source_b, DynamicEventSliceBorrowCasAttempts()).Times(0);
+  EXPECT_CALL(*source_b, EventBufferRetentionDurationNanoseconds()).Times(0);
+  EXPECT_CALL(*source_b, MaxFlushBufferToFileAttempts()).Times(0);
+  EXPECT_CALL(*source_b, FlushAllEvents()).Times(0);
+
+  std::vector<std::unique_ptr<Source>> sources{};
+  sources.reserve(2);
+  sources.emplace_back(std::move(source_a));
+  sources.emplace_back(std::move(source_b));
+
+  const auto config =
+      Config::FromSourcesOrDefault(std::move(sources), default_config);
+  ASSERT_EQ(config, expected_config);
+}
+
+// NOLINTNEXTLINE
+TEST(Config, ReadsSecondarySourceIfPrimaryDoesNotContainConfiguration) {
+  const Config default_config{
+      .trace_file_path = "/path/to/trace/",
+      .compression_strategy = util::compression::Strategy::kNone,
+      .session_id = 1,
+      .thread_event_buffer_capacity = 2,
+      .max_reserved_event_buffer_slice_capacity = 3,
+      .max_dynamic_event_buffer_slice_capacity = 4,
+      .reserved_event_pool_capacity = 5,
+      .dynamic_event_pool_capacity = 6,
+      .dynamic_event_slice_borrow_cas_attempts = 7,
+      .event_buffer_retention_duration_nanoseconds = 8,
+      .max_flush_buffer_to_file_attempts = 9,
+      .flush_all_events = false,
+  };
+  const Config expected_config{
+      .trace_file_path = "/path/to/other/trace/",
+      .compression_strategy = util::compression::Strategy::kSnappy,
+      .session_id = 10,
+      .thread_event_buffer_capacity = 20,
+      .max_reserved_event_buffer_slice_capacity = 30,
+      .max_dynamic_event_buffer_slice_capacity = 40,
+      .reserved_event_pool_capacity = 50,
+      .dynamic_event_pool_capacity = 60,
+      .dynamic_event_slice_borrow_cas_attempts = 70,
+      .event_buffer_retention_duration_nanoseconds = 80,
+      .max_flush_buffer_to_file_attempts = 90,
+      .flush_all_events = true,
+  };
+  ASSERT_NE(default_config, expected_config);
+
+  auto source_a = std::make_unique<SourceMock>();
+  EXPECT_CALL(*source_a, Read())
+      .WillOnce(Return(std::vector<Source::ReadError>{}));
+  EXPECT_CALL(*source_a, IsRead())
+      .WillOnce(Return(false))
+      .WillRepeatedly(Return(true));
+  EXPECT_CALL(*source_a, TraceFilePath()).WillRepeatedly(Return(std::nullopt));
+  EXPECT_CALL(*source_a, CompressionStrategy())
+      .WillRepeatedly(Return(std::nullopt));
+  EXPECT_CALL(*source_a, SessionId()).WillRepeatedly(Return(std::nullopt));
+  EXPECT_CALL(*source_a, ThreadEventBufferCapacity())
+      .WillRepeatedly(Return(std::nullopt));
+  EXPECT_CALL(*source_a, MaxReservedEventBufferSliceCapacity())
+      .WillRepeatedly(Return(std::nullopt));
+  EXPECT_CALL(*source_a, MaxDynamicEventBufferSliceCapacity())
+      .WillRepeatedly(Return(std::nullopt));
+  EXPECT_CALL(*source_a, ReservedEventPoolCapacity())
+      .WillRepeatedly(Return(std::nullopt));
+  EXPECT_CALL(*source_a, DynamicEventPoolCapacity())
+      .WillRepeatedly(Return(std::nullopt));
+  EXPECT_CALL(*source_a, DynamicEventSliceBorrowCasAttempts())
+      .WillRepeatedly(Return(std::nullopt));
+  EXPECT_CALL(*source_a, EventBufferRetentionDurationNanoseconds())
+      .WillRepeatedly(Return(std::nullopt));
+  EXPECT_CALL(*source_a, MaxFlushBufferToFileAttempts())
+      .WillRepeatedly(Return(std::nullopt));
+  EXPECT_CALL(*source_a, FlushAllEvents()).WillRepeatedly(Return(std::nullopt));
+
+  auto source_b = std::make_unique<SourceMock>();
+  EXPECT_CALL(*source_b, Read())
+      .WillOnce(Return(std::vector<Source::ReadError>{}));
+  EXPECT_CALL(*source_b, IsRead())
+      .WillOnce(Return(false))
+      .WillRepeatedly(Return(true));
+  EXPECT_CALL(*source_b, TraceFilePath())
+      .WillRepeatedly(Return(expected_config.trace_file_path));
+  EXPECT_CALL(*source_b, CompressionStrategy())
+      .WillRepeatedly(Return(expected_config.compression_strategy));
+  EXPECT_CALL(*source_b, SessionId())
+      .WillRepeatedly(Return(expected_config.session_id));
+  EXPECT_CALL(*source_b, ThreadEventBufferCapacity())
+      .WillRepeatedly(Return(expected_config.thread_event_buffer_capacity));
+  EXPECT_CALL(*source_b, MaxReservedEventBufferSliceCapacity())
+      .WillRepeatedly(
+          Return(expected_config.max_reserved_event_buffer_slice_capacity));
+  EXPECT_CALL(*source_b, MaxDynamicEventBufferSliceCapacity())
+      .WillRepeatedly(
+          Return(expected_config.max_dynamic_event_buffer_slice_capacity));
+  EXPECT_CALL(*source_b, ReservedEventPoolCapacity())
+      .WillRepeatedly(Return(expected_config.reserved_event_pool_capacity));
+  EXPECT_CALL(*source_b, DynamicEventPoolCapacity())
+      .WillRepeatedly(Return(expected_config.dynamic_event_pool_capacity));
+  EXPECT_CALL(*source_b, DynamicEventSliceBorrowCasAttempts())
+      .WillRepeatedly(
+          Return(expected_config.dynamic_event_slice_borrow_cas_attempts));
+  EXPECT_CALL(*source_b, EventBufferRetentionDurationNanoseconds())
+      .WillRepeatedly(
+          Return(expected_config.event_buffer_retention_duration_nanoseconds));
+  EXPECT_CALL(*source_b, MaxFlushBufferToFileAttempts())
+      .WillRepeatedly(
+          Return(expected_config.max_flush_buffer_to_file_attempts));
+  EXPECT_CALL(*source_b, FlushAllEvents())
+      .WillRepeatedly(Return(expected_config.flush_all_events));
+
+  std::vector<std::unique_ptr<Source>> sources{};
+  sources.reserve(2);
+  sources.emplace_back(std::move(source_a));
+  sources.emplace_back(std::move(source_b));
+
+  const auto config =
+      Config::FromSourcesOrDefault(std::move(sources), default_config);
+  ASSERT_EQ(config, expected_config);
 }
 
 }  // namespace

--- a/spoor/runtime/config/env_source.cc
+++ b/spoor/runtime/config/env_source.cc
@@ -1,0 +1,185 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "spoor/runtime/config/env_source.h"
+
+#include <functional>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "absl/strings/str_format.h"
+#include "gsl/gsl"
+#include "spoor/runtime/config/source.h"
+#include "spoor/runtime/trace/trace.h"
+#include "util/env/env.h"
+#include "util/numeric.h"
+#include "util/result.h"
+
+namespace spoor::runtime::config {
+
+using util::env::GetEnv;
+
+EnvSource::EnvSource(Options options)
+    : options_{std::move(options)}, read_{false} {}
+
+template <class T>
+auto ReadConfig(
+    const std::string_view key,
+    gsl::not_null<std::vector<Source::ReadError>*> errors,
+    std::function<std::optional<util::result::Result<T, util::result::None>>(
+        std::string_view)>
+        get_env) -> std::optional<T> {
+  const auto value = get_env(key);
+  if (!value.has_value()) return {};
+  if (value.value().IsErr()) {
+    errors->push_back({
+        .type = Source::ReadError::Type::kUnknownValue,
+        .message = absl::StrFormat("Cannot parse value for key \"%s\".", key),
+    });
+    return {};
+  }
+  return value.value().Ok();
+}
+
+auto EnvSource::Read() -> std::vector<ReadError> {
+  constexpr auto empty_string_is_nullopt{true};
+  constexpr auto normalize{true};
+  auto finally = gsl::finally([this] { read_ = true; });
+
+  std::vector<ReadError> errors{};
+
+  trace_file_path_ = ReadConfig<decltype(trace_file_path_)::value_type>(
+      kTraceFilePathEnvKey, &errors, [&](const auto key) {
+        return GetEnv(key, empty_string_is_nullopt, options_.get_env);
+      });
+  compression_strategy_ =
+      ReadConfig<decltype(compression_strategy_)::value_type>(
+          kCompressionStrategyEnvKey, &errors, [&](const auto key) {
+            return GetEnv(key, util::compression::kStrategyMap, normalize,
+                          options_.get_env);
+          });
+  session_id_ = ReadConfig<decltype(session_id_)::value_type>(
+      kSessionIdEnvKey, &errors, [&](const auto key) {
+        return GetEnv<decltype(session_id_)::value_type>(key, options_.get_env);
+      });
+  thread_event_buffer_capacity_ =
+      ReadConfig<decltype(thread_event_buffer_capacity_)::value_type>(
+          kThreadEventBufferCapacityEnvKey, &errors, [&](const auto key) {
+            return GetEnv<decltype(thread_event_buffer_capacity_)::value_type>(
+                key, options_.get_env);
+          });
+  max_reserved_event_buffer_slice_capacity_ = ReadConfig<
+      decltype(max_reserved_event_buffer_slice_capacity_)::value_type>(
+      kMaxReservedEventBufferSliceCapacityEnvKey, &errors, [&](const auto key) {
+        return GetEnv<
+            decltype(max_reserved_event_buffer_slice_capacity_)::value_type>(
+            key, options_.get_env);
+      });
+  max_dynamic_event_buffer_slice_capacity_ = ReadConfig<
+      decltype(max_dynamic_event_buffer_slice_capacity_)::value_type>(
+      kMaxDynamicEventBufferSliceCapacityEnvKey, &errors, [&](const auto key) {
+        return GetEnv<
+            decltype(max_dynamic_event_buffer_slice_capacity_)::value_type>(
+            key, options_.get_env);
+      });
+  reserved_event_pool_capacity_ =
+      ReadConfig<decltype(reserved_event_pool_capacity_)::value_type>(
+          kReservedEventPoolCapacityEnvKey, &errors, [&](const auto key) {
+            return GetEnv<decltype(reserved_event_pool_capacity_)::value_type>(
+                key, options_.get_env);
+          });
+  dynamic_event_pool_capacity_ =
+      ReadConfig<decltype(dynamic_event_pool_capacity_)::value_type>(
+          kDynamicEventPoolCapacityEnvKey, &errors, [&](const auto key) {
+            return GetEnv<decltype(dynamic_event_pool_capacity_)::value_type>(
+                key, options_.get_env);
+          });
+  dynamic_event_slice_borrow_cas_attempts_ = ReadConfig<
+      decltype(dynamic_event_slice_borrow_cas_attempts_)::value_type>(
+      kDynamicEventSliceBorrowCasAttemptsEnvKey, &errors, [&](const auto key) {
+        return GetEnv<
+            decltype(dynamic_event_slice_borrow_cas_attempts_)::value_type>(
+            key, options_.get_env);
+      });
+  event_buffer_retention_duration_nanoseconds_ = ReadConfig<
+      decltype(event_buffer_retention_duration_nanoseconds_)::value_type>(
+      kEventBufferRetentionDurationNanosecondsEnvKey, &errors,
+      [&](const auto key) {
+        return GetEnv<
+            decltype(event_buffer_retention_duration_nanoseconds_)::value_type>(
+            key, options_.get_env);
+      });
+  max_flush_buffer_to_file_attempts_ = ReadConfig<
+      decltype(max_flush_buffer_to_file_attempts_)::value_type>(
+      kMaxFlushBufferToFileAttemptsEnvKey, &errors, [&](const auto key) {
+        return GetEnv<decltype(max_flush_buffer_to_file_attempts_)::value_type>(
+            key, options_.get_env);
+      });
+  flush_all_events_ = ReadConfig<decltype(flush_all_events_)::value_type>(
+      kFlushAllEventsEnvKey, &errors, [&](const auto key) {
+        return GetEnv<decltype(flush_all_events_)::value_type>(
+            key, options_.get_env);
+      });
+
+  return errors;
+}
+
+auto EnvSource::IsRead() const -> bool { return read_; }
+
+auto EnvSource::TraceFilePath() const -> std::optional<std::string> {
+  return trace_file_path_;
+}
+
+auto EnvSource::CompressionStrategy() const
+    -> std::optional<util::compression::Strategy> {
+  return compression_strategy_;
+}
+
+auto EnvSource::SessionId() const -> std::optional<trace::SessionId> {
+  return session_id_;
+}
+
+auto EnvSource::ThreadEventBufferCapacity() const -> std::optional<SizeType> {
+  return thread_event_buffer_capacity_;
+}
+
+auto EnvSource::MaxReservedEventBufferSliceCapacity() const
+    -> std::optional<SizeType> {
+  return max_reserved_event_buffer_slice_capacity_;
+}
+
+auto EnvSource::MaxDynamicEventBufferSliceCapacity() const
+    -> std::optional<SizeType> {
+  return max_dynamic_event_buffer_slice_capacity_;
+}
+
+auto EnvSource::ReservedEventPoolCapacity() const -> std::optional<SizeType> {
+  return reserved_event_pool_capacity_;
+}
+
+auto EnvSource::DynamicEventPoolCapacity() const -> std::optional<SizeType> {
+  return dynamic_event_pool_capacity_;
+}
+
+auto EnvSource::DynamicEventSliceBorrowCasAttempts() const
+    -> std::optional<SizeType> {
+  return dynamic_event_slice_borrow_cas_attempts_;
+}
+
+auto EnvSource::EventBufferRetentionDurationNanoseconds() const
+    -> std::optional<trace::DurationNanoseconds> {
+  return event_buffer_retention_duration_nanoseconds_;
+}
+
+auto EnvSource::MaxFlushBufferToFileAttempts() const -> std::optional<int32> {
+  return max_flush_buffer_to_file_attempts_;
+}
+
+auto EnvSource::FlushAllEvents() const -> std::optional<bool> {
+  return flush_all_events_;
+}
+
+}  // namespace spoor::runtime::config

--- a/spoor/runtime/config/env_source.h
+++ b/spoor/runtime/config/env_source.h
@@ -1,0 +1,118 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <array>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "spoor/runtime/config/source.h"
+#include "spoor/runtime/trace/trace.h"
+#include "util/compression/compressor.h"
+#include "util/env/env.h"
+#include "util/numeric.h"
+
+namespace spoor::runtime::config {
+
+constexpr std::string_view kTraceFilePathEnvKey{
+    "SPOOR_RUNTIME_TRACE_FILE_PATH"};
+constexpr std::string_view kCompressionStrategyEnvKey{
+    "SPOOR_RUNTIME_COMPRESSION_STRATEGY"};
+constexpr std::string_view kSessionIdEnvKey{"SPOOR_RUNTIME_SESSION_ID"};
+constexpr std::string_view kThreadEventBufferCapacityEnvKey{
+    "SPOOR_RUNTIME_THEAD_EVENT_BUFFER_CAPACITY"};
+constexpr std::string_view kMaxReservedEventBufferSliceCapacityEnvKey{
+    "SPOOR_RUNTIME_MAX_RESERVED_EVENT_BUFFER_SLICE_CAPACITY"};
+constexpr std::string_view kMaxDynamicEventBufferSliceCapacityEnvKey{
+    "SPOOR_RUNTIME_MAX_DYNAMIC_EVENT_BUFFER_SLICE_CAPACITY"};
+constexpr std::string_view kReservedEventPoolCapacityEnvKey{
+    "SPOOR_RUNTIME_RESERVED_EVENT_POOL_CAPACITY"};
+constexpr std::string_view kDynamicEventPoolCapacityEnvKey{
+    "SPOOR_RUNTIME_DYNAMIC_EVENT_POOL_CAPACITY"};
+constexpr std::string_view kDynamicEventSliceBorrowCasAttemptsEnvKey{
+    "SPOOR_RUNTIME_DYNAMIC_EVENT_SLICE_BORROW_CAS_ATTEMPTS"};
+constexpr std::string_view kEventBufferRetentionDurationNanosecondsEnvKey{
+    "SPOOR_RUNTIME_EVENT_BUFFER_RETENTION_DURATION_NANOSECONDS"};
+constexpr std::string_view kMaxFlushBufferToFileAttemptsEnvKey{
+    "SPOOR_RUNTIME_MAX_FLUSH_BUFFER_TO_FILE_ATTEMPTS"};
+constexpr std::string_view kFlushAllEventsEnvKey{
+    "SPOOR_RUNTIME_FLUSH_ALL_EVENTS"};
+constexpr std::array<std::string_view, 12> kEnvConfigKeys{{
+    kTraceFilePathEnvKey,
+    kCompressionStrategyEnvKey,
+    kSessionIdEnvKey,
+    kThreadEventBufferCapacityEnvKey,
+    kMaxReservedEventBufferSliceCapacityEnvKey,
+    kMaxDynamicEventBufferSliceCapacityEnvKey,
+    kReservedEventPoolCapacityEnvKey,
+    kDynamicEventPoolCapacityEnvKey,
+    kDynamicEventSliceBorrowCasAttemptsEnvKey,
+    kEventBufferRetentionDurationNanosecondsEnvKey,
+    kMaxFlushBufferToFileAttemptsEnvKey,
+    kFlushAllEventsEnvKey,
+}};
+
+class EnvSource final : public Source {
+ public:
+  struct alignas(64) Options {
+    util::env::StdGetEnv get_env;
+  };
+
+  EnvSource() = delete;
+  explicit EnvSource(Options options);
+  EnvSource(const EnvSource&) = delete;
+  EnvSource(EnvSource&&) noexcept = default;
+  auto operator=(const EnvSource&) -> EnvSource& = delete;
+  auto operator=(EnvSource&&) noexcept -> EnvSource& = default;
+  ~EnvSource() override = default;
+
+  [[nodiscard]] auto Read() -> std::vector<ReadError> override;
+  [[nodiscard]] auto IsRead() const -> bool override;
+
+  [[nodiscard]] auto TraceFilePath() const
+      -> std::optional<std::string> override;
+  [[nodiscard]] auto CompressionStrategy() const
+      -> std::optional<util::compression::Strategy> override;
+  [[nodiscard]] auto SessionId() const
+      -> std::optional<trace::SessionId> override;
+  [[nodiscard]] auto ThreadEventBufferCapacity() const
+      -> std::optional<SizeType> override;
+  [[nodiscard]] auto MaxReservedEventBufferSliceCapacity() const
+      -> std::optional<SizeType> override;
+  [[nodiscard]] auto MaxDynamicEventBufferSliceCapacity() const
+      -> std::optional<SizeType> override;
+  [[nodiscard]] auto ReservedEventPoolCapacity() const
+      -> std::optional<SizeType> override;
+  [[nodiscard]] auto DynamicEventPoolCapacity() const
+      -> std::optional<SizeType> override;
+  [[nodiscard]] auto DynamicEventSliceBorrowCasAttempts() const
+      -> std::optional<SizeType> override;
+  [[nodiscard]] auto EventBufferRetentionDurationNanoseconds() const
+      -> std::optional<trace::DurationNanoseconds> override;
+  [[nodiscard]] auto MaxFlushBufferToFileAttempts() const
+      -> std::optional<int32> override;
+  [[nodiscard]] auto FlushAllEvents() const -> std::optional<bool> override;
+
+ private:
+  Options options_;
+  bool read_;
+
+  std::optional<std::string> trace_file_path_;
+  std::optional<util::compression::Strategy> compression_strategy_;
+  std::optional<trace::SessionId> session_id_;
+  std::optional<SizeType> thread_event_buffer_capacity_;
+  std::optional<SizeType> max_reserved_event_buffer_slice_capacity_;
+  std::optional<SizeType> max_dynamic_event_buffer_slice_capacity_;
+  std::optional<SizeType> reserved_event_pool_capacity_;
+  std::optional<SizeType> dynamic_event_pool_capacity_;
+  std::optional<SizeType> dynamic_event_slice_borrow_cas_attempts_;
+  std::optional<trace::DurationNanoseconds>
+      event_buffer_retention_duration_nanoseconds_;
+  std::optional<int32> max_flush_buffer_to_file_attempts_;
+  std::optional<bool> flush_all_events_;
+};
+
+}  // namespace spoor::runtime::config

--- a/spoor/runtime/config/env_source_test.cc
+++ b/spoor/runtime/config/env_source_test.cc
@@ -1,0 +1,229 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "spoor/runtime/config/env_source.h"
+
+#include <algorithm>
+#include <iterator>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "absl/strings/str_format.h"
+#include "gtest/gtest.h"
+#include "util/compression/compressor.h"
+#include "util/flat_map/flat_map.h"
+
+namespace {
+
+using spoor::runtime::config::EnvSource;
+using spoor::runtime::config::kCompressionStrategyEnvKey;
+using spoor::runtime::config::kDynamicEventPoolCapacityEnvKey;
+using spoor::runtime::config::kDynamicEventSliceBorrowCasAttemptsEnvKey;
+using spoor::runtime::config::kEnvConfigKeys;
+using spoor::runtime::config::kEventBufferRetentionDurationNanosecondsEnvKey;
+using spoor::runtime::config::kFlushAllEventsEnvKey;
+using spoor::runtime::config::kMaxDynamicEventBufferSliceCapacityEnvKey;
+using spoor::runtime::config::kMaxFlushBufferToFileAttemptsEnvKey;
+using spoor::runtime::config::kMaxReservedEventBufferSliceCapacityEnvKey;
+using spoor::runtime::config::kReservedEventPoolCapacityEnvKey;
+using spoor::runtime::config::kSessionIdEnvKey;
+using spoor::runtime::config::kThreadEventBufferCapacityEnvKey;
+using spoor::runtime::config::kTraceFilePathEnvKey;
+
+TEST(EnvSource, ReadsConfig) {  // NOLINT
+  const auto get_env = [](const char* key) {
+    constexpr util::flat_map::FlatMap<std::string_view, std::string_view,
+                                      kEnvConfigKeys.size()>
+        environment{
+            {kTraceFilePathEnvKey, "/path/to/trace/"},
+            {kCompressionStrategyEnvKey, "snappy"},
+            {kSessionIdEnvKey, "1"},
+            {kThreadEventBufferCapacityEnvKey, "2"},
+            {kMaxReservedEventBufferSliceCapacityEnvKey, "3"},
+            {kMaxDynamicEventBufferSliceCapacityEnvKey, "4"},
+            {kReservedEventPoolCapacityEnvKey, "5"},
+            {kDynamicEventPoolCapacityEnvKey, "6"},
+            {kDynamicEventSliceBorrowCasAttemptsEnvKey, "7"},
+            {kEventBufferRetentionDurationNanosecondsEnvKey, "8"},
+            {kMaxFlushBufferToFileAttemptsEnvKey, "9"},
+            {kFlushAllEventsEnvKey, "true"},
+        };
+    return environment.FirstValueForKey(key).value().data();
+  };
+  EnvSource env_config{{.get_env = get_env}};
+
+  ASSERT_FALSE(env_config.TraceFilePath().has_value());
+  ASSERT_FALSE(env_config.CompressionStrategy().has_value());
+  ASSERT_FALSE(env_config.SessionId().has_value());
+  ASSERT_FALSE(env_config.ThreadEventBufferCapacity().has_value());
+  ASSERT_FALSE(env_config.MaxReservedEventBufferSliceCapacity().has_value());
+  ASSERT_FALSE(env_config.MaxDynamicEventBufferSliceCapacity().has_value());
+  ASSERT_FALSE(env_config.ReservedEventPoolCapacity().has_value());
+  ASSERT_FALSE(env_config.DynamicEventPoolCapacity().has_value());
+  ASSERT_FALSE(env_config.DynamicEventSliceBorrowCasAttempts().has_value());
+  ASSERT_FALSE(
+      env_config.EventBufferRetentionDurationNanoseconds().has_value());
+  ASSERT_FALSE(env_config.MaxFlushBufferToFileAttempts().has_value());
+  ASSERT_FALSE(env_config.FlushAllEvents().has_value());
+
+  ASSERT_FALSE(env_config.IsRead());
+  const auto read_errors = env_config.Read();
+  ASSERT_TRUE(env_config.IsRead());
+  ASSERT_TRUE(read_errors.empty());
+
+  const auto trace_file_path = env_config.TraceFilePath();
+  ASSERT_TRUE(trace_file_path.has_value());
+  ASSERT_EQ(trace_file_path.value(), "/path/to/trace/");
+  const auto compression_strategy = env_config.CompressionStrategy();
+  ASSERT_TRUE(compression_strategy.has_value());
+  ASSERT_EQ(compression_strategy.value(), util::compression::Strategy::kSnappy);
+  const auto session_id = env_config.SessionId();
+  ASSERT_TRUE(session_id.has_value());
+  ASSERT_EQ(session_id.value(), 1);
+  const auto thread_event_buffer_capacity =
+      env_config.ThreadEventBufferCapacity();
+  ASSERT_TRUE(thread_event_buffer_capacity.has_value());
+  ASSERT_EQ(thread_event_buffer_capacity.value(), 2);
+  const auto max_reserved_event_buffer_slice_capacity =
+      env_config.MaxReservedEventBufferSliceCapacity();
+  ASSERT_TRUE(max_reserved_event_buffer_slice_capacity.has_value());
+  ASSERT_EQ(max_reserved_event_buffer_slice_capacity.value(), 3);
+  const auto max_dynamic_event_buffer_slice_capacity =
+      env_config.MaxDynamicEventBufferSliceCapacity();
+  ASSERT_TRUE(max_dynamic_event_buffer_slice_capacity.has_value());
+  ASSERT_EQ(max_dynamic_event_buffer_slice_capacity.value(), 4);
+  const auto reserved_event_pool_capacity =
+      env_config.ReservedEventPoolCapacity();
+  ASSERT_TRUE(reserved_event_pool_capacity.has_value());
+  ASSERT_EQ(reserved_event_pool_capacity.value(), 5);
+  const auto dynamic_event_pool_capacity =
+      env_config.DynamicEventPoolCapacity();
+  ASSERT_TRUE(dynamic_event_pool_capacity.has_value());
+  ASSERT_EQ(dynamic_event_pool_capacity.value(), 6);
+  const auto dynamic_event_slice_borrow_cas_attempts =
+      env_config.DynamicEventSliceBorrowCasAttempts();
+  ASSERT_TRUE(dynamic_event_slice_borrow_cas_attempts.has_value());
+  ASSERT_EQ(dynamic_event_slice_borrow_cas_attempts.value(), 7);
+  const auto event_buffer_retention_duration_nanoseconds =
+      env_config.EventBufferRetentionDurationNanoseconds();
+  ASSERT_TRUE(event_buffer_retention_duration_nanoseconds.has_value());
+  ASSERT_EQ(event_buffer_retention_duration_nanoseconds, 8);
+  const auto max_flush_buffer_to_file_attempts =
+      env_config.MaxFlushBufferToFileAttempts();
+  ASSERT_TRUE(max_flush_buffer_to_file_attempts.has_value());
+  ASSERT_EQ(max_flush_buffer_to_file_attempts.value(), 9);
+  const auto flush_all_events = env_config.FlushAllEvents();
+  ASSERT_TRUE(flush_all_events.has_value());
+  ASSERT_TRUE(flush_all_events.value());
+}
+
+TEST(EnvSource, NormalizesCompressionStrategy) {  // NOLINT
+  const auto get_env = [](const char* key) -> const char* {
+    constexpr util::flat_map::FlatMap<std::string_view, std::string_view, 1>
+        environment{{kCompressionStrategyEnvKey, "     sNaPpY    "}};
+    auto value = environment.FirstValueForKey(key);
+    if (value.has_value()) return value.value().data();
+    return nullptr;
+  };
+  EnvSource env_config{{.get_env = get_env}};
+
+  const auto read_errors = env_config.Read();
+  ASSERT_TRUE(read_errors.empty());
+
+  const auto compression_strategy = env_config.CompressionStrategy();
+  ASSERT_TRUE(compression_strategy.has_value());
+  ASSERT_EQ(compression_strategy.value(), util::compression::Strategy::kSnappy);
+}
+
+TEST(FileConfig, HandlesEmptyEnv) {  // NOLINT
+  const auto get_env = [](const char* /*unused*/) { return nullptr; };
+  EnvSource env_config{{.get_env = get_env}};
+
+  const auto read_errors = env_config.Read();
+  ASSERT_TRUE(read_errors.empty());
+
+  ASSERT_FALSE(env_config.TraceFilePath().has_value());
+  ASSERT_FALSE(env_config.CompressionStrategy().has_value());
+  ASSERT_FALSE(env_config.SessionId().has_value());
+  ASSERT_FALSE(env_config.ThreadEventBufferCapacity().has_value());
+  ASSERT_FALSE(env_config.MaxReservedEventBufferSliceCapacity().has_value());
+  ASSERT_FALSE(env_config.MaxDynamicEventBufferSliceCapacity().has_value());
+  ASSERT_FALSE(env_config.ReservedEventPoolCapacity().has_value());
+  ASSERT_FALSE(env_config.DynamicEventPoolCapacity().has_value());
+  ASSERT_FALSE(env_config.DynamicEventSliceBorrowCasAttempts().has_value());
+  ASSERT_FALSE(
+      env_config.EventBufferRetentionDurationNanoseconds().has_value());
+  ASSERT_FALSE(env_config.MaxFlushBufferToFileAttempts().has_value());
+  ASSERT_FALSE(env_config.FlushAllEvents().has_value());
+}
+
+TEST(EnvSource, HandlesBadValue) {  // NOLINT
+  const auto get_env = [](const char* key) {
+    constexpr util::flat_map::FlatMap<std::string_view, std::string_view,
+                                      kEnvConfigKeys.size()>
+        environment{
+            {kTraceFilePathEnvKey, "42"},
+            {kCompressionStrategyEnvKey, "42"},
+            {kSessionIdEnvKey, "foo"},
+            {kThreadEventBufferCapacityEnvKey, "foo"},
+            {kMaxReservedEventBufferSliceCapacityEnvKey, "foo"},
+            {kMaxDynamicEventBufferSliceCapacityEnvKey, "foo"},
+            {kReservedEventPoolCapacityEnvKey, "foo"},
+            {kDynamicEventPoolCapacityEnvKey, "foo"},
+            {kDynamicEventSliceBorrowCasAttemptsEnvKey, "foo"},
+            {kEventBufferRetentionDurationNanosecondsEnvKey, "foo"},
+            {kMaxFlushBufferToFileAttemptsEnvKey, "foo"},
+            {kFlushAllEventsEnvKey, "foo"},
+        };
+    return environment.FirstValueForKey(key).value().data();
+  };
+  EnvSource env_config{{.get_env = get_env}};
+
+  ASSERT_FALSE(env_config.IsRead());
+  const auto read_errors = env_config.Read();
+  ASSERT_TRUE(env_config.IsRead());
+
+  // Reading the trace file path into a string cannot fail.
+  ASSERT_EQ(read_errors.size(), kEnvConfigKeys.size() - 1);
+  const auto error_messages = [&read_errors] {
+    std::vector<std::string> messages{};
+    std::transform(std::cbegin(read_errors), std::cend(read_errors),
+                   std::back_inserter(messages),
+                   [](const auto& error) { return error.message; });
+    std::sort(std::begin(messages), std::end(messages));
+    return messages;
+  }();
+  const auto expected_error_messages = [&] {
+    std::vector<std::string_view> keys{};
+    keys.reserve(std::size(kEnvConfigKeys) - 1);
+    std::copy_if(std::cbegin(kEnvConfigKeys), std::cend(kEnvConfigKeys),
+                 std::back_inserter(keys),
+                 [](const auto key) { return key != kTraceFilePathEnvKey; });
+    std::vector<std::string> messages{};
+    std::transform(std::cbegin(keys), std::cend(keys),
+                   std::back_inserter(messages), [](const auto key) {
+                     return absl::StrFormat(
+                         "Cannot parse value for key \"%s\".", key);
+                   });
+    std::sort(std::begin(messages), std::end(messages));
+    return messages;
+  }();
+  ASSERT_EQ(error_messages, expected_error_messages);
+
+  ASSERT_TRUE(env_config.TraceFilePath().has_value());
+  ASSERT_FALSE(env_config.CompressionStrategy().has_value());
+  ASSERT_FALSE(env_config.SessionId().has_value());
+  ASSERT_FALSE(env_config.ThreadEventBufferCapacity().has_value());
+  ASSERT_FALSE(env_config.MaxReservedEventBufferSliceCapacity().has_value());
+  ASSERT_FALSE(env_config.MaxDynamicEventBufferSliceCapacity().has_value());
+  ASSERT_FALSE(env_config.ReservedEventPoolCapacity().has_value());
+  ASSERT_FALSE(env_config.DynamicEventPoolCapacity().has_value());
+  ASSERT_FALSE(env_config.DynamicEventSliceBorrowCasAttempts().has_value());
+  ASSERT_FALSE(
+      env_config.EventBufferRetentionDurationNanoseconds().has_value());
+  ASSERT_FALSE(env_config.MaxFlushBufferToFileAttempts().has_value());
+  ASSERT_FALSE(env_config.FlushAllEvents().has_value());
+}
+
+}  // namespace

--- a/spoor/runtime/config/file_source.cc
+++ b/spoor/runtime/config/file_source.cc
@@ -1,0 +1,186 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "spoor/runtime/config/file_source.h"
+
+#include <algorithm>
+#include <iterator>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "absl/strings/ascii.h"
+#include "absl/strings/str_format.h"
+#include "spoor/runtime/config/source.h"
+#include "spoor/runtime/trace/trace.h"
+#include "tomlplusplus/toml.h"
+#include "util/compression/compressor.h"
+#include "util/numeric.h"
+
+namespace spoor::runtime::config {
+
+FileSource::FileSource(Options options)
+    : options_{std::move(options)}, read_{false} {}
+
+template <class T>
+auto ReadConfig(const toml::table& table, const std::string_view key,
+                gsl::not_null<std::vector<Source::ReadError>*> errors)
+    -> std::optional<T> {
+  const auto* table_value = table.get(key);
+  if (table_value == nullptr) return {};
+  auto value = table_value->value<T>();
+  if (!value.has_value()) {
+    errors->push_back({
+        .type = Source::ReadError::Type::kUnknownValue,
+        .message = absl::StrFormat("Cannot parse value for key \"%s\".", key),
+    });
+  }
+  return value;
+}
+
+auto FileSource::Read() -> std::vector<ReadError> {
+  auto finally_set_read = gsl::finally([this] { read_ = true; });
+
+  const auto file_path = options_.file_path;
+  auto& file = *options_.file_reader;
+  file.Open(file_path);
+  if (!file.IsOpen()) {
+    return {{
+        .type = ReadError::Type::kFailedToOpenFile,
+        .message = absl::StrFormat(
+            "Failed to open the file \"%s\" for reading.", file_path),
+    }};
+  }
+  auto finally_close_file = gsl::finally([&file] { file.Close(); });
+
+  auto toml_result = toml::parse(file.Istream());
+  if (!toml_result) {
+    return {{
+        .type = ReadError::Type::kMalformedFile,
+        .message{toml_result.error().description()},
+    }};
+  }
+  const auto table = std::move(toml_result).table();
+
+  std::vector<ReadError> errors{};
+
+  for (const auto& [key, node] : table) {
+    if (std::find(std::cbegin(kFileConfigKeys), std::cend(kFileConfigKeys),
+                  key) == std::cend(kFileConfigKeys)) {
+      errors.push_back({
+          .type = ReadError::Type::kUnknownKey,
+          .message = absl::StrFormat("Unknown key \"%s\".", key),
+      });
+    }
+  }
+
+  trace_file_path_ = ReadConfig<decltype(trace_file_path_)::value_type>(
+      table, kTraceFilePathFileKey, &errors);
+  compression_strategy_ = [&]() -> decltype(compression_strategy_) {
+    const auto compression_strategy_user_value =
+        ReadConfig<std::string>(table, kCompressionStrategyFileKey, &errors);
+    if (!compression_strategy_user_value.has_value()) return {};
+    auto normalized_value = compression_strategy_user_value.value();
+    absl::StripAsciiWhitespace(&normalized_value);
+    absl::AsciiStrToLower(&normalized_value);
+    const auto compression_strategy =
+        util::compression::kStrategyMap.FirstValueForKey(normalized_value);
+    if (!compression_strategy.has_value()) {
+      errors.push_back({
+          .type = ReadError::Type::kUnknownValue,
+          .message = absl::StrFormat("Unknown compression strategy \"%s\".",
+                                     compression_strategy_user_value.value()),
+      });
+    }
+    return compression_strategy;
+  }();
+  session_id_ = ReadConfig<decltype(session_id_)::value_type>(
+      table, kSessionIdFileKey, &errors);
+  thread_event_buffer_capacity_ =
+      ReadConfig<decltype(thread_event_buffer_capacity_)::value_type>(
+          table, kThreadEventBufferCapacityFileKey, &errors);
+  max_reserved_event_buffer_slice_capacity_ = ReadConfig<
+      decltype(max_reserved_event_buffer_slice_capacity_)::value_type>(
+      table, kMaxReservedEventBufferSliceCapacityFileKey, &errors);
+  max_dynamic_event_buffer_slice_capacity_ = ReadConfig<
+      decltype(max_dynamic_event_buffer_slice_capacity_)::value_type>(
+      table, kMaxDynamicEventBufferSliceCapacityFileKey, &errors);
+  reserved_event_pool_capacity_ =
+      ReadConfig<decltype(reserved_event_pool_capacity_)::value_type>(
+          table, kReservedEventPoolCapacityFileKey, &errors);
+  dynamic_event_pool_capacity_ =
+      ReadConfig<decltype(dynamic_event_pool_capacity_)::value_type>(
+          table, kDynamicEventPoolCapacityFileKey, &errors);
+  dynamic_event_slice_borrow_cas_attempts_ = ReadConfig<
+      decltype(dynamic_event_slice_borrow_cas_attempts_)::value_type>(
+      table, kDynamicEventSliceBorrowCasAttemptsFileKey, &errors);
+  event_buffer_retention_duration_nanoseconds_ = ReadConfig<
+      decltype(event_buffer_retention_duration_nanoseconds_)::value_type>(
+      table, kEventBufferRetentionDurationNanosecondsFileKey, &errors);
+  max_flush_buffer_to_file_attempts_ =
+      ReadConfig<decltype(max_flush_buffer_to_file_attempts_)::value_type>(
+          table, kMaxFlushBufferToFileAttemptsFileKey, &errors);
+  flush_all_events_ = ReadConfig<decltype(flush_all_events_)::value_type>(
+      table, kFlushAllEventsFileKey, &errors);
+
+  return errors;
+}
+
+auto FileSource::IsRead() const -> bool { return read_; }
+
+auto FileSource::TraceFilePath() const -> std::optional<std::string> {
+  return trace_file_path_;
+}
+
+auto FileSource::CompressionStrategy() const
+    -> std::optional<util::compression::Strategy> {
+  return compression_strategy_;
+}
+
+auto FileSource::SessionId() const -> std::optional<trace::SessionId> {
+  return session_id_;
+}
+
+auto FileSource::ThreadEventBufferCapacity() const -> std::optional<SizeType> {
+  return thread_event_buffer_capacity_;
+}
+
+auto FileSource::MaxReservedEventBufferSliceCapacity() const
+    -> std::optional<SizeType> {
+  return max_reserved_event_buffer_slice_capacity_;
+}
+
+auto FileSource::MaxDynamicEventBufferSliceCapacity() const
+    -> std::optional<SizeType> {
+  return max_dynamic_event_buffer_slice_capacity_;
+}
+
+auto FileSource::ReservedEventPoolCapacity() const -> std::optional<SizeType> {
+  return reserved_event_pool_capacity_;
+}
+
+auto FileSource::DynamicEventPoolCapacity() const -> std::optional<SizeType> {
+  return dynamic_event_pool_capacity_;
+}
+
+auto FileSource::DynamicEventSliceBorrowCasAttempts() const
+    -> std::optional<SizeType> {
+  return dynamic_event_slice_borrow_cas_attempts_;
+}
+
+auto FileSource::EventBufferRetentionDurationNanoseconds() const
+    -> std::optional<trace::DurationNanoseconds> {
+  return event_buffer_retention_duration_nanoseconds_;
+}
+
+auto FileSource::MaxFlushBufferToFileAttempts() const -> std::optional<int32> {
+  return max_flush_buffer_to_file_attempts_;
+}
+
+auto FileSource::FlushAllEvents() const -> std::optional<bool> {
+  return flush_all_events_;
+}
+
+}  // namespace spoor::runtime::config

--- a/spoor/runtime/config/file_source.h
+++ b/spoor/runtime/config/file_source.h
@@ -1,0 +1,118 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <array>
+#include <filesystem>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "spoor/runtime/config/source.h"
+#include "spoor/runtime/trace/trace.h"
+#include "util/compression/compressor.h"
+#include "util/file_system/file_reader.h"
+#include "util/numeric.h"
+
+namespace spoor::runtime::config {
+
+constexpr std::string_view kTraceFilePathFileKey{"trace_file_path"};
+constexpr std::string_view kCompressionStrategyFileKey{"compression_strategy"};
+constexpr std::string_view kSessionIdFileKey{"session_id"};
+constexpr std::string_view kThreadEventBufferCapacityFileKey{
+    "thread_event_buffer_capacity"};
+constexpr std::string_view kMaxReservedEventBufferSliceCapacityFileKey{
+    "max_reserved_event_buffer_slice_capacity"};
+constexpr std::string_view kMaxDynamicEventBufferSliceCapacityFileKey{
+    "max_dynamic_event_buffer_slice_capacity"};
+constexpr std::string_view kReservedEventPoolCapacityFileKey{
+    "reserved_event_pool_capacity"};
+constexpr std::string_view kDynamicEventPoolCapacityFileKey{
+    "dynamic_event_pool_capacity"};
+constexpr std::string_view kDynamicEventSliceBorrowCasAttemptsFileKey{
+    "dynamic_event_slice_borrow_cas_attempts"};
+constexpr std::string_view kEventBufferRetentionDurationNanosecondsFileKey{
+    "event_buffer_retention_duration_nanoseconds"};
+constexpr std::string_view kMaxFlushBufferToFileAttemptsFileKey{
+    "max_flush_buffer_to_file_attempts"};
+constexpr std::string_view kFlushAllEventsFileKey{"flush_all_events"};
+constexpr std::array<std::string_view, 12> kFileConfigKeys{{
+    kTraceFilePathFileKey,
+    kCompressionStrategyFileKey,
+    kSessionIdFileKey,
+    kThreadEventBufferCapacityFileKey,
+    kMaxReservedEventBufferSliceCapacityFileKey,
+    kMaxDynamicEventBufferSliceCapacityFileKey,
+    kReservedEventPoolCapacityFileKey,
+    kDynamicEventPoolCapacityFileKey,
+    kDynamicEventSliceBorrowCasAttemptsFileKey,
+    kEventBufferRetentionDurationNanosecondsFileKey,
+    kMaxFlushBufferToFileAttemptsFileKey,
+    kFlushAllEventsFileKey,
+}};
+
+class FileSource final : public Source {
+ public:
+  struct alignas(32) Options {
+    std::unique_ptr<util::file_system::FileReader> file_reader;
+    std::filesystem::path file_path;
+  };
+
+  FileSource() = delete;
+  explicit FileSource(Options options);
+  FileSource(const FileSource&) = delete;
+  FileSource(FileSource&&) noexcept = default;
+  auto operator=(const FileSource&) -> FileSource& = delete;
+  auto operator=(FileSource&&) noexcept -> FileSource& = default;
+  ~FileSource() override = default;
+
+  [[nodiscard]] auto Read() -> std::vector<ReadError> override;
+  [[nodiscard]] auto IsRead() const -> bool override;
+
+  [[nodiscard]] auto TraceFilePath() const
+      -> std::optional<std::string> override;
+  [[nodiscard]] auto CompressionStrategy() const
+      -> std::optional<util::compression::Strategy> override;
+  [[nodiscard]] auto SessionId() const
+      -> std::optional<trace::SessionId> override;
+  [[nodiscard]] auto ThreadEventBufferCapacity() const
+      -> std::optional<SizeType> override;
+  [[nodiscard]] auto MaxReservedEventBufferSliceCapacity() const
+      -> std::optional<SizeType> override;
+  [[nodiscard]] auto MaxDynamicEventBufferSliceCapacity() const
+      -> std::optional<SizeType> override;
+  [[nodiscard]] auto ReservedEventPoolCapacity() const
+      -> std::optional<SizeType> override;
+  [[nodiscard]] auto DynamicEventPoolCapacity() const
+      -> std::optional<SizeType> override;
+  [[nodiscard]] auto DynamicEventSliceBorrowCasAttempts() const
+      -> std::optional<SizeType> override;
+  [[nodiscard]] auto EventBufferRetentionDurationNanoseconds() const
+      -> std::optional<trace::DurationNanoseconds> override;
+  [[nodiscard]] auto MaxFlushBufferToFileAttempts() const
+      -> std::optional<int32> override;
+  [[nodiscard]] auto FlushAllEvents() const -> std::optional<bool> override;
+
+ private:
+  Options options_;
+  bool read_;
+
+  std::optional<std::string> trace_file_path_;
+  std::optional<util::compression::Strategy> compression_strategy_;
+  std::optional<trace::SessionId> session_id_;
+  std::optional<SizeType> thread_event_buffer_capacity_;
+  std::optional<SizeType> max_reserved_event_buffer_slice_capacity_;
+  std::optional<SizeType> max_dynamic_event_buffer_slice_capacity_;
+  std::optional<SizeType> reserved_event_pool_capacity_;
+  std::optional<SizeType> dynamic_event_pool_capacity_;
+  std::optional<SizeType> dynamic_event_slice_borrow_cas_attempts_;
+  std::optional<trace::DurationNanoseconds>
+      event_buffer_retention_duration_nanoseconds_;
+  std::optional<int32> max_flush_buffer_to_file_attempts_;
+  std::optional<bool> flush_all_events_;
+};
+
+}  // namespace spoor::runtime::config

--- a/spoor/runtime/config/file_source_test.cc
+++ b/spoor/runtime/config/file_source_test.cc
@@ -1,0 +1,347 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "spoor/runtime/config/file_source.h"
+
+#include <algorithm>
+#include <filesystem>
+#include <iterator>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "absl/strings/str_format.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "spoor/runtime/buffer/circular_buffer.h"
+#include "spoor/runtime/config/source.h"
+#include "spoor/runtime/trace/trace.h"
+#include "util/compression/compressor.h"
+#include "util/file_system/file_reader_mock.h"
+
+namespace {
+
+using spoor::runtime::config::FileSource;
+using spoor::runtime::config::kCompressionStrategyFileKey;
+using spoor::runtime::config::kDynamicEventPoolCapacityFileKey;
+using spoor::runtime::config::kDynamicEventSliceBorrowCasAttemptsFileKey;
+using spoor::runtime::config::kEventBufferRetentionDurationNanosecondsFileKey;
+using spoor::runtime::config::kFileConfigKeys;
+using spoor::runtime::config::kFlushAllEventsFileKey;
+using spoor::runtime::config::kMaxDynamicEventBufferSliceCapacityFileKey;
+using spoor::runtime::config::kMaxFlushBufferToFileAttemptsFileKey;
+using spoor::runtime::config::kMaxReservedEventBufferSliceCapacityFileKey;
+using spoor::runtime::config::kReservedEventPoolCapacityFileKey;
+using spoor::runtime::config::kSessionIdFileKey;
+using spoor::runtime::config::kThreadEventBufferCapacityFileKey;
+using spoor::runtime::config::kTraceFilePathFileKey;
+using spoor::runtime::config::Source;
+using testing::Return;
+using testing::ReturnRef;
+using util::file_system::testing::FileReaderMock;
+using SizeType = spoor::runtime::buffer::CircularBuffer<
+    spoor::runtime::trace::Event>::SizeType;
+
+TEST(FileSource, ReadsConfig) {  // NOLINT
+  const std::filesystem::path file_path{"/path/to/spoor_runtime_config.toml"};
+  std::stringstream buffer{};
+  buffer << kTraceFilePathFileKey << " = '/path/to/trace/'\n"
+         << kCompressionStrategyFileKey << " = 'snappy'\n"
+         << kSessionIdFileKey << " = 1\n"
+         << kThreadEventBufferCapacityFileKey << " = 2\n"
+         << kMaxReservedEventBufferSliceCapacityFileKey << " = 3\n"
+         << kMaxDynamicEventBufferSliceCapacityFileKey << " = 4\n"
+         << kReservedEventPoolCapacityFileKey << " = 5\n"
+         << kDynamicEventPoolCapacityFileKey << " = 6\n"
+         << kDynamicEventSliceBorrowCasAttemptsFileKey << " = 7\n"
+         << kEventBufferRetentionDurationNanosecondsFileKey << " = 8\n"
+         << kMaxFlushBufferToFileAttemptsFileKey << " = 9\n"
+         << kFlushAllEventsFileKey << " = true";
+  auto file_reader = std::make_unique<FileReaderMock>();
+  EXPECT_CALL(*file_reader, Open(file_path));
+  EXPECT_CALL(*file_reader, IsOpen()).WillOnce(Return(true));
+  EXPECT_CALL(*file_reader, Istream()).WillOnce(ReturnRef(buffer));
+  EXPECT_CALL(*file_reader, Close());
+  FileSource file_config{{
+      .file_reader{std::move(file_reader)},
+      .file_path{file_path},
+  }};
+
+  ASSERT_FALSE(file_config.TraceFilePath().has_value());
+  ASSERT_FALSE(file_config.CompressionStrategy().has_value());
+  ASSERT_FALSE(file_config.SessionId().has_value());
+  ASSERT_FALSE(file_config.ThreadEventBufferCapacity().has_value());
+  ASSERT_FALSE(file_config.MaxReservedEventBufferSliceCapacity().has_value());
+  ASSERT_FALSE(file_config.MaxDynamicEventBufferSliceCapacity().has_value());
+  ASSERT_FALSE(file_config.ReservedEventPoolCapacity().has_value());
+  ASSERT_FALSE(file_config.DynamicEventPoolCapacity().has_value());
+  ASSERT_FALSE(file_config.DynamicEventSliceBorrowCasAttempts().has_value());
+  ASSERT_FALSE(
+      file_config.EventBufferRetentionDurationNanoseconds().has_value());
+  ASSERT_FALSE(file_config.MaxFlushBufferToFileAttempts().has_value());
+  ASSERT_FALSE(file_config.FlushAllEvents().has_value());
+
+  ASSERT_FALSE(file_config.IsRead());
+  const auto read_errors = file_config.Read();
+  ASSERT_TRUE(file_config.IsRead());
+  ASSERT_TRUE(read_errors.empty());
+
+  const auto trace_file_path = file_config.TraceFilePath();
+  ASSERT_TRUE(trace_file_path.has_value());
+  ASSERT_EQ(trace_file_path.value(), "/path/to/trace/");
+  const auto compression_strategy = file_config.CompressionStrategy();
+  ASSERT_TRUE(compression_strategy.has_value());
+  ASSERT_EQ(compression_strategy.value(), util::compression::Strategy::kSnappy);
+  const auto session_id = file_config.SessionId();
+  ASSERT_TRUE(session_id.has_value());
+  ASSERT_EQ(session_id.value(), 1);
+  const auto thread_event_buffer_capacity =
+      file_config.ThreadEventBufferCapacity();
+  ASSERT_TRUE(thread_event_buffer_capacity.has_value());
+  ASSERT_EQ(thread_event_buffer_capacity.value(), 2);
+  const auto max_reserved_event_buffer_slice_capacity =
+      file_config.MaxReservedEventBufferSliceCapacity();
+  ASSERT_TRUE(max_reserved_event_buffer_slice_capacity.has_value());
+  ASSERT_EQ(max_reserved_event_buffer_slice_capacity.value(), 3);
+  const auto max_dynamic_event_buffer_slice_capacity =
+      file_config.MaxDynamicEventBufferSliceCapacity();
+  ASSERT_TRUE(max_dynamic_event_buffer_slice_capacity.has_value());
+  ASSERT_EQ(max_dynamic_event_buffer_slice_capacity.value(), 4);
+  const auto reserved_event_pool_capacity =
+      file_config.ReservedEventPoolCapacity();
+  ASSERT_TRUE(reserved_event_pool_capacity.has_value());
+  ASSERT_EQ(reserved_event_pool_capacity.value(), 5);
+  const auto dynamic_event_pool_capacity =
+      file_config.DynamicEventPoolCapacity();
+  ASSERT_TRUE(dynamic_event_pool_capacity.has_value());
+  ASSERT_EQ(dynamic_event_pool_capacity.value(), 6);
+  const auto dynamic_event_slice_borrow_cas_attempts =
+      file_config.DynamicEventSliceBorrowCasAttempts();
+  ASSERT_TRUE(dynamic_event_slice_borrow_cas_attempts.has_value());
+  ASSERT_EQ(dynamic_event_slice_borrow_cas_attempts.value(), 7);
+  const auto event_buffer_retention_duration_nanoseconds =
+      file_config.EventBufferRetentionDurationNanoseconds();
+  ASSERT_TRUE(event_buffer_retention_duration_nanoseconds.has_value());
+  ASSERT_EQ(event_buffer_retention_duration_nanoseconds, 8);
+  const auto max_flush_buffer_to_file_attempts =
+      file_config.MaxFlushBufferToFileAttempts();
+  ASSERT_TRUE(max_flush_buffer_to_file_attempts.has_value());
+  ASSERT_EQ(max_flush_buffer_to_file_attempts.value(), 9);
+  const auto flush_all_events = file_config.FlushAllEvents();
+  ASSERT_TRUE(flush_all_events.has_value());
+  ASSERT_TRUE(flush_all_events.value());
+}
+
+TEST(FileSource, NormalizesCompressionStrategy) {  // NOLINT
+  const std::filesystem::path file_path{"/path/to/spoor_runtime_config.toml"};
+  std::stringstream buffer{};
+  buffer << kCompressionStrategyFileKey << " = \"     sNaPpY    \"";
+  auto file_reader = std::make_unique<FileReaderMock>();
+  EXPECT_CALL(*file_reader, Open(file_path));
+  EXPECT_CALL(*file_reader, IsOpen()).WillOnce(Return(true));
+  EXPECT_CALL(*file_reader, Istream()).WillOnce(ReturnRef(buffer));
+  EXPECT_CALL(*file_reader, Close());
+  FileSource file_config{{
+      .file_reader{std::move(file_reader)},
+      .file_path{file_path},
+  }};
+
+  const auto read_errors = file_config.Read();
+  ASSERT_TRUE(read_errors.empty());
+
+  const auto compression_strategy = file_config.CompressionStrategy();
+  ASSERT_TRUE(compression_strategy.has_value());
+  ASSERT_EQ(compression_strategy.value(), util::compression::Strategy::kSnappy);
+}
+
+TEST(FileSource, HandlesEmptyFile) {  // NOLINT
+  const std::filesystem::path file_path{"/path/to/spoor_runtime_config.toml"};
+  std::stringstream buffer{};
+  auto file_reader = std::make_unique<FileReaderMock>();
+  EXPECT_CALL(*file_reader, Open(file_path));
+  EXPECT_CALL(*file_reader, IsOpen()).WillOnce(Return(true));
+  EXPECT_CALL(*file_reader, Istream()).WillOnce(ReturnRef(buffer));
+  EXPECT_CALL(*file_reader, Close());
+  FileSource file_config{{
+      .file_reader{std::move(file_reader)},
+      .file_path{file_path},
+  }};
+
+  const auto read_errors = file_config.Read();
+  ASSERT_TRUE(read_errors.empty());
+
+  ASSERT_FALSE(file_config.TraceFilePath().has_value());
+  ASSERT_FALSE(file_config.CompressionStrategy().has_value());
+  ASSERT_FALSE(file_config.SessionId().has_value());
+  ASSERT_FALSE(file_config.ThreadEventBufferCapacity().has_value());
+  ASSERT_FALSE(file_config.MaxReservedEventBufferSliceCapacity().has_value());
+  ASSERT_FALSE(file_config.MaxDynamicEventBufferSliceCapacity().has_value());
+  ASSERT_FALSE(file_config.ReservedEventPoolCapacity().has_value());
+  ASSERT_FALSE(file_config.DynamicEventPoolCapacity().has_value());
+  ASSERT_FALSE(file_config.DynamicEventSliceBorrowCasAttempts().has_value());
+  ASSERT_FALSE(
+      file_config.EventBufferRetentionDurationNanoseconds().has_value());
+  ASSERT_FALSE(file_config.MaxFlushBufferToFileAttempts().has_value());
+  ASSERT_FALSE(file_config.FlushAllEvents().has_value());
+}
+
+TEST(FileSource, HandlesFailedToOpenFile) {  // NOLINT
+  const std::filesystem::path file_path{"/path/to/spoor_runtime_config.toml"};
+  auto file_reader = std::make_unique<FileReaderMock>();
+  EXPECT_CALL(*file_reader, Open(file_path));
+  EXPECT_CALL(*file_reader, IsOpen()).WillOnce(Return(false));
+  EXPECT_CALL(*file_reader, Close()).Times(0);
+  FileSource file_config{{
+      .file_reader{std::move(file_reader)},
+      .file_path{file_path},
+  }};
+  const auto read_errors = file_config.Read();
+  ASSERT_EQ(read_errors.size(), 1);
+  const auto& error = read_errors.front();
+  ASSERT_EQ(error.type, Source::ReadError::Type::kFailedToOpenFile);
+  ASSERT_EQ(error.message,
+            "Failed to open the file \"/path/to/spoor_runtime_config.toml\" "
+            "for reading.");
+  ASSERT_TRUE(file_config.IsRead());
+}
+
+TEST(FileSource, HandlesMalformedFile) {  // NOLINT
+  const std::filesystem::path file_path{"/path/to/spoor_runtime_config.toml"};
+  std::stringstream buffer{"bad toml"};
+  auto file_reader = std::make_unique<FileReaderMock>();
+  EXPECT_CALL(*file_reader, Open(file_path));
+  EXPECT_CALL(*file_reader, IsOpen()).WillOnce(Return(true));
+  EXPECT_CALL(*file_reader, Istream()).WillOnce(ReturnRef(buffer));
+  EXPECT_CALL(*file_reader, Close());
+  FileSource file_config{{
+      .file_reader{std::move(file_reader)},
+      .file_path{file_path},
+  }};
+
+  const auto read_errors = file_config.Read();
+  ASSERT_EQ(read_errors.size(), 1);
+  const auto& error = read_errors.front();
+  ASSERT_EQ(error.type, Source::ReadError::Type::kMalformedFile);
+}
+
+TEST(FileSource, HandlesUnknownKey) {  // NOLINT
+  constexpr std::string_view bad_key{"bad_key"};
+  const std::filesystem::path file_path{"/path/to/spoor_runtime_config.toml"};
+  std::stringstream buffer{};
+  buffer << bad_key << " = false\n" << kFlushAllEventsFileKey << " = true";
+  auto file_reader = std::make_unique<FileReaderMock>();
+  EXPECT_CALL(*file_reader, Open(file_path));
+  EXPECT_CALL(*file_reader, IsOpen()).WillOnce(Return(true));
+  EXPECT_CALL(*file_reader, Istream()).WillOnce(ReturnRef(buffer));
+  EXPECT_CALL(*file_reader, Close());
+  FileSource file_config{{
+      .file_reader{std::move(file_reader)},
+      .file_path{file_path},
+  }};
+
+  const auto read_errors = file_config.Read();
+  ASSERT_EQ(read_errors.size(), 1);
+  const auto& error = read_errors.front();
+  ASSERT_EQ(error.type, Source::ReadError::Type::kUnknownKey);
+  ASSERT_EQ(error.message, absl::StrFormat("Unknown key \"%s\".", bad_key));
+
+  const auto flush_all_events = file_config.FlushAllEvents();
+  ASSERT_TRUE(flush_all_events.has_value());
+  ASSERT_TRUE(flush_all_events.value());
+}
+
+TEST(FileSource, HandlesBadValue) {  // NOLINT
+  const std::filesystem::path file_path{"/path/to/spoor_runtime_config.toml"};
+  std::stringstream buffer{};
+  buffer << kTraceFilePathFileKey << " = 42\n"
+         << kCompressionStrategyFileKey << " = 42\n"
+         << kSessionIdFileKey << " = '42'\n"
+         << kThreadEventBufferCapacityFileKey << " = '42'\n"
+         << kMaxReservedEventBufferSliceCapacityFileKey << " = '42'\n"
+         << kMaxDynamicEventBufferSliceCapacityFileKey << " = '42'\n"
+         << kReservedEventPoolCapacityFileKey << " = '42'\n"
+         << kDynamicEventPoolCapacityFileKey << " = '42'\n"
+         << kDynamicEventSliceBorrowCasAttemptsFileKey << " = '42'\n"
+         << kEventBufferRetentionDurationNanosecondsFileKey << " = '42'\n"
+         << kMaxFlushBufferToFileAttemptsFileKey << " = '42'\n"
+         << kFlushAllEventsFileKey << " = 'true'";
+  auto file_reader = std::make_unique<FileReaderMock>();
+  EXPECT_CALL(*file_reader, Open(file_path));
+  EXPECT_CALL(*file_reader, IsOpen()).WillOnce(Return(true));
+  EXPECT_CALL(*file_reader, Istream()).WillOnce(ReturnRef(buffer));
+  EXPECT_CALL(*file_reader, Close());
+
+  FileSource file_config{{
+      .file_reader{std::move(file_reader)},
+      .file_path{file_path},
+  }};
+
+  const auto read_errors = file_config.Read();
+  ASSERT_EQ(read_errors.size(), std::size(kFileConfigKeys));
+  ASSERT_TRUE(std::all_of(
+      std::cbegin(read_errors), std::cend(read_errors), [](const auto& error) {
+        return error.type == Source::ReadError::Type::kUnknownValue;
+      }));
+  const auto error_messages = [&read_errors] {
+    std::vector<std::string> messages{};
+    std::transform(std::cbegin(read_errors), std::cend(read_errors),
+                   std::back_inserter(messages),
+                   [](const auto& error) { return error.message; });
+    std::sort(std::begin(messages), std::end(messages));
+    return messages;
+  }();
+  const auto expected_error_messages = [&] {
+    std::vector<std::string> messages{};
+    std::transform(std::cbegin(kFileConfigKeys), std::cend(kFileConfigKeys),
+                   std::back_inserter(messages), [](const auto key) {
+                     return absl::StrFormat(
+                         "Cannot parse value for key \"%s\".", key);
+                   });
+    std::sort(std::begin(messages), std::end(messages));
+    return messages;
+  }();
+  ASSERT_EQ(error_messages, expected_error_messages);
+
+  ASSERT_FALSE(file_config.TraceFilePath().has_value());
+  ASSERT_FALSE(file_config.CompressionStrategy().has_value());
+  ASSERT_FALSE(file_config.SessionId().has_value());
+  ASSERT_FALSE(file_config.ThreadEventBufferCapacity().has_value());
+  ASSERT_FALSE(file_config.MaxReservedEventBufferSliceCapacity().has_value());
+  ASSERT_FALSE(file_config.MaxDynamicEventBufferSliceCapacity().has_value());
+  ASSERT_FALSE(file_config.ReservedEventPoolCapacity().has_value());
+  ASSERT_FALSE(file_config.DynamicEventPoolCapacity().has_value());
+  ASSERT_FALSE(file_config.DynamicEventSliceBorrowCasAttempts().has_value());
+  ASSERT_FALSE(
+      file_config.EventBufferRetentionDurationNanoseconds().has_value());
+  ASSERT_FALSE(file_config.MaxFlushBufferToFileAttempts().has_value());
+  ASSERT_FALSE(file_config.FlushAllEvents().has_value());
+}
+
+TEST(FileSource, HandlesUnknownCompressionStrategy) {  // NOLINT
+  const std::filesystem::path file_path{"/path/to/spoor_runtime_config.toml"};
+  std::stringstream buffer{};
+  buffer << kCompressionStrategyFileKey << " = 'lz4'";
+
+  auto file_reader = std::make_unique<FileReaderMock>();
+  EXPECT_CALL(*file_reader, Open(file_path));
+  EXPECT_CALL(*file_reader, IsOpen()).WillOnce(Return(true));
+  EXPECT_CALL(*file_reader, Istream()).WillOnce(ReturnRef(buffer));
+  EXPECT_CALL(*file_reader, Close());
+  FileSource file_config{{
+      .file_reader{std::move(file_reader)},
+      .file_path{file_path},
+  }};
+
+  const auto read_errors = file_config.Read();
+  ASSERT_EQ(read_errors.size(), 1);
+  const auto& error = read_errors.front();
+  ASSERT_EQ(error.type, Source::ReadError::Type::kUnknownValue);
+  ASSERT_EQ(error.message, "Unknown compression strategy \"lz4\".");
+  const auto compression_strategy = file_config.CompressionStrategy();
+  ASSERT_FALSE(compression_strategy.has_value());
+}
+
+}  // namespace

--- a/spoor/runtime/config/source.h
+++ b/spoor/runtime/config/source.h
@@ -1,0 +1,72 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "spoor/runtime/buffer/circular_buffer.h"
+#include "spoor/runtime/trace/trace.h"
+#include "util/compression/compressor.h"
+#include "util/numeric.h"
+
+namespace spoor::runtime::config {
+
+class Source {
+ public:
+  using SizeType = buffer::CircularBuffer<trace::Event>::SizeType;
+
+  struct alignas(32) ReadError {
+    enum class Type {
+      kFailedToOpenFile,
+      kMalformedFile,
+      kUnknownKey,
+      kUnknownValue,
+    };
+
+    Type type;
+    std::string message;
+  };
+
+  virtual ~Source() = default;
+
+  // Synchronously read the configuration from the data source. Makes a "best
+  // effort" to read the configuration, even if there are errors.
+  [[nodiscard]] virtual auto Read() -> std::vector<ReadError> = 0;
+  [[nodiscard]] virtual auto IsRead() const -> bool = 0;
+
+  [[nodiscard]] virtual auto TraceFilePath() const
+      -> std::optional<std::string> = 0;
+  [[nodiscard]] virtual auto CompressionStrategy() const
+      -> std::optional<util::compression::Strategy> = 0;
+  [[nodiscard]] virtual auto SessionId() const
+      -> std::optional<trace::SessionId> = 0;
+  [[nodiscard]] virtual auto ThreadEventBufferCapacity() const
+      -> std::optional<SizeType> = 0;
+  [[nodiscard]] virtual auto MaxReservedEventBufferSliceCapacity() const
+      -> std::optional<SizeType> = 0;
+  [[nodiscard]] virtual auto MaxDynamicEventBufferSliceCapacity() const
+      -> std::optional<SizeType> = 0;
+  [[nodiscard]] virtual auto ReservedEventPoolCapacity() const
+      -> std::optional<SizeType> = 0;
+  [[nodiscard]] virtual auto DynamicEventPoolCapacity() const
+      -> std::optional<SizeType> = 0;
+  [[nodiscard]] virtual auto DynamicEventSliceBorrowCasAttempts() const
+      -> std::optional<SizeType> = 0;
+  [[nodiscard]] virtual auto EventBufferRetentionDurationNanoseconds() const
+      -> std::optional<trace::DurationNanoseconds> = 0;
+  [[nodiscard]] virtual auto MaxFlushBufferToFileAttempts() const
+      -> std::optional<int32> = 0;
+  [[nodiscard]] virtual auto FlushAllEvents() const -> std::optional<bool> = 0;
+
+ protected:
+  constexpr Source() = default;
+  constexpr Source(const Source&) = default;
+  constexpr Source(Source&&) noexcept = default;
+  constexpr auto operator=(const Source&) -> Source& = default;
+  constexpr auto operator=(Source&&) noexcept -> Source& = default;
+};
+
+}  // namespace spoor::runtime::config

--- a/spoor/runtime/config/source_mock.h
+++ b/spoor/runtime/config/source_mock.h
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "gmock/gmock.h"
+#include "spoor/runtime/config/source.h"
+#include "spoor/runtime/trace/trace.h"
+#include "util/compression/compressor.h"
+#include "util/numeric.h"
+
+namespace spoor::runtime::config::testing {
+
+class SourceMock final : public Source {
+ public:
+  MOCK_METHOD((std::vector<ReadError>), Read, (), (override));  // NOLINT
+  MOCK_METHOD(bool, IsRead, (), (const, override));             // NOLINT
+
+  MOCK_METHOD(  // NOLINT
+      (std::optional<std::string>), TraceFilePath, (), (const, override));
+  MOCK_METHOD(  // NOLINT
+      std::optional<util::compression::Strategy>, CompressionStrategy, (),
+      (const, override));
+  MOCK_METHOD(  // NOLINT
+      (std::optional<trace::SessionId>), SessionId, (), (const, override));
+  MOCK_METHOD(  // NOLINT
+      (std::optional<SizeType>), ThreadEventBufferCapacity, (),
+      (const, override));
+  MOCK_METHOD(  // NOLINT
+      (std::optional<SizeType>), MaxReservedEventBufferSliceCapacity, (),
+      (const, override));
+  MOCK_METHOD(  // NOLINT
+      (std::optional<SizeType>), MaxDynamicEventBufferSliceCapacity, (),
+      (const, override));
+  MOCK_METHOD(  // NOLINT
+      (std::optional<SizeType>), ReservedEventPoolCapacity, (),
+      (const, override));
+  MOCK_METHOD(  // NOLINT
+      (std::optional<SizeType>), DynamicEventPoolCapacity, (),
+      (const, override));
+  MOCK_METHOD(  // NOLINT
+      (std::optional<SizeType>), DynamicEventSliceBorrowCasAttempts, (),
+      (const, override));
+  MOCK_METHOD(  // NOLINT
+      (std::optional<trace::DurationNanoseconds>),
+      EventBufferRetentionDurationNanoseconds, (), (const, override));
+  MOCK_METHOD(  // NOLINT
+      (std::optional<int32>), MaxFlushBufferToFileAttempts, (),
+      (const, override));
+  MOCK_METHOD(  // NOLINT
+      (std::optional<bool>), FlushAllEvents, (), (const, override));
+};
+
+}  // namespace spoor::runtime::config::testing

--- a/util/compression/BUILD
+++ b/util/compression/BUILD
@@ -29,6 +29,7 @@ cc_library(
     deps = [
         "//util:numeric",
         "//util:result",
+        "//util/flat_map",
         "@com_google_snappy//:snappy",
         "@com_microsoft_gsl//:gsl",
     ],

--- a/util/compression/compressor.h
+++ b/util/compression/compressor.h
@@ -3,7 +3,11 @@
 
 #pragma once
 
+#include <array>
+#include <string_view>
+
 #include "gsl/gsl"
+#include "util/flat_map/flat_map.h"
 #include "util/numeric.h"
 #include "util/result.h"
 
@@ -16,6 +20,9 @@ enum class Strategy : uint8 {
 
 constexpr std::array<Strategy, 2> kStrategies{
     {Strategy::kNone, Strategy::kSnappy}};
+constexpr util::flat_map::FlatMap<std::string_view, Strategy,
+                                  std::size(kStrategies)>
+    kStrategyMap{{"none", Strategy::kNone}, {"snappy", Strategy::kSnappy}};
 
 class Compressor {
  public:


### PR DESCRIPTION
Adds support to configure the runtime via a file. Environment variables override the file config.

```toml
# spoor_runtime_config.toml

trace_file_path = "~/Documents/trace/"
compression_strategy = "snappy"
session_id = 42
thread_event_buffer_capacity = 1000000
max_reserved_event_buffer_slice_capacity = 1000000
max_dynamic_event_buffer_slice_capacity = 1000000
reserved_event_pool_capacity = 10000000
event_buffer_retention_duration_nanoseconds = 10000000000
dynamic_event_pool_capacity = 0x7fffffffffffffff
max_flush_buffer_to_file_attempts = 2
flush_all_events = true
```

Right now the configuration file is hard-coded as `spoor_runtime_config.toml`. This is already a substantial PR so we'll implement config file path configuration as a follow-up. We'll also update the documentation in a follow-up.

Introduces #219.