### PR TITLE
Remove redundant iOS and macSO apple_static_library

### DIFF
--- a/spoor/runtime/BUILD
+++ b/spoor/runtime/BUILD
@@ -39,22 +39,6 @@ cc_static_library(
     deps = [":runtime"],
 )
 
-apple_static_library(
-    name = "spoor_runtime_ios",
-    linkopts = SPOOR_DEFAULT_LINKOPTS,
-    platform_type = "ios",
-    visibility = ["//visibility:public"],
-    deps = [":runtime"],
-)
-
-apple_static_library(
-    name = "spoor_runtime_macos",
-    linkopts = SPOOR_DEFAULT_LINKOPTS,
-    platform_type = "macos",
-    visibility = ["//visibility:public"],
-    deps = [":runtime"],
-)
-
 cc_library(
     name = "runtime_stub",
     srcs = [

--- a/toolchain/xcode/BUILD
+++ b/toolchain/xcode/BUILD
@@ -137,11 +137,11 @@ _TOOLCHAIN_TARGETS_TO_OUTS = [
         TOOLCHAIN_NAME + "/usr/bin/shared.py",
     ],
     [
-        "//spoor/runtime:spoor_runtime_ios",
+        "//spoor/runtime/wrappers/apple:spoor_runtime_ios",
         TOOLCHAIN_NAME + "/spoor/lib/libspoor_runtime_ios.a",
     ],
     [
-        "//spoor/runtime:spoor_runtime_macos",
+        "//spoor/runtime/wrappers/apple:spoor_runtime_macos",
         TOOLCHAIN_NAME + "/spoor/lib/libspoor_runtime_macos.a",
     ],
     [


### PR DESCRIPTION
Removes the redundant iOS and macSO apple_static_library in `//spoor/runtime`. Instead, we use the apple_static_library in `//spoor/runtime/wrappers/apple`.