### PR TITLE
Runtime file config path

### DIFF
--- a/docs/configuration/instrumentation.md
+++ b/docs/configuration/instrumentation.md
@@ -1,61 +1,111 @@
 # Instrumentation
 
-Configure Spoor's instrumentation with environment variables.
-
 ## Source code
 
 [spoor/instrumentation/config/][spoor-instrumentation-config]
 
 ## Instrumentation options
 
-### SPOOR_INSTRUMENTATION_ENABLE_RUNTIME
+Configure Spoor's instrumentation with environment variables.
+
+!!! note "Config functions"
+    Spoor does not instrument
+    [user-defined config functions][user-defined-config] to prevent recursive
+    initialization.
+
+### Enable runtime
+
 Automatically enable Spoor's runtime.
 
 **Default:** `true`
 
-### SPOOR_INSTRUMENTATION_FILTERS_FILE
+Source               | Key
+-------------------- | --------------------------------------
+Environment variable | `SPOOR_INSTRUMENTATION_ENABLE_RUNTIME`
+
+### Filters file
+
 Path to the [filters file](#filters-file).
 
 **Default:** Empty (no filters)
 
-### SPOOR_INSTRUMENTATION_FORCE_BINARY_OUTPUT
+Source               | Key
+-------------------- | ------------------------------------
+Environment variable | `SPOOR_INSTRUMENTATION_FILTERS_FILE`
+
+### Force binary output
+
 Force printing binary data to the console.
 
 **Default:** `false`
 
-### SPOOR_INSTRUMENTATION_INITIALIZE_RUNTIME
+Source               | Key
+-------------------- | -------------------------------------------
+Environment variable | `SPOOR_INSTRUMENTATION_FORCE_BINARY_OUTPUT`
+
+### Initialize runtime
+
 Automatically initialize Spoor's runtime. This is achieved by injecting a call
 to `_spoor_runtime_Initialize()` at the start of `main`.
 
 **Default:** `true`
 
-### SPOOR_INSTRUMENTATION_INJECT_INSTRUMENTATION
+Source               | Key
+-------------------- | ------------------------------------------
+Environment variable | `SPOOR_INSTRUMENTATION_INITIALIZE_RUNTIME`
+
+### Inject instrumentation
+
 Inject Spoor instrumentation.
 
 **Default:** `true`
 
-### SPOOR_INSTRUMENTATION_MODULE_ID
+Source               | Key
+-------------------- | ----------------------------------------------
+Environment variable | `SPOOR_INSTRUMENTATION_INJECT_INSTRUMENTATION`
+
+### Module ID
+
 Override the LLVM module's ID.
 
 **Default:** Empty (do not override LLVM module ID)
 
-### SPOOR_INSTRUMENTATION_OUTPUT_FILE
+Source               | Key
+-------------------- | ---------------------------------
+Environment variable | `SPOOR_INSTRUMENTATION_MODULE_ID`
+
+### Output file
+
 Spoor instrumentation symbols output file.
 
 **Default:** `-` (stdout)
 
-### SPOOR_INSTRUMENTATION_OUTPUT_SYMBOLS_FILE
+Source               | Key
+-------------------- | -----------------------------------
+Environment variable | `SPOOR_INSTRUMENTATION_OUTPUT_FILE`
+
+### Output symbols file
+
 Spoor instrumentation symbols output file. The path must be absolute and all
 parent directories must exist. Tilde expansion is not supported.
 
 **Default:** Empty (error)
 
-### SPOOR_INSTRUMENTATION_OUTPUT_LANGUAGE
+Source               | Key
+-------------------- | -------------------------------------------
+Environment variable | `SPOOR_INSTRUMENTATION_OUTPUT_SYMBOLS_FILE`
+
+### Output language
+
 Language in which to output the transformed code.
 
 **Options:** `ir` or `bitcode`.
 
 **Default value:** `bitcode`
+
+Source               | Key
+-------------------- | ---------------------------------------
+Environment variable | `SPOOR_INSTRUMENTATION_OUTPUT_LANGUAGE`
 
 ## Filters file
 
@@ -64,9 +114,11 @@ match an allow list rule.
 
 A function must match all conditions within in a block or allow rule to apply.
 
-Note: An empty rule matches everything.
+!!! note "Match everything"
+    An empty rule matches everything.
 
-Tip: Escape backslashes in regular expressions.
+!!! info "Backslashes"
+    Escape backslashes in regular expressions.
 
 **Example filters file**
 
@@ -93,14 +145,24 @@ whose demangled name matches `^facebook::jsc::.*"`, **EXCEPT** for the main
 function which is always instrumented (regardless of its source file path or
 instruction count).
 
-### rule_name
+### Rule name
+
 Optional. Helpful description of the rule. If a filter matches a function during
 instrumentation (either blocking or allowing it), the rule's name is reported in
 the emitted symbols metadata. If multiple rules apply to a function, only one of
 the rules is reported.
 
-### source_file_path
+Source      | Key
+----------- | -----------
+Config file | `rule_name`
+
+### Source file path
+
 Optional. Regular expression (string) matching the source file path.
+
+Source      | Key
+----------- | ------------------
+Config file | `source_file_path`
 
 **Example source file paths**
 
@@ -112,8 +174,13 @@ Optional. Regular expression (string) matching the source file path.
 <compiler-generated>
 ```
 
-### function_demangled_name
+### Demangled function name
+
 Optional. Regular expression (string) matching the demangled function name.
+
+Source      | Key
+----------- | -------------------------
+Config file | `function_demangled_name`
 
 **Example demangled function names**
 
@@ -133,30 +200,48 @@ app_ios.Bootstrap.appDidFinish(with: Swift.Optional<Swift.Dictionary<__C.UIAppli
 +[RCTCxxBridge runRunLoop]
 ```
 
-### function_linkage_name
+### Function linkage name
+
 Optional. Regular expression (string) matching the function's linkage name.
+
+Source      | Key
+----------- | -----------------------
+Config file | `function_linkage_name`
 
 **Example function linkage names**
 
 ```
 main
 ```
+
 ```
 _ZNSt3__1L4sortINS_12basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEEEEvNS_11__wrap_iterIPT_EESA_
 ```
 ```
 $s7app_ios9BootstrapC0A9DidFinish4withySDySo29UIApplicationLaunchOptionsKeyaypGSg_tF
 ```
+
 ```
 +[RCTCxxBridge runRunLoop]
 ```
 
-### function_ir_instruction_count_lt
+### Function IR instruction count less than
+
 Optional. Integer. Matches all functions with an IR instruction count strictly
 less than the provided value.
 
-### function_ir_instruction_count_gt
+Source      | Key
+----------- | ----------------------------------
+Config file | `function_ir_instruction_count_lt`
+
+### Function IR instruction count greater than
+
 Optional. Integer. Matches all functions with an IR instruction count strictly
 greater than the provided value.
 
+Source      | Key
+----------- | ----------------------------------
+Config file | `function_ir_instruction_count_gt`
+
 [spoor-instrumentation-config]: https://github.com/microsoft/spoor/tree/master/spoor/instrumentation/config
+[user-defined-config]: /configuration/runtime/#configuration-file

--- a/docs/configuration/runtime.md
+++ b/docs/configuration/runtime.md
@@ -1,107 +1,249 @@
 # Runtime
 
-Configure Spoor's runtime with environment variables.
+Configure Spoor's runtime with environment variables or a configuration file.
+
+!!! info "Precedence"
+    Environment configurations override file configurations.
 
 ## Source code
 
 [spoor/runtime/config/][spoor-runtime-config]
 
-## Calculating memory impact
-
-```
-event_size = 24 bytes
-min_memory_impact = event_size * SPOOR_RUNTIME_RESERVED_EVENT_POOL_CAPACITY
-max_memory_impact = min_memory_impact + event_size * SPOOR_RUNTIME_RESERVED_EVENT_POOL_CAPACITY
-```
-
 ## Runtime options
 
-### SPOOR_RUNTIME_TRACE_FILE_PATH
+### Trace file path
 
-Directory in which to save flushed trace files. The path must exist, and end
-with a trailing `/`.
+Directory in which to save flushed trace files.
+
+**Type:** `string`
 
 **Default:** `.`
 
-### SPOOR_RUNTIME_COMPRESSION_STRATEGY
+Source               | Key
+-------------------- | ------------------------------
+Environment variable | `SPOOR_RUNTIME_TRACE_FILE_PATH`
+Config file          | `trace_file_path`
+
+!!! warning "Path requirements"
+    The path must exist and end with a trailing `/`.
+
+!!! tip "Environment variable expansion"
+    Spoor automatically expands environment variables. A tilde (i.e., `~`)
+    expands to the value of `$HOME`.
+
+### Compression strategy
 
 Strategy used to compress the trace file on flush.
 
-**Options:** `none` or `snappy`.
+**Type:** `string`
 
-Snappy offers a ~3x compression ratio.
+**Options:** `none` or `snappy`
 
 **Default:** `snappy`
 
-### SPOOR_RUNTIME_SESSION_ID
+Source               | Key
+-------------------- | ------------------------------------
+Environment variable | `SPOOR_RUNTIME_COMPRESSION_STRATEGY`
+Config file          | `compression_strategy`
+
+!!! tip "Compression ratio"
+    Snappy offers a ~3x compression ratio.
+
+### Session ID
 
 Session identifier used to differentiate between runs.
 
-**Default:** Random number (distinct for each launch)
+**Type:** `uint64`
 
-### SPOOR_RUNTIME_THEAD_EVENT_BUFFER_CAPACITY
+**Default:** Random number (likely distinct for each launch)
+
+Source               | Key
+-------------------- | --------------------------
+Environment variable | `SPOOR_RUNTIME_SESSION_ID`
+Config file          | `session_id`
+
+### Thread event buffer capacity
 
 Maximum number of events (zero or more slices) a thread may hold in its buffer.
 
-**Default:** `10000`
+**Type:** `uint64`
 
-### SPOOR_RUNTIME_MAX_RESERVED_EVENT_BUFFER_SLICE_CAPACITY
+**Default:** `10,000`
+
+Source               | Key
+-------------------- | -------------------------------------------
+Environment variable | `SPOOR_RUNTIME_THEAD_EVENT_BUFFER_CAPACITY`
+Config file          | `thread_event_buffer_capacity`
+
+### Max reserved event buffer slice capacity
 
 Maximum number of events that a thread event buffer may request at once from
 the reserved pool. These events are stored in a contiguous slice of memory.
 
-**Default:** `1000`
+**Type:** `uint64`
 
-### SPOOR_RUNTIME_MAX_DYNAMIC_EVENT_BUFFER_SLICE_CAPACITY
+**Default:** `1,000`
+
+Source               | Key
+-------------------- | --------------------------------------------------------
+Environment variable | `SPOOR_RUNTIME_MAX_RESERVED_EVENT_BUFFER_SLICE_CAPACITY`
+Config file          | `max_reserved_event_buffer_slice_capacity`
+
+### Max dynamic event buffer slice capacity
 
 Maximum number of events that a thread event buffer may request at once from the
 dynamic pool. These events are stored in a contiguous slice of memory.
 
-**Default:** `1000`
+**Type:** `uint64`
 
-### SPOOR_RUNTIME_RESERVED_EVENT_POOL_CAPACITY
+**Default:** `1,000`
+
+Source               | Key
+-------------------- | -------------------------------------------------------
+Environment variable | `SPOOR_RUNTIME_MAX_DYNAMIC_EVENT_BUFFER_SLICE_CAPACITY`
+Config file          | `max_dynamic_event_buffer_slice_capacity`
+
+### Reserved event pool capacity
 
 Event object pool size. The reserved pool is (dynamically) allocated as a
 continuous block of memory on initialization and released on deinitialization.
 
+**Type:** `uint64`
+
 **Default:** `0`
 
-### SPOOR_RUNTIME_DYNAMIC_EVENT_POOL_CAPACITY
+Source               | Key
+-------------------- | --------------------------------------------
+Environment variable | `SPOOR_RUNTIME_RESERVED_EVENT_POOL_CAPACITY`
+Config file          | `reserved_event_pool_capacity`
+
+### Dynamic event pool capacity
 
 Maximum number of events that can be dynamically allocated.
 
-**Default:** `18446744073709551615` (i.e., `max(uint64)`)
+**Type:** `uint64`
 
-### SPOOR_RUNTIME_DYNAMIC_EVENT_SLICE_BORROW_CAS_ATTEMPTS
+**Default:** `18,446,744,073,709,551,615` (i.e., `max(uint64)`)
 
-Number of [compare and swap][compare_and_swap] attempts to borrow a slice from
+Source               | Key
+-------------------- | -------------------------------------------
+Environment variable | `SPOOR_RUNTIME_DYNAMIC_EVENT_POOL_CAPACITY`
+Config file          | `dynamic_event_pool_capacity`
+
+### Dynamic event slice borrow CAS attempts
+
+Number of [compare and swap][compare-and-swap] attempts to borrow a slice from
 the dynamic buffer pool.
+
+**Type:** `uint64`
 
 **Default:** `1`
 
-### SPOOR_RUNTIME_EVENT_BUFFER_RETENTION_DURATION_NANOSECONDS
+Source               | Key
+-------------------- | --------------------------
+Environment variable | `SPOOR_RUNTIME_DYNAMIC_EVENT_SLICE_BORROW_CAS_ATTEMPTS`
+Config file          | `dynamic_event_slice_borrow_cas_attempts`
 
-Duration to retain a thread's buffer after a thread ends (in anticipation of a
-flush event).
+### Event buffer retention duration
 
-This value is ignored when `SPOOR_RUNTIME_FLUSH_ALL_EVENTS` is `true`.
+Duration in nanoseconds to retain a thread's buffer after a thread ends (in
+anticipation of a flush event).
+
+This value is ignored when [flush all events][flush-all-events] is `true`.
+
+**Type:** `int64`
 
 **Default:** `0`
 
-### SPOOR_RUNTIME_MAX_FLUSH_BUFFER_TO_FILE_ATTEMPTS
+Source               | Key
+-------------------- | -----------------------------------------------------------
+Environment variable | `SPOOR_RUNTIME_EVENT_BUFFER_RETENTION_DURATION_NANOSECONDS`
+Config file          | `event_buffer_retention_duration_nanoseconds`
+
+### Max flush buffer to file attempts
 
 Maximum number of attempts to flush a buffer before discarding it.
 
+**Type:** `int32`
+
 **Default:** `2`
 
-### SPOOR_RUNTIME_FLUSH_ALL_EVENTS
+Source               | Key
+-------------------- | -------------------------------------------------
+Environment variable | `SPOOR_RUNTIME_MAX_FLUSH_BUFFER_TO_FILE_ATTEMPTS`
+Config file          | `max_flush_buffer_to_file_attempts`
+
+### Flush all events
 
 When `true`, flushes a buffer as soon as it fills. When `false`, the buffer acts
 as a circular buffer and old events are overridden.
 
+**Type:** `bool`
+
 **Default:** `true`
 
-[compare_and_swap]: https://en.wikipedia.org/wiki/Compare-and-swap
-[config_h]: https://github.com/microsoft/spoor/blob/master/spoor/runtime/config/config.h
+Source               | Key
+-------------------- | --------------------------
+Environment variable | `SPOOR_RUNTIME_FLUSH_ALL_EVENTS`
+Config file          | `flush_all_events`
+
+## Configuration file
+
+To set a configuration file, implement the symbol
+`spoor::runtime::ConfigFilePath()`.
+
+Return `std::nullopt` or link against `libspoor_runtime_default_config.a` to use
+the default config.
+
+```c++
+// spoor_config.cc
+
+namespace spoor::runtime {
+
+auto ConfigFilePath() -> std::optional<std::string> {
+  return "/path/to/spoor_runtime_config.toml";
+}
+
+}  // namespace spoor::runtime
+```
+
+**Example configuration file**
+
+```toml
+# spoor_runtime_config.toml
+
+trace_file_path = "/path/to/trace/"
+compression_strategy = "snappy"
+session_id = 42
+thread_event_buffer_capacity = 1_000_000
+max_reserved_event_buffer_slice_capacity = 1_000_000
+max_dynamic_event_buffer_slice_capacity = 1_000_000
+reserved_event_pool_capacity = 10_000_000
+dynamic_event_pool_capacity = 9_223_372_036_854_775_807
+dynamic_event_slice_borrow_cas_attempts = 1
+event_buffer_retention_duration_nanoseconds = 10_000_000_000
+max_flush_buffer_to_file_attempts = 2
+flush_all_events = true
+```
+
+!!! warning "Config file max value"
+    Many configuration types are **unsigned** 64-bit integers, however, TOML
+    only supports up to **signed** 64-bit integers. Therefore, the maximum
+    possilbe value in the config file is
+    `max(int64) = 9,223,372,036,854,775,807`, not
+    `max(uint64) = 18,446,744,073,709,551,615`.
+
+    See [microsoft/spoor/issues/219][toml-signed-integer-issue].
+
+## Calculating memory impact
+
+```
+event size = 24 bytes
+min memory impact = event_size * reserved event pool capacity
+max memory impact = min memory impact + event size * dynamic event pool capacity
+```
+
+[compare-and-swap]: https://en.wikipedia.org/wiki/Compare-and-swap
+[flush-all-events]: #flush-all-events
 [spoor-runtime-config]: https://github.com/microsoft/spoor/tree/master/spoor/runtime/config
-[trace_h]: https://github.com/microsoft/spoor/blob/master/spoor/runtime/trace/trace.h
+[toml-signed-integer-issue]: https://github.com/microsoft/spoor/issues/219

--- a/docs/tutorials/fibonacci.md
+++ b/docs/tutorials/fibonacci.md
@@ -20,6 +20,7 @@ You will need:
 * Spoor's toolchain including
     * `spoor_opt`: Compiler instrumentation
     * `libspoor_runtime.a`: Runtime library
+    * `libspoor_runtime_default_config.a`: Runtime library default configuration
     * `spoor`: Postprocessing tool
 * `clang++`, `rustc`, `swiftc`, or another LLVM-based compiler of your choice.
 * `clang++` to assemble the IR and link in the standard library.
@@ -754,16 +755,18 @@ in-memory and flushing them to disk.
     clang++ \
       fib_instrumented.ll \
       -o fib_instrumented \
-      -L/path/to/libspoor_runtime \
-      -lspoor_runtime
+      -L/path/to/spoor/libraries \
+      -lspoor_runtime \
+      -lspoor_runtime_default_config
     ```
 === "Rust"
     ```bash
     clang++ \
       fib_instrumented.ll \
       -o fib_instrumented \
-      -L/path/to/libspoor_runtime \
+      -L/path/to/spoor/libraries \
       -lspoor_runtime \
+      -lspoor_runtime_default_config \
       -L/path/to/.rustup/toolchains/stable-target/lib \
       -lstd-xxxxxxxxxxxxxxxx \
       -Wl,-rpath,/path/to/.rustup/toolchains/stable-target/lib
@@ -775,6 +778,7 @@ in-memory and flushing them to disk.
       -o fib_instrumented \
       -L/path/to/libspoor_runtime \
       -lspoor_runtime \
+      -lspoor_runtime_default_config \
       -L/usr/lib/swift
     ```
 

--- a/docs/tutorials/wikipedia-ios.md
+++ b/docs/tutorials/wikipedia-ios.md
@@ -172,12 +172,10 @@ mkdir trace
 ```
 
 === "UI"
-    Configure Wikipedia's scheme with a `SPOOR_RUNTIME_TRACE_FILE_PATH`
-    _run action_ environment variable: `Wikipedia > Edit Scheme…`.
+    Configure Wikipedia's scheme with a _run action_ environment variable that
+    sets the trace file output path: `Wikipedia > Edit Scheme..`.
 
-    **Environment variables**
-
-    Name                          | Value
+    Key                           | Value
     ----------------------------- | ---------------
     SPOOR_RUNTIME_TRACE_FILE_PATH | /path/to/trace/
 
@@ -206,7 +204,7 @@ mkdir trace
       org.wikimedia.wikipedia
     ```
 
-Spoor's runtime emits trace files in the `trace` folder.
+Spoor's runtime emits trace files in the `trace` folder configured above.
 
 ```bash
 ls trace

--- a/spoor/BUILD
+++ b/spoor/BUILD
@@ -8,6 +8,7 @@ sh_test(
     data = [
         "//spoor/instrumentation:spoor_opt",
         "//spoor/runtime:spoor_runtime",
+        "//spoor/runtime:spoor_runtime_default_config",
         "//spoor/test_data",
         "//spoor/tools:spoor",
         "@dev_perfetto_trace_processor//file:trace_processor",

--- a/spoor/instrumentation/filters/BUILD
+++ b/spoor/instrumentation/filters/BUILD
@@ -12,14 +12,18 @@ load(
 
 cc_library(
     name = "filters",
-    srcs = ["filters.cc"],
-    hdrs = ["filters.h"],
+    srcs = [
+        "filter.cc",
+        "filters.cc",
+    ],
+    hdrs = [
+        "filter.h",
+        "filters.h",
+    ],
     copts = SPOOR_DEFAULT_COPTS,
     linkopts = SPOOR_DEFAULT_LINKOPTS,
     visibility = ["//spoor/instrumentation:__subpackages__"],
-    deps = [
-        "//util:numeric",
-    ],
+    deps = ["//util:numeric"],
 )
 
 cc_test(
@@ -67,6 +71,30 @@ cc_test(
         ":filters_reader",
         "//util/file_system:file_system_mock",
         "@com_google_absl//absl/strings:str_format",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "default_filters",
+    srcs = ["default_filters.cc"],
+    hdrs = ["default_filters.h"],
+    copts = SPOOR_DEFAULT_COPTS,
+    linkopts = SPOOR_DEFAULT_LINKOPTS,
+    visibility = ["//spoor/instrumentation:__subpackages__"],
+    deps = [":filters"],
+)
+
+cc_test(
+    name = "default_filters_test",
+    size = "small",
+    srcs = ["default_filters_test.cc"],
+    copts = SPOOR_DEFAULT_TEST_COPTS,
+    linkopts = SPOOR_DEFAULT_TEST_LINKOPTS,
+    visibility = ["//visibility:private"],
+    deps = [
+        ":default_filters",
+        ":filters",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/spoor/instrumentation/filters/default_filters.cc
+++ b/spoor/instrumentation/filters/default_filters.cc
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "spoor/instrumentation/filters/default_filters.h"
+
+#include <vector>
+
+#include "spoor/instrumentation/filters/filter.h"
+
+namespace spoor::instrumentation::filters {
+
+auto DefaultFilters() -> std::vector<Filter> {
+  // Do not instrument config functions to prevent recursive initialization.
+  return {{
+      .action = Filter::Action::kBlock,
+      .rule_name = "Block config file path configuration function",
+      .source_file_path = {},
+      .function_demangled_name = R"(^spoor::runtime::ConfigFilePath\(\)$)",
+      .function_linkage_name = {},
+      .function_ir_instruction_count_lt = {},
+      .function_ir_instruction_count_gt = {},
+  }};
+}
+
+}  // namespace spoor::instrumentation::filters

--- a/spoor/instrumentation/filters/default_filters.h
+++ b/spoor/instrumentation/filters/default_filters.h
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include <vector>
+
+#include "spoor/instrumentation/filters/filter.h"
+
+namespace spoor::instrumentation::filters {
+
+auto DefaultFilters() -> std::vector<Filter>;
+
+}  // namespace spoor::instrumentation::filters

--- a/spoor/instrumentation/filters/default_filters_test.cc
+++ b/spoor/instrumentation/filters/default_filters_test.cc
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "spoor/instrumentation/filters/default_filters.h"
+
+#include "gtest/gtest.h"
+#include "spoor/instrumentation/filters/filters.h"
+
+namespace {
+
+using spoor::instrumentation::filters::DefaultFilters;
+using spoor::instrumentation::filters::Filters;
+using spoor::instrumentation::filters::FunctionInfo;
+
+TEST(DefaultFilters, GetDefaults) {  // NOLINT
+  const Filters default_filters{DefaultFilters()};
+  const FunctionInfo function_info{
+      .source_file_path = "/path/to/config.cc",
+      .demangled_name = "spoor::runtime::ConfigFilePath()",
+      .linkage_name = "__ZN5spoor7runtime14ConfigFilePathEv",
+      .ir_instruction_count = 0,
+  };
+  ASSERT_FALSE(default_filters.InstrumentFunction(function_info).instrument);
+}
+
+}  // namespace

--- a/spoor/instrumentation/filters/filter.cc
+++ b/spoor/instrumentation/filters/filter.cc
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "spoor/instrumentation/filters/filter.h"
+
+#include <regex>
+
+namespace spoor::instrumentation::filters {
+
+auto Filter::Matches(const FunctionInfo& function_info) const -> bool {
+  auto matches{true};
+  if (source_file_path.has_value()) {
+    const std::regex pattern{source_file_path.value()};
+    matches &= std::regex_match(function_info.source_file_path, pattern);
+  }
+  if (function_demangled_name.has_value()) {
+    const std::regex pattern{function_demangled_name.value()};
+    matches &= std::regex_match(function_info.demangled_name, pattern);
+  }
+  if (function_linkage_name.has_value()) {
+    const std::regex pattern{function_linkage_name.value()};
+    matches &= std::regex_match(function_info.linkage_name, pattern);
+  }
+  if (function_ir_instruction_count_lt.has_value()) {
+    matches &= function_info.ir_instruction_count <
+               function_ir_instruction_count_lt.value();
+  }
+  if (function_ir_instruction_count_gt.has_value()) {
+    matches &= function_ir_instruction_count_gt.value() <
+               function_info.ir_instruction_count;
+  }
+  return matches;
+}
+
+auto operator==(const Filter& lhs, const Filter& rhs) -> bool {
+  return lhs.action == rhs.action && lhs.rule_name == rhs.rule_name &&
+         lhs.source_file_path == rhs.source_file_path &&
+         lhs.function_demangled_name == rhs.function_demangled_name &&
+         lhs.function_linkage_name == rhs.function_linkage_name &&
+         lhs.function_ir_instruction_count_lt ==
+             rhs.function_ir_instruction_count_lt &&
+         lhs.function_ir_instruction_count_gt ==
+             rhs.function_ir_instruction_count_gt;
+}
+
+}  // namespace spoor::instrumentation::filters

--- a/spoor/instrumentation/filters/filter.h
+++ b/spoor/instrumentation/filters/filter.h
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <optional>
+#include <string>
+
+#include "util/numeric.h"
+
+namespace spoor::instrumentation::filters {
+
+struct alignas(128) FunctionInfo {
+  std::string source_file_path;
+  std::string demangled_name;
+  std::string linkage_name;
+  int32 ir_instruction_count;
+};
+
+struct alignas(128) Filter {
+  enum class Action {
+    kAllow,
+    kBlock,
+  };
+
+  // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
+  Action action;
+  // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
+  std::optional<std::string> rule_name;
+  // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
+  std::optional<std::string> source_file_path;
+  // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
+  std::optional<std::string> function_demangled_name;
+  // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
+  std::optional<std::string> function_linkage_name;
+  // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
+  std::optional<int32> function_ir_instruction_count_lt;
+  // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
+  std::optional<int32> function_ir_instruction_count_gt;
+
+  [[nodiscard]] auto Matches(const FunctionInfo& function_info) const -> bool;
+};
+
+auto operator==(const Filter& lhs, const Filter& rhs) -> bool;
+
+}  // namespace spoor::instrumentation::filters

--- a/spoor/instrumentation/filters/filters.cc
+++ b/spoor/instrumentation/filters/filters.cc
@@ -4,35 +4,11 @@
 #include "spoor/instrumentation/filters/filters.h"
 
 #include <algorithm>
-#include <regex>
 #include <vector>
 
-namespace spoor::instrumentation::filters {
+#include "spoor/instrumentation/filters/filter.h"
 
-auto Filter::Matches(const FunctionInfo& function_info) const -> bool {
-  auto matches{true};
-  if (source_file_path.has_value()) {
-    std::regex pattern{source_file_path.value()};
-    matches &= std::regex_match(function_info.source_file_path, pattern);
-  }
-  if (function_demangled_name.has_value()) {
-    std::regex pattern{function_demangled_name.value()};
-    matches &= std::regex_match(function_info.demangled_name, pattern);
-  }
-  if (function_linkage_name.has_value()) {
-    std::regex pattern{function_linkage_name.value()};
-    matches &= std::regex_match(function_info.linkage_name, pattern);
-  }
-  if (function_ir_instruction_count_lt.has_value()) {
-    matches &= function_info.ir_instruction_count <
-               function_ir_instruction_count_lt.value();
-  }
-  if (function_ir_instruction_count_gt.has_value()) {
-    matches &= function_ir_instruction_count_gt.value() <
-               function_info.ir_instruction_count;
-  }
-  return matches;
-}
+namespace spoor::instrumentation::filters {
 
 Filters::Filters(std::initializer_list<Filter> filters) : filters_{filters} {}
 
@@ -71,17 +47,6 @@ auto Filters::InstrumentFunction(const FunctionInfo& function_info) const
       .instrument = !block || allow,
       .active_filter_rule_name = active_filter_rule_name,
   };
-}
-
-auto operator==(const Filter& lhs, const Filter& rhs) -> bool {
-  return lhs.action == rhs.action && lhs.rule_name == rhs.rule_name &&
-         lhs.source_file_path == rhs.source_file_path &&
-         lhs.function_demangled_name == rhs.function_demangled_name &&
-         lhs.function_linkage_name == rhs.function_linkage_name &&
-         lhs.function_ir_instruction_count_lt ==
-             rhs.function_ir_instruction_count_lt &&
-         lhs.function_ir_instruction_count_gt ==
-             rhs.function_ir_instruction_count_gt;
 }
 
 auto operator==(const Filters& lhs, const Filters& rhs) -> bool {

--- a/spoor/instrumentation/filters/filters.h
+++ b/spoor/instrumentation/filters/filters.h
@@ -7,42 +7,9 @@
 #include <string>
 #include <vector>
 
-#include "util/numeric.h"
+#include "spoor/instrumentation/filters/filter.h"
 
 namespace spoor::instrumentation::filters {
-
-struct alignas(128) FunctionInfo {
-  std::string source_file_path;
-  std::string demangled_name;
-  std::string linkage_name;
-  int32 ir_instruction_count;
-};
-
-struct alignas(128) Filter {
-  enum class Action {
-    kAllow,
-    kBlock,
-  };
-
-  // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
-  Action action;
-  // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
-  std::optional<std::string> rule_name;
-  // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
-  std::optional<std::string> source_file_path;
-  // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
-  std::optional<std::string> function_demangled_name;
-  // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
-  std::optional<std::string> function_linkage_name;
-  // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
-  std::optional<int32> function_ir_instruction_count_lt;
-  // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
-  std::optional<int32> function_ir_instruction_count_gt;
-
-  [[nodiscard]] auto Matches(const FunctionInfo& function_info) const -> bool;
-};
-
-auto operator==(const Filter& lhs, const Filter& rhs) -> bool;
 
 class Filters {
  public:

--- a/spoor/instrumentation/filters/filters_file_reader.cc
+++ b/spoor/instrumentation/filters/filters_file_reader.cc
@@ -11,7 +11,7 @@
 
 #include "absl/strings/str_format.h"
 #include "gsl/gsl"
-#include "spoor/instrumentation/filters/filters.h"
+#include "spoor/instrumentation/filters/filter.h"
 #include "tomlplusplus/toml.h"
 #include "util/result.h"
 
@@ -68,7 +68,7 @@ auto FiltersFileReader::Read(const std::filesystem::path& file_path) const
     }
   }
 
-  return Filters{filters};
+  return filters;
 }
 
 auto FiltersFileReader::ParseFilter(const Filter::Action action,

--- a/spoor/instrumentation/filters/filters_file_reader_test.cc
+++ b/spoor/instrumentation/filters/filters_file_reader_test.cc
@@ -6,6 +6,7 @@
 #include <filesystem>
 #include <memory>
 #include <sstream>
+#include <vector>
 
 #include "absl/strings/str_format.h"
 #include "gmock/gmock.h"
@@ -17,7 +18,6 @@
 namespace {
 
 using spoor::instrumentation::filters::Filter;
-using spoor::instrumentation::filters::Filters;
 using spoor::instrumentation::filters::FiltersFileReader;
 using spoor::instrumentation::filters::FiltersReader;
 using spoor::instrumentation::filters::kActions;
@@ -64,7 +64,7 @@ TEST(FiltersFileReader, ParsesConfig) {  // NOLINT
   FiltersFileReader filters_file_reader{{
       .file_reader = std::move(file_reader),
   }};
-  const Filters expected_filters{
+  const std::vector<Filter> expected_filters{
       {
           .action = Filter::Action::kAllow,
           .rule_name = "Rule 0",

--- a/spoor/instrumentation/filters/filters_reader.h
+++ b/spoor/instrumentation/filters/filters_reader.h
@@ -5,8 +5,9 @@
 
 #include <filesystem>
 #include <string>
+#include <vector>
 
-#include "spoor/instrumentation/filters/filters.h"
+#include "spoor/instrumentation/filters/filter.h"
 #include "util/result.h"
 
 namespace spoor::instrumentation::filters {
@@ -25,7 +26,7 @@ class FiltersReader {
     std::string message;
   };
 
-  using Result = util::result::Result<Filters, Error>;
+  using Result = util::result::Result<std::vector<Filter>, Error>;
 
   constexpr FiltersReader() = default;
   constexpr FiltersReader(const FiltersReader&) = default;

--- a/spoor/instrumentation/inject_instrumentation/BUILD
+++ b/spoor/instrumentation/inject_instrumentation/BUILD
@@ -35,6 +35,8 @@ cc_library(
     deps = [
         ":inject_instrumentation_private",
         "//spoor/instrumentation:instrumentation_info",
+        "//spoor/instrumentation/filters",
+        "//spoor/instrumentation/filters:default_filters",
         "//spoor/instrumentation/filters:filters_reader",
         "//spoor/instrumentation/symbols:symbols_cc_proto",
         "//spoor/instrumentation/symbols:symbols_writer",

--- a/spoor/instrumentation/inject_instrumentation/inject_instrumentation_test.cc
+++ b/spoor/instrumentation/inject_instrumentation/inject_instrumentation_test.cc
@@ -43,7 +43,6 @@ namespace {
 using google::protobuf::util::MessageDifferencer;
 using google::protobuf::util::TimeUtil;
 using spoor::instrumentation::filters::Filter;
-using spoor::instrumentation::filters::Filters;
 using spoor::instrumentation::filters::FiltersReader;
 using spoor::instrumentation::filters::testing::FiltersReaderMock;
 using spoor::instrumentation::inject_instrumentation::InjectInstrumentation;
@@ -129,11 +128,12 @@ TEST(InjectInstrumentation, InstrumentsModule) {  // NOLINT
     bool initialize_runtime;
     bool enable_runtime;
   };
-  constexpr std::array<TestCase, 4> test_cases{
-      {{kInstrumentedIrFile, false, false},
-       {kInstrumentedIrFile, false, true},
-       {kInstrumentedInitializedIrFile, true, false},
-       {kInstrumentedInitializedEnabledIrFile, true, true}}};
+  constexpr std::array<TestCase, 4> test_cases{{
+      {kInstrumentedIrFile, false, false},
+      {kInstrumentedIrFile, false, true},
+      {kInstrumentedInitializedIrFile, true, false},
+      {kInstrumentedInitializedEnabledIrFile, true, true},
+  }};
   const std::filesystem::path symbols_file_path{"/path/to/file.spoor_symbols"};
 
   for (const auto& test_case : test_cases) {
@@ -182,7 +182,7 @@ TEST(InjectInstrumentation, InstrumentsModule) {  // NOLINT
 TEST(InjectInstrumentation, OutputsInstrumentedSymbols) {  // NOLINT
   struct alignas(128) TestCase {
     std::string_view ir_file;
-    Filters filters;
+    std::vector<Filter> filters;
     std::function<Symbols(const llvm::Module&)> expected_symbols;
   };
 
@@ -638,7 +638,7 @@ TEST(InjectInstrumentation, OutputsInstrumentedSymbols) {  // NOLINT
 
 TEST(InjectInstrumentation, FunctionBlocklist) {  // NOLINT
   const std::filesystem::path filters_file_path{"/path/to/filters.toml"};
-  const Filters filters{{
+  const std::vector<Filter> filters{{
       .action = Filter::Action::kBlock,
       .rule_name = "Block Fibonacci",
       .source_file_path = {},
@@ -693,7 +693,7 @@ TEST(InjectInstrumentation, FunctionBlocklist) {  // NOLINT
 
 TEST(InjectInstrumentation, FunctionAllowListOverridesBlocklist) {  // NOLINT
   const std::filesystem::path filters_file_path{"/path/to/filters.toml"};
-  const Filters filters{
+  const std::vector<Filter> filters{
       {
           .action = Filter::Action::kBlock,
           .rule_name = "Block Fibonacci",
@@ -779,7 +779,7 @@ TEST(InjectInstrumentation, InstructionThreshold) {  // NOLINT
   const std::filesystem::path symbols_file_path{"/path/to/file.spoor_symbols"};
 
   for (const auto& config : configs) {
-    const Filters filters{
+    const std::vector<Filter> filters{
         {
             .action = Filter::Action::kBlock,
             .rule_name = "Block small functions",
@@ -887,7 +887,7 @@ TEST(InjectInstrumentation, DoNotInjectInstrumentationConfig) {  // NOLINT
 
 TEST(InjectInstrumentation, ReturnValue) {  // NOLINT
   struct alignas(32) TestCaseConfig {
-    Filters filters;
+    std::vector<Filter> filters;
     bool are_all_preserved;
   };
   const std::vector<TestCaseConfig> configs{

--- a/spoor/integration_test.sh
+++ b/spoor/integration_test.sh
@@ -41,6 +41,7 @@ fi
   "$INSTRUMENTED_IR_FILE" \
   -L"$BASE_PATH/runtime" \
   -lspoor_runtime \
+  -lspoor_runtime_default_config \
   -o "$OUTPUT_EXECUTABLE_FILE"
 
 FIB_RESULT="$($OUTPUT_EXECUTABLE_FILE)"

--- a/spoor/runtime/BUILD
+++ b/spoor/runtime/BUILD
@@ -58,6 +58,20 @@ cc_static_library(
     deps = [":runtime_stub"],
 )
 
+cc_library(
+    name = "runtime_default_config",
+    srcs = ["runtime_default_config.cc"],
+    copts = SPOOR_DEFAULT_COPTS,
+    linkopts = SPOOR_DEFAULT_LINKOPTS,
+    visibility = ["//visibility:public"],
+)
+
+cc_static_library(
+    name = "spoor_runtime_default_config",
+    visibility = ["//visibility:public"],
+    deps = [":runtime_default_config"],
+)
+
 cc_test(
     name = "runtime_test",
     size = "small",
@@ -70,6 +84,7 @@ cc_test(
     visibility = ["//visibility:private"],
     deps = [
         ":runtime",
+        ":runtime_default_config",
         "@com_google_absl//absl/synchronization",
         "@com_google_absl//absl/time",
         "@com_google_googletest//:gtest_main",
@@ -85,10 +100,37 @@ cc_test(
     linkopts = SPOOR_DEFAULT_TEST_LINKOPTS,
     visibility = ["//visibility:private"],
     deps = [
+        ":runtime_default_config",
         ":runtime_stub",
         "@com_google_absl//absl/synchronization",
         "@com_google_absl//absl/time",
         "@com_google_googletest//:gtest_main",
         "@com_microsoft_gsl//:gsl",
+    ],
+)
+
+cc_test(
+    name = "runtime_default_config_test",
+    size = "small",
+    srcs = ["runtime_default_config_test.cc"],
+    copts = SPOOR_DEFAULT_TEST_COPTS,
+    linkopts = SPOOR_DEFAULT_TEST_LINKOPTS,
+    visibility = ["//visibility:private"],
+    deps = [
+        ":runtime_default_config",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "runtime_override_default_config_test",
+    size = "small",
+    srcs = ["runtime_override_default_config_test.cc"],
+    copts = SPOOR_DEFAULT_TEST_COPTS,
+    linkopts = SPOOR_DEFAULT_TEST_LINKOPTS,
+    visibility = ["//visibility:private"],
+    deps = [
+        ":runtime_default_config",
+        "@com_google_googletest//:gtest_main",
     ],
 )

--- a/spoor/runtime/config/BUILD
+++ b/spoor/runtime/config/BUILD
@@ -52,6 +52,8 @@ cc_library(
         "//spoor/runtime/trace",
         "//util:numeric",
         "//util/compression",
+        "//util/env",
+        "//util/file_system",
     ],
 )
 

--- a/spoor/runtime/config/config.h
+++ b/spoor/runtime/config/config.h
@@ -11,6 +11,7 @@
 #include "spoor/runtime/config/source.h"
 #include "spoor/runtime/trace/trace.h"
 #include "util/compression/compressor.h"
+#include "util/env/env.h"
 
 namespace spoor::runtime::config {
 
@@ -21,7 +22,8 @@ struct alignas(128) Config {
   static auto Default() -> Config;
   static auto FromSourcesOrDefault(
       std::vector<std::unique_ptr<Source>>&& sources,
-      const Config& default_config) -> Config;
+      const Config& default_config, const util::env::StdGetEnv& get_env)
+      -> Config;
 
   std::filesystem::path trace_file_path;
   util::compression::Strategy compression_strategy;

--- a/spoor/runtime/config/file_source.h
+++ b/spoor/runtime/config/file_source.h
@@ -14,6 +14,7 @@
 #include "spoor/runtime/config/source.h"
 #include "spoor/runtime/trace/trace.h"
 #include "util/compression/compressor.h"
+#include "util/env/env.h"
 #include "util/file_system/file_reader.h"
 #include "util/numeric.h"
 
@@ -56,9 +57,10 @@ constexpr std::array<std::string_view, 12> kFileConfigKeys{{
 
 class FileSource final : public Source {
  public:
-  struct alignas(32) Options {
+  struct alignas(128) Options {
     std::unique_ptr<util::file_system::FileReader> file_reader;
     std::filesystem::path file_path;
+    util::env::StdGetEnv get_env;
   };
 
   FileSource() = delete;

--- a/spoor/runtime/runtime.cc
+++ b/spoor/runtime/runtime.cc
@@ -8,9 +8,9 @@
 
 #include <chrono>
 #include <cstddef>
-#include <cstdint>
 #include <filesystem>
 #include <memory>
+#include <optional>
 #include <system_error>
 #include <thread>
 #include <type_traits>
@@ -42,114 +42,284 @@ static_assert(std::is_same_v<FunctionId, trace::FunctionId>);
 static_assert(std::is_same_v<SessionId, trace::SessionId>);
 static_assert(
     std::is_same_v<TimestampNanoseconds, trace::TimestampNanoseconds>);
+static_assert(std::is_same_v<FunctionId, _spoor_runtime_FunctionId>);
 
 }  // namespace spoor::runtime
 
 namespace {
 
-using spoor::runtime::runtime_manager::RuntimeManager;
+class SteadyClock {
+ public:
+  ~SteadyClock() = default;
+  SteadyClock(const SteadyClock&) = delete;
+  SteadyClock(SteadyClock&&) = delete;
+  auto operator=(const SteadyClock&) -> SteadyClock& = delete;
+  auto operator=(SteadyClock&&) -> SteadyClock& = delete;
 
-const auto kConfig = [] {  // NOLINT(fuchsia-statically-constructed-objects)
-  spoor::runtime::config::EnvSource::Options env_source_options{
-      .get_env = std::getenv};
-  spoor::runtime::config::FileSource::Options file_source_options{
+  static auto Instance() -> util::time::SteadyClock&;
+
+ private:
+  SteadyClock() = default;
+};
+
+class SystemClock {
+ public:
+  ~SystemClock() = default;
+  SystemClock(const SystemClock&) = delete;
+  SystemClock(SystemClock&&) = delete;
+  auto operator=(const SystemClock&) -> SystemClock& = delete;
+  auto operator=(SystemClock&&) -> SystemClock& = delete;
+
+  static auto Instance() -> util::time::SystemClock&;
+
+ private:
+  SystemClock() = default;
+};
+
+class LocalFileSystem {
+ public:
+  ~LocalFileSystem() = default;
+  LocalFileSystem(const LocalFileSystem&) = delete;
+  LocalFileSystem(LocalFileSystem&&) = delete;
+  auto operator=(const LocalFileSystem&) -> LocalFileSystem& = delete;
+  auto operator=(LocalFileSystem&&) -> LocalFileSystem& = delete;
+
+  static auto Instance() -> util::file_system::LocalFileSystem&;
+
+ private:
+  LocalFileSystem() = default;
+};
+
+class TraceFileReader {
+ public:
+  ~TraceFileReader() = default;
+  TraceFileReader(const TraceFileReader&) = delete;
+  TraceFileReader(TraceFileReader&&) = delete;
+  auto operator=(const TraceFileReader&) -> TraceFileReader& = delete;
+  auto operator=(TraceFileReader&&) -> TraceFileReader& = delete;
+
+  static auto Instance() -> spoor::runtime::trace::TraceFileReader&;
+
+ private:
+  TraceFileReader() = default;
+};
+
+class TraceFileWriter {
+ public:
+  ~TraceFileWriter() = default;
+  TraceFileWriter(const TraceFileWriter&) = delete;
+  TraceFileWriter(TraceFileWriter&&) = delete;
+  auto operator=(const TraceFileWriter&) -> TraceFileWriter& = delete;
+  auto operator=(TraceFileWriter&&) -> TraceFileWriter& = delete;
+
+  static auto Instance() -> spoor::runtime::trace::TraceFileWriter&;
+
+ private:
+  TraceFileWriter() = default;
+};
+
+class Config {
+ public:
+  ~Config() = default;
+  Config(const Config&) = delete;
+  Config(Config&&) = delete;
+  auto operator=(const Config&) -> Config& = delete;
+  auto operator=(Config&&) -> Config& = delete;
+
+  static auto Instance() -> const spoor::runtime::config::Config&;
+
+ private:
+  Config() = default;
+};
+
+class RuntimeManager {
+ public:
+  ~RuntimeManager() = default;
+  RuntimeManager(const RuntimeManager&) = delete;
+  RuntimeManager(RuntimeManager&&) = delete;
+  auto operator=(const RuntimeManager&) -> RuntimeManager& = delete;
+  auto operator=(RuntimeManager&&) -> RuntimeManager& = delete;
+
+  static auto Instance() -> spoor::runtime::runtime_manager::RuntimeManager&;
+  template <class ConstIterator>
+  static auto FlushedTraceFiles(
+      ConstIterator directory_begin, ConstIterator directory_end,
+      gsl::not_null<spoor::runtime::trace::TraceReader*> trace_reader,
+      std::function<void(std::vector<std::filesystem::path>)> completion)
+      -> void;
+  template <class ConstIterator>
+  static auto DeleteFlushedTraceFilesOlderThan(
+      std::chrono::time_point<std::chrono::system_clock> timestamp,
+      ConstIterator directory_begin, ConstIterator directory_end,
+      gsl::not_null<util::file_system::FileSystem*> file_system,
+      gsl::not_null<spoor::runtime::trace::TraceReader*> trace_reader,
+      std::function<void(
+          spoor::runtime::runtime_manager::RuntimeManager::DeletedFilesInfo)>
+          completion) -> void;
+
+ private:
+  RuntimeManager() = default;
+};
+
+auto SystemClock::Instance() -> util::time::SystemClock& {
+  static util::time::SystemClock system_clock{};
+  return system_clock;
+}
+
+auto SteadyClock::Instance() -> util::time::SteadyClock& {
+  static util::time::SteadyClock steady_clock{};
+  return steady_clock;
+}
+
+auto LocalFileSystem::Instance() -> util::file_system::LocalFileSystem& {
+  static util::file_system::LocalFileSystem file_system{};
+  return file_system;
+}
+
+auto TraceFileReader::Instance() -> spoor::runtime::trace::TraceFileReader& {
+  static spoor::runtime::trace::TraceFileReader trace_file_reader{{
+      .file_system{std::make_unique<util::file_system::LocalFileSystem>()},
       .file_reader{std::make_unique<util::file_system::LocalFileReader>()},
-      .file_path{"spoor_runtime_config.toml"},
-  };
-  auto sources = std::vector<std::unique_ptr<spoor::runtime::config::Source>>{};
-  sources.reserve(2);
-  sources.emplace_back(std::make_unique<spoor::runtime::config::EnvSource>(
-      std::move(env_source_options)));
-  sources.emplace_back(std::make_unique<spoor::runtime::config::FileSource>(
-      std::move(file_source_options)));
-  return spoor::runtime::config::Config::FromSourcesOrDefault(
-      std::move(sources), spoor::runtime::config::Config::Default());
-}();
-// clang-format off NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables, fuchsia-statically-constructed-objects) clang-format on
-util::time::SystemClock system_clock_{};
-// clang-format off NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables, fuchsia-statically-constructed-objects) clang-format on
-util::time::SteadyClock steady_clock_{};
-// clang-format off NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables, fuchsia-statically-constructed-objects) clang-format on
-util::file_system::LocalFileSystem file_system_{};
-// clang-format off NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables, fuchsia-statically-constructed-objects) clang-format on
-spoor::runtime::trace::TraceFileReader trace_reader_{{
-    .file_system{std::make_unique<util::file_system::LocalFileSystem>()},
-    .file_reader{std::make_unique<util::file_system::LocalFileReader>()},
-}};
-// clang-format off NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables, fuchsia-statically-constructed-objects) clang-format on
-spoor::runtime::trace::TraceFileWriter trace_writer_{{
-    .file_writer{std::make_unique<util::file_system::LocalFileWriter>()},
-    .compression_strategy = kConfig.compression_strategy,
-    .initial_buffer_capacity = kConfig.thread_event_buffer_capacity,
-}};
-// clang-format off NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables, fuchsia-statically-constructed-objects) clang-format on
-spoor::runtime::flush_queue::DiskFlushQueue flush_queue_{
-    {.trace_file_path = kConfig.trace_file_path,
-     .buffer_retention_duration =
-         std::chrono::nanoseconds{
-             kConfig.event_buffer_retention_duration_nanoseconds},
-     .system_clock = &system_clock_,
-     .steady_clock = &steady_clock_,
-     .trace_writer = &trace_writer_,
-     .session_id = kConfig.session_id,
-     .process_id = ::getpid(),
-     .max_buffer_flush_attempts = kConfig.max_flush_buffer_to_file_attempts,
-     .flush_all_events = kConfig.flush_all_events}};
-// clang-format off NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables, fuchsia-statically-constructed-objects) clang-format on
-RuntimeManager runtime_{
-    {.steady_clock = &steady_clock_,
-     .flush_queue = &flush_queue_,
-     .thread_event_buffer_capacity = kConfig.thread_event_buffer_capacity,
-     .reserved_pool_capacity = kConfig.reserved_event_pool_capacity,
-     .reserved_pool_max_slice_capacity =
-         kConfig.max_reserved_event_buffer_slice_capacity,
-     .dynamic_pool_capacity = kConfig.dynamic_event_pool_capacity,
-     .dynamic_pool_max_slice_capacity =
-         kConfig.max_dynamic_event_buffer_slice_capacity,
-     .dynamic_pool_borrow_cas_attempts =
-         kConfig.dynamic_event_slice_borrow_cas_attempts,
-     .max_buffer_flush_attempts = kConfig.max_flush_buffer_to_file_attempts,
-     .flush_all_events = kConfig.flush_all_events}};
+  }};
+  return trace_file_reader;
+}
+
+auto TraceFileWriter::Instance() -> spoor::runtime::trace::TraceFileWriter& {
+  static spoor::runtime::trace::TraceFileWriter trace_file_writer{{
+      .file_writer{std::make_unique<util::file_system::LocalFileWriter>()},
+      .compression_strategy = Config::Instance().compression_strategy,
+      .initial_buffer_capacity =
+          Config::Instance().thread_event_buffer_capacity,
+  }};
+  return trace_file_writer;
+}
+
+auto Config::Instance() -> const spoor::runtime::config::Config& {
+  static auto sources = [] {
+    std::vector<std::unique_ptr<spoor::runtime::config::Source>> sources{};
+    spoor::runtime::config::EnvSource::Options env_source_options{
+        .get_env = std::getenv};
+    sources.emplace_back(std::make_unique<spoor::runtime::config::EnvSource>(
+        std::move(env_source_options)));
+    const auto config_file_path = spoor::runtime::ConfigFilePath();
+    if (config_file_path.has_value()) {
+      spoor::runtime::config::FileSource::Options file_source_options{
+          .file_reader{std::make_unique<util::file_system::LocalFileReader>()},
+          .file_path{config_file_path.value()},
+          .get_env{std::getenv},
+      };
+      sources.emplace_back(std::make_unique<spoor::runtime::config::FileSource>(
+          std::move(file_source_options)));
+    }
+    return sources;
+  }();
+  static auto instance = spoor::runtime::config::Config::FromSourcesOrDefault(
+      std::move(sources), spoor::runtime::config::Config::Default(),
+      std::getenv);
+  return instance;
+};
+
+auto RuntimeManager::Instance()
+    -> spoor::runtime::runtime_manager::RuntimeManager& {
+  static spoor::runtime::flush_queue::DiskFlushQueue flush_queue{{
+      .trace_file_path = Config::Instance().trace_file_path,
+      .buffer_retention_duration =
+          std::chrono::nanoseconds{
+              Config::Instance().event_buffer_retention_duration_nanoseconds},
+      .system_clock = &SystemClock::Instance(),
+      .steady_clock = &SteadyClock::Instance(),
+      .trace_writer = &TraceFileWriter::Instance(),
+      .session_id = Config::Instance().session_id,
+      .process_id = ::getpid(),
+      .max_buffer_flush_attempts =
+          Config::Instance().max_flush_buffer_to_file_attempts,
+      .flush_all_events = Config::Instance().flush_all_events,
+  }};
+  static spoor::runtime::runtime_manager::RuntimeManager runtime_manager{{
+      .steady_clock = &SteadyClock::Instance(),
+      .flush_queue = &flush_queue,
+      .thread_event_buffer_capacity =
+          Config::Instance().thread_event_buffer_capacity,
+      .reserved_pool_capacity = Config::Instance().reserved_event_pool_capacity,
+      .reserved_pool_max_slice_capacity =
+          Config::Instance().max_reserved_event_buffer_slice_capacity,
+      .dynamic_pool_capacity = Config::Instance().dynamic_event_pool_capacity,
+      .dynamic_pool_max_slice_capacity =
+          Config::Instance().max_dynamic_event_buffer_slice_capacity,
+      .dynamic_pool_borrow_cas_attempts =
+          Config::Instance().dynamic_event_slice_borrow_cas_attempts,
+      .max_buffer_flush_attempts =
+          Config::Instance().max_flush_buffer_to_file_attempts,
+      .flush_all_events = Config::Instance().flush_all_events,
+  }};
+  return runtime_manager;
+}
+
+template <class ConstIterator>
+auto RuntimeManager::FlushedTraceFiles(
+    ConstIterator directory_begin, ConstIterator directory_end,
+    gsl::not_null<spoor::runtime::trace::TraceReader*> trace_reader,
+    std::function<void(std::vector<std::filesystem::path>)> completion)
+    -> void {
+  spoor::runtime::runtime_manager::RuntimeManager::FlushedTraceFiles(
+      directory_begin, directory_end, trace_reader, completion);
+}
+
+template <class ConstIterator>
+auto RuntimeManager::DeleteFlushedTraceFilesOlderThan(
+    std::chrono::time_point<std::chrono::system_clock> timestamp,
+    ConstIterator directory_begin, ConstIterator directory_end,
+    gsl::not_null<util::file_system::FileSystem*> file_system,
+    gsl::not_null<spoor::runtime::trace::TraceReader*> trace_reader,
+    std::function<
+        void(spoor::runtime::runtime_manager::RuntimeManager::DeletedFilesInfo)>
+        completion) -> void {
+  spoor::runtime::runtime_manager::RuntimeManager::
+      DeleteFlushedTraceFilesOlderThan(timestamp, directory_begin,
+                                       directory_end, file_system, trace_reader,
+                                       completion);
+}
 
 }  // namespace
 
 namespace spoor::runtime {
 
-auto Initialize() -> void { runtime_.Initialize(); }
+auto Initialize() -> void { RuntimeManager::Instance().Initialize(); }
 
-auto Deinitialize() -> void { runtime_.Deinitialize(); }
+auto Deinitialize() -> void { RuntimeManager::Instance().Deinitialize(); }
 
-auto Initialized() -> bool { return runtime_.Initialized(); }
+auto Initialized() -> bool { return RuntimeManager::Instance().Initialized(); }
 
-auto Enable() -> void { runtime_.Enable(); }
+auto Enable() -> void { RuntimeManager::Instance().Enable(); }
 
-auto Disable() -> void { runtime_.Disable(); }
+auto Disable() -> void { RuntimeManager::Instance().Disable(); }
 
-auto Enabled() -> bool { return runtime_.Enabled(); }
+auto Enabled() -> bool { return RuntimeManager::Instance().Enabled(); }
 
 auto LogEvent(const EventType event,
               const TimestampNanoseconds steady_clock_timestamp,
               const std::uint64_t payload_1, const std::uint64_t payload_2)
     -> void {
-  runtime_.LogEvent(event, steady_clock_timestamp, payload_1, payload_2);
+  RuntimeManager::Instance().LogEvent(event, steady_clock_timestamp, payload_1,
+                                      payload_2);
 }
 
 auto LogEvent(const EventType event, const std::uint64_t payload_1,
               const std::uint64_t payload_2) -> void {
-  runtime_.LogEvent(event, payload_1, payload_2);
+  RuntimeManager::Instance().LogEvent(event, payload_1, payload_2);
 }
 
 auto FlushTraceEvents(std::function<void()> callback) -> void {
-  runtime_.Flush(std::move(callback));
+  RuntimeManager::Instance().Flush(std::move(callback));
 }
 
-auto ClearTraceEvents() -> void { runtime_.Clear(); }
+auto ClearTraceEvents() -> void { RuntimeManager::Instance().Clear(); }
 
 auto FlushedTraceFiles(
     std::function<void(std::vector<std::filesystem::path>)> callback) -> void {
   std::error_code error{};
-  const std::filesystem::directory_iterator directory{kConfig.trace_file_path,
-                                                      error};
+  const std::filesystem::directory_iterator directory{
+      ::Config::Instance().trace_file_path, error};
   if (error) {
     if (callback != nullptr) {
       std::thread{std::move(callback), std::vector<std::filesystem::path>{}}
@@ -157,9 +327,9 @@ auto FlushedTraceFiles(
     }
     return;
   }
-  RuntimeManager::FlushedTraceFiles(std::filesystem::begin(directory),
-                                    std::filesystem::end(directory),
-                                    &trace_reader_, std::move(callback));
+  RuntimeManager::FlushedTraceFiles(
+      std::filesystem::begin(directory), std::filesystem::end(directory),
+      &TraceFileReader::Instance(), std::move(callback));
 }
 
 auto DeleteFlushedTraceFilesOlderThan(
@@ -167,19 +337,21 @@ auto DeleteFlushedTraceFilesOlderThan(
     std::function<void(DeletedFilesInfo)> callback) -> void {
   auto callback_adapter =
       [callback{std::move(callback)}](
-          const RuntimeManager::DeletedFilesInfo deleted_files_info) {
+          const spoor::runtime::runtime_manager::RuntimeManager::
+              DeletedFilesInfo deleted_files_info) {
         if (callback == nullptr) return;
         callback({.deleted_files = deleted_files_info.deleted_files,
                   .deleted_bytes = deleted_files_info.deleted_bytes});
       };
 
   std::error_code error{};
-  const std::filesystem::directory_iterator directory{kConfig.trace_file_path,
-                                                      error};
+  const std::filesystem::directory_iterator directory{
+      ::Config::Instance().trace_file_path, error};
   if (error) {
-    std::thread{std::move(callback_adapter),
-                RuntimeManager::DeletedFilesInfo{.deleted_files = 0,
-                                                 .deleted_bytes = 0}}
+    std::thread{
+        std::move(callback_adapter),
+        spoor::runtime::runtime_manager::RuntimeManager::DeletedFilesInfo{
+            .deleted_files = 0, .deleted_bytes = 0}}
         .detach();
     return;
   }
@@ -188,27 +360,32 @@ auto DeleteFlushedTraceFilesOlderThan(
           std::chrono::seconds{system_timestamp_seconds}};
   RuntimeManager::DeleteFlushedTraceFilesOlderThan(
       system_timestamp, std::filesystem::begin(directory),
-      std::filesystem::end(directory), &file_system_, &trace_reader_,
-      std::move(callback_adapter));
+      std::filesystem::end(directory), &LocalFileSystem::Instance(),
+      &TraceFileReader::Instance(), std::move(callback_adapter));
 }
 
-auto GetConfig() -> Config {
-  return {.trace_file_path = kConfig.trace_file_path,
-          .session_id = kConfig.session_id,
-          .thread_event_buffer_capacity = kConfig.thread_event_buffer_capacity,
-          .max_reserved_event_buffer_slice_capacity =
-              kConfig.max_reserved_event_buffer_slice_capacity,
-          .max_dynamic_event_buffer_slice_capacity =
-              kConfig.max_dynamic_event_buffer_slice_capacity,
-          .reserved_event_pool_capacity = kConfig.reserved_event_pool_capacity,
-          .dynamic_event_pool_capacity = kConfig.dynamic_event_pool_capacity,
-          .dynamic_event_slice_borrow_cas_attempts =
-              kConfig.dynamic_event_slice_borrow_cas_attempts,
-          .event_buffer_retention_duration_nanoseconds =
-              kConfig.event_buffer_retention_duration_nanoseconds,
-          .max_flush_buffer_to_file_attempts =
-              kConfig.max_flush_buffer_to_file_attempts,
-          .flush_all_events = kConfig.flush_all_events};
+auto GetConfig() -> spoor::runtime::Config {
+  return {
+      .trace_file_path = ::Config::Instance().trace_file_path,
+      .session_id = ::Config::Instance().session_id,
+      .thread_event_buffer_capacity =
+          ::Config::Instance().thread_event_buffer_capacity,
+      .max_reserved_event_buffer_slice_capacity =
+          ::Config::Instance().max_reserved_event_buffer_slice_capacity,
+      .max_dynamic_event_buffer_slice_capacity =
+          ::Config::Instance().max_dynamic_event_buffer_slice_capacity,
+      .reserved_event_pool_capacity =
+          ::Config::Instance().reserved_event_pool_capacity,
+      .dynamic_event_pool_capacity =
+          ::Config::Instance().dynamic_event_pool_capacity,
+      .dynamic_event_slice_borrow_cas_attempts =
+          ::Config::Instance().dynamic_event_slice_borrow_cas_attempts,
+      .event_buffer_retention_duration_nanoseconds =
+          ::Config::Instance().event_buffer_retention_duration_nanoseconds,
+      .max_flush_buffer_to_file_attempts =
+          ::Config::Instance().max_flush_buffer_to_file_attempts,
+      .flush_all_events = ::Config::Instance().flush_all_events,
+  };
 }
 
 auto StubImplementation() -> bool { return false; }
@@ -216,11 +393,11 @@ auto StubImplementation() -> bool { return false; }
 }  // namespace spoor::runtime
 
 auto _spoor_runtime_LogFunctionEntry(
-    const spoor::runtime::FunctionId function_id) -> void {
-  runtime_.LogFunctionEntry(function_id);
+    const _spoor_runtime_FunctionId function_id) -> void {
+  RuntimeManager::Instance().LogFunctionEntry(function_id);
 }
 
-auto _spoor_runtime_LogFunctionExit(
-    const spoor::runtime::FunctionId function_id) -> void {
-  runtime_.LogFunctionExit(function_id);
+auto _spoor_runtime_LogFunctionExit(const _spoor_runtime_FunctionId function_id)
+    -> void {
+  RuntimeManager::Instance().LogFunctionExit(function_id);
 }

--- a/spoor/runtime/runtime.h
+++ b/spoor/runtime/runtime.h
@@ -13,8 +13,22 @@
 #include <cstdint>
 #include <filesystem>
 #include <functional>
+#include <optional>
+#include <string>
 #include <vector>
 
+// Configuration
+// Implement these functions to configure Spoor's runtime. Return `std::nullopt`
+// or link against `libspoor_runtime_default_config.a` to use the default
+// config. Configuration implementations are never instrumented.
+namespace spoor::runtime {
+
+// Returns the path to Spoor's runtime config file.
+SPOOR_RUNTIME_EXPORT extern auto ConfigFilePath() -> std::optional<std::string>;
+
+}  // namespace spoor::runtime
+
+// Runtime API
 namespace spoor::runtime {
 
 using DurationNanoseconds = std::int64_t;
@@ -112,10 +126,12 @@ auto operator==(const Config& lhs, const Config& rhs) -> bool;
 
 }  // namespace spoor::runtime
 
-extern "C" {
-
 // Internal.
 // Exposed for use by Spoor's instrumentation.
+extern "C" {
+
+using _spoor_runtime_FunctionId = spoor::runtime::FunctionId;
+
 auto _spoor_runtime_Initialize() -> void;
 auto _spoor_runtime_Deinitialize() -> void;
 auto _spoor_runtime_Enable() -> void;

--- a/spoor/runtime/runtime_common.cc
+++ b/spoor/runtime/runtime_common.cc
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#include <cstring>
-
 #include "spoor/runtime/runtime.h"
 
 namespace spoor::runtime {

--- a/spoor/runtime/runtime_default_config.cc
+++ b/spoor/runtime/runtime_default_config.cc
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include <optional>
+#include <string>
+
+namespace spoor::runtime {
+
+__attribute__((weak)) auto ConfigFilePath() -> std::optional<std::string> {
+  return {};
+}
+
+}  // namespace spoor::runtime

--- a/spoor/runtime/runtime_default_config_test.cc
+++ b/spoor/runtime/runtime_default_config_test.cc
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include <optional>
+#include <string>
+
+#include "gtest/gtest.h"
+
+namespace spoor::runtime {
+
+extern auto ConfigFilePath() -> std::optional<std::string>;
+
+}  // namespace spoor::runtime
+
+namespace {
+
+TEST(Runtime, ConfigFilePath) {  // NOLINT
+  ASSERT_EQ(spoor::runtime::ConfigFilePath(), std::optional<std::string>{});
+}
+
+}  // namespace

--- a/spoor/runtime/runtime_override_default_config_test.cc
+++ b/spoor/runtime/runtime_override_default_config_test.cc
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// This test will fail to compile if we do not implement one of the methods.
+
+#include <optional>
+#include <string>
+
+#include "gtest/gtest.h"
+
+namespace spoor::runtime {
+
+auto ConfigFilePath() -> std::optional<std::string> {
+  return "/path/to/spoor_runtime_config.toml";
+}
+
+}  // namespace spoor::runtime
+
+namespace {
+
+TEST(Runtime, ConfigFilePath) {  // NOLINT
+  ASSERT_NE(spoor::runtime::ConfigFilePath(), std::nullopt);
+}
+
+}  // namespace

--- a/spoor/runtime/wrappers/apple/BUILD
+++ b/spoor/runtime/wrappers/apple/BUILD
@@ -104,6 +104,24 @@ apple_static_library(
     deps = [":runtime_stub_lib"],
 )
 
+apple_static_library(
+    name = "spoor_runtime_default_config_ios",
+    linkopts = SPOOR_DEFAULT_LINKOPTS,
+    minimum_os_version = _MINIMUM_IOS_VERSION,
+    platform_type = "ios",
+    visibility = ["//visibility:public"],
+    deps = [":runtime_default_config_lib"],
+)
+
+apple_static_library(
+    name = "spoor_runtime_default_config_macos",
+    linkopts = SPOOR_DEFAULT_LINKOPTS,
+    minimum_os_version = _MINIMUM_IOS_VERSION,
+    platform_type = "macos",
+    visibility = ["//visibility:public"],
+    deps = [":runtime_default_config_lib"],
+)
+
 objc_library(
     name = "runtime_lib",
     srcs = _LIB_SRCS,
@@ -122,6 +140,14 @@ objc_library(
     module_name = _STUB_MODULE_NAME,
     visibility = ["//visibility:private"],
     deps = ["//spoor/runtime:runtime_stub"],
+)
+
+objc_library(
+    name = "runtime_default_config_lib",
+    copts = _LIB_COPTS,
+    module_name = _MODULE_NAME,
+    visibility = ["//visibility:private"],
+    deps = ["//spoor/runtime:runtime_default_config"],
 )
 
 # Tests
@@ -198,6 +224,7 @@ objc_library(
     visibility = ["//visibility:private"],
     deps = [
         ":runtime_lib",
+        "//spoor/runtime:runtime_default_config",
     ],
 )
 
@@ -211,5 +238,6 @@ objc_library(
     visibility = ["//visibility:private"],
     deps = [
         ":runtime_stub_lib",
+        "//spoor/runtime:runtime_default_config",
     ],
 )

--- a/toolchain/xcode/BUILD
+++ b/toolchain/xcode/BUILD
@@ -145,6 +145,14 @@ _TOOLCHAIN_TARGETS_TO_OUTS = [
         TOOLCHAIN_NAME + "/spoor/lib/libspoor_runtime_macos.a",
     ],
     [
+        "//spoor/runtime/wrappers/apple:spoor_runtime_default_config_ios",
+        TOOLCHAIN_NAME + "/spoor/lib/libspoor_runtime_default_config_ios.a",
+    ],
+    [
+        "//spoor/runtime/wrappers/apple:spoor_runtime_default_config_macos",
+        TOOLCHAIN_NAME + "/spoor/lib/libspoor_runtime_default_config_macos.a",
+    ],
+    [
         "//spoor/instrumentation:spoor_opt",
         TOOLCHAIN_NAME + "/spoor/bin/spoor_opt",
     ],

--- a/toolchain/xcode/clang_clangxx_test.py
+++ b/toolchain/xcode/clang_clangxx_test.py
@@ -110,14 +110,16 @@ def _test_parses_link_args(input_args, input_args_file, main, popen_mock):
   popen_handle.return_value.wait.assert_called_once()
   assert return_code == 0
   popen_args = popen_mock.call_args.args[0]
-  assert popen_args[:-3] == ['default_clang_clangxx'] + input_args
+  assert popen_args[:-4] == ['default_clang_clangxx'] + input_args
   if 'ios' in input_args_file:
-    assert popen_args[-3:] == [
-        '-L/spoor/library/path', '-lspoor_runtime_ios', '-lc++'
+    assert popen_args[-4:] == [
+        '-L/spoor/library/path', '-lspoor_runtime_ios', '-lc++',
+        '-lspoor_runtime_default_config_ios'
     ]
   if 'macos' in input_args_file:
-    assert popen_args[-3:] == [
-        '-L/spoor/library/path', '-lspoor_runtime_macos', '-lc++'
+    assert popen_args[-4:] == [
+        '-L/spoor/library/path', '-lspoor_runtime_macos', '-lc++',
+        '-lspoor_runtime_default_config_macos'
     ]
 
 


### PR DESCRIPTION
Configure the runtime using a config file (instead of just environment variables).

The config file is set by implementing `spoor::runtime::ConfigFilePath() -> std::optional<std::string>`. This function is never instrumented to prevent recursive initialization.

This PR also lazily initializes the runtime's dependencies and creates a `spoor_runtime_library_default_config` library against which users can link to get a default implementation. This library is automatically linked by the Xcode toolchain to make onboarding easier so users don't need to implement the config functions.