### PR TITLE
Clang Tidy portability

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,10 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+# altera-struct-pack-align
+#   Some types (e.g., function pointers) have different sizes on different
+#   architectures so an optimal struct alignment on one architecture is not
+#   necessarily optimal on another.
 # cppcoreguidelines-init-variables
 #   Appears not to support the {} default initializer.
 # fuchsia-default-arguments
@@ -26,6 +30,7 @@
 #   https://clang.llvm.org/extra/clang-tidy/checks/list.html#id117
 Checks: '
   *,
+  -altera-struct-pack-align,
   -cppcoreguidelines-init-variables,
   -fuchsia-default-arguments,
   -fuchsia-default-arguments-calls,

--- a/spoor/instrumentation/config/config.h
+++ b/spoor/instrumentation/config/config.h
@@ -19,7 +19,7 @@ enum class OutputLanguage {
 
 // Prefer alphabetization readability over optimal struct ordering for this
 // single-use config. NOLINTNEXTLINE(clang-analyzer-optin.performance.Padding)
-struct alignas(128) Config {
+struct Config {
   // Alphabetized to match the order printed in --help.
   bool enable_runtime;
   std::optional<std::string> filters_file;

--- a/spoor/instrumentation/filters/filter.h
+++ b/spoor/instrumentation/filters/filter.h
@@ -10,14 +10,14 @@
 
 namespace spoor::instrumentation::filters {
 
-struct alignas(128) FunctionInfo {
+struct FunctionInfo {
   std::string source_file_path;
   std::string demangled_name;
   std::string linkage_name;
   int32 ir_instruction_count;
 };
 
-struct alignas(128) Filter {
+struct Filter {
   enum class Action {
     kAllow,
     kBlock,

--- a/spoor/instrumentation/filters/filters.h
+++ b/spoor/instrumentation/filters/filters.h
@@ -13,7 +13,7 @@ namespace spoor::instrumentation::filters {
 
 class Filters {
  public:
-  struct alignas(64) InstrumentFunctionResult {
+  struct InstrumentFunctionResult {
     bool instrument;
     std::optional<std::string> active_filter_rule_name;
   };

--- a/spoor/instrumentation/filters/filters_reader.h
+++ b/spoor/instrumentation/filters/filters_reader.h
@@ -14,7 +14,7 @@ namespace spoor::instrumentation::filters {
 
 class FiltersReader {
  public:
-  struct alignas(32) Error {
+  struct Error {
     enum class Type {
       kFailedToOpenFile,
       kMalformedFile,

--- a/spoor/instrumentation/filters/filters_test.cc
+++ b/spoor/instrumentation/filters/filters_test.cc
@@ -16,7 +16,7 @@ using spoor::instrumentation::filters::Filter;
 using spoor::instrumentation::filters::Filters;
 using spoor::instrumentation::filters::FunctionInfo;
 
-struct alignas(128) TestCase {
+struct TestCase {
   FunctionInfo function_info;
   bool instrument;
   std::optional<std::string> active_filter_rule_name;

--- a/spoor/instrumentation/inject_instrumentation/inject_instrumentation.h
+++ b/spoor/instrumentation/inject_instrumentation/inject_instrumentation.h
@@ -31,7 +31,7 @@ namespace spoor::instrumentation::inject_instrumentation {
 class InjectInstrumentation
     : public llvm::PassInfoMixin<InjectInstrumentation> {
  public:
-  struct alignas(128) Options {
+  struct Options {
     bool inject_instrumentation;
     std::unique_ptr<filters::FiltersReader> filters_reader;
     std::unique_ptr<symbols::SymbolsWriter> symbols_writer;
@@ -61,7 +61,7 @@ class InjectInstrumentation
       -> llvm::PreservedAnalyses;
 
  private:
-  struct alignas(128) InstrumentModuleResult {
+  struct InstrumentModuleResult {
     symbols::Symbols symbols;
     bool modified;
   };

--- a/spoor/instrumentation/inject_instrumentation/inject_instrumentation_test.cc
+++ b/spoor/instrumentation/inject_instrumentation/inject_instrumentation_test.cc
@@ -123,7 +123,7 @@ MATCHER_P(SymbolsEq, expected, "Symbols are not equal.") {  // NOLINT
 }
 
 TEST(InjectInstrumentation, InstrumentsModule) {  // NOLINT
-  struct alignas(32) TestCase {
+  struct TestCase {
     std::string_view expected_ir_file;
     bool initialize_runtime;
     bool enable_runtime;
@@ -180,7 +180,7 @@ TEST(InjectInstrumentation, InstrumentsModule) {  // NOLINT
 }
 
 TEST(InjectInstrumentation, OutputsInstrumentedSymbols) {  // NOLINT
-  struct alignas(128) TestCase {
+  struct TestCase {
     std::string_view ir_file;
     std::vector<Filter> filters;
     std::function<Symbols(const llvm::Module&)> expected_symbols;
@@ -758,7 +758,7 @@ TEST(InjectInstrumentation, FunctionAllowListOverridesBlocklist) {  // NOLINT
 }
 
 TEST(InjectInstrumentation, InstructionThreshold) {  // NOLINT
-  struct alignas(32) TestCaseConfig {
+  struct TestCaseConfig {
     int32 instruction_threshold;
     std::string_view expected_ir_file;
   };
@@ -886,7 +886,7 @@ TEST(InjectInstrumentation, DoNotInjectInstrumentationConfig) {  // NOLINT
 }
 
 TEST(InjectInstrumentation, ReturnValue) {  // NOLINT
-  struct alignas(32) TestCaseConfig {
+  struct TestCaseConfig {
     std::vector<Filter> filters;
     bool are_all_preserved;
   };

--- a/spoor/runtime/buffer/buffer_slice_pool_test.cc
+++ b/spoor/runtime/buffer/buffer_slice_pool_test.cc
@@ -30,7 +30,7 @@ using CombinedPool = spoor::runtime::buffer::CombinedBufferSlicePool<ValueType>;
 using DynamicPool = spoor::runtime::buffer::DynamicBufferSlicePool<ValueType>;
 using ReservedPool = spoor::runtime::buffer::ReservedBufferSlicePool<ValueType>;
 
-struct alignas(32) Options {
+struct Options {
   SizeType max_slice_capacity;
   SizeType capacity;
   SizeType borrow_cas_attempts;

--- a/spoor/runtime/buffer/circular_slice_buffer.h
+++ b/spoor/runtime/buffer/circular_slice_buffer.h
@@ -32,7 +32,7 @@ class CircularSliceBuffer final : public CircularBuffer<T> {
   using SlicePool = BufferSlicePool<T>;
   using SlicesType = std::vector<OwnedSlicePtr>;
 
-  struct alignas(16) Options {
+  struct Options {
     gsl::not_null<SlicePool*> buffer_slice_pool;
     SizeType capacity;
   };

--- a/spoor/runtime/buffer/combined_buffer_slice_pool.h
+++ b/spoor/runtime/buffer/combined_buffer_slice_pool.h
@@ -28,7 +28,7 @@ class CombinedBufferSlicePool final : public BufferSlicePool<T> {
   using ReservedPool = ReservedBufferSlicePool<T>;
   using DynamicPool = DynamicBufferSlicePool<T>;
 
-  struct alignas(64) Options {
+  struct Options {
     typename ReservedPool::Options reserved_pool_options;
     typename DynamicPool::Options dynamic_pool_options;
   };

--- a/spoor/runtime/buffer/dynamic_buffer_slice_pool.h
+++ b/spoor/runtime/buffer/dynamic_buffer_slice_pool.h
@@ -28,7 +28,7 @@ class DynamicBufferSlicePool final : public BufferSlicePool<T> {
   using BorrowResult = util::result::Result<OwnedSlicePtr, BorrowError>;
   using ReturnResult = typename util::memory::PtrOwner<Slice>::Result;
 
-  struct alignas(32) Options {
+  struct Options {
     SizeType max_slice_capacity;
     SizeType capacity;
     SizeType borrow_cas_attempts;

--- a/spoor/runtime/buffer/reserved_buffer_slice_pool.h
+++ b/spoor/runtime/buffer/reserved_buffer_slice_pool.h
@@ -30,7 +30,7 @@ class ReservedBufferSlicePool final : public BufferSlicePool<T> {
   using BorrowResult = util::result::Result<OwnedSlicePtr, BorrowError>;
   using ReturnResult = typename util::memory::PtrOwner<Slice>::Result;
 
-  struct alignas(16) Options {
+  struct Options {
     SizeType max_slice_capacity;
     SizeType capacity;
   };

--- a/spoor/runtime/config/config.h
+++ b/spoor/runtime/config/config.h
@@ -15,7 +15,7 @@
 
 namespace spoor::runtime::config {
 
-struct alignas(128) Config {
+struct Config {
   using SizeType = buffer::CircularBuffer<trace::Event>::SizeType;
   static_assert(std::is_same_v<SizeType, Source::SizeType>);
 

--- a/spoor/runtime/config/env_source.h
+++ b/spoor/runtime/config/env_source.h
@@ -57,7 +57,7 @@ constexpr std::array<std::string_view, 12> kEnvConfigKeys{{
 
 class EnvSource final : public Source {
  public:
-  struct alignas(64) Options {
+  struct Options {
     util::env::StdGetEnv get_env;
   };
 

--- a/spoor/runtime/config/file_source.h
+++ b/spoor/runtime/config/file_source.h
@@ -57,7 +57,7 @@ constexpr std::array<std::string_view, 12> kFileConfigKeys{{
 
 class FileSource final : public Source {
  public:
-  struct alignas(128) Options {
+  struct Options {
     std::unique_ptr<util::file_system::FileReader> file_reader;
     std::filesystem::path file_path;
     util::env::StdGetEnv get_env;

--- a/spoor/runtime/config/source.h
+++ b/spoor/runtime/config/source.h
@@ -18,7 +18,7 @@ class Source {
  public:
   using SizeType = buffer::CircularBuffer<trace::Event>::SizeType;
 
-  struct alignas(32) ReadError {
+  struct ReadError {
     enum class Type {
       kFailedToOpenFile,
       kMalformedFile,

--- a/spoor/runtime/event_logger/event_logger.h
+++ b/spoor/runtime/event_logger/event_logger.h
@@ -22,7 +22,7 @@ class EventLogger {
   using Buffer = buffer::CircularSliceBuffer<trace::Event>;
   using SizeType = Buffer::SizeType;
 
-  struct alignas(32) Options {
+  struct Options {
     gsl::not_null<flush_queue::FlushQueue<Buffer>*> flush_queue;
     SizeType preferred_capacity;
     bool flush_buffer_when_full;

--- a/spoor/runtime/flush_queue/disk_flush_queue.h
+++ b/spoor/runtime/flush_queue/disk_flush_queue.h
@@ -32,7 +32,7 @@ class DiskFlushQueue final
   using Buffer = buffer::CircularSliceBuffer<trace::Event>;
   using SizeType = Buffer::SizeType;
 
-  struct alignas(128) Options {
+  struct Options {
     std::filesystem::path trace_file_path;
     std::chrono::nanoseconds buffer_retention_duration;
     gsl::not_null<util::time::SystemClock*> system_clock;
@@ -64,7 +64,7 @@ class DiskFlushQueue final
   [[nodiscard]] auto Empty() const -> bool;
 
  private:
-  struct alignas(128) FlushInfo {
+  struct FlushInfo {
     Buffer buffer;
     std::chrono::time_point<std::chrono::steady_clock> flush_timestamp;
     trace::ThreadId thread_id;

--- a/spoor/runtime/runtime.h
+++ b/spoor/runtime/runtime.h
@@ -39,12 +39,12 @@ using SizeType = std::uint64_t;
 using SystemTimestampSeconds = std::int64_t;
 using TimestampNanoseconds = std::int64_t;
 
-struct alignas(16) DeletedFilesInfo {
+struct DeletedFilesInfo {
   std::int32_t deleted_files;
   std::int64_t deleted_bytes;
 };
 
-struct alignas(128) Config {
+struct Config {
   std::filesystem::path trace_file_path;
   SessionId session_id;
   SizeType thread_event_buffer_capacity;

--- a/spoor/runtime/runtime_manager/runtime_manager.h
+++ b/spoor/runtime/runtime_manager/runtime_manager.h
@@ -29,7 +29,7 @@ class RuntimeManager final : public event_logger::EventLoggerNotifier {
   using Buffer = buffer::CircularSliceBuffer<trace::Event>;
   using SizeType = Buffer::SizeType;
 
-  struct alignas(128) Options {
+  struct Options {
     gsl::not_null<util::time::SteadyClock*> steady_clock;
     gsl::not_null<flush_queue::FlushQueue<Buffer>*> flush_queue;
     SizeType thread_event_buffer_capacity;
@@ -42,7 +42,7 @@ class RuntimeManager final : public event_logger::EventLoggerNotifier {
     bool flush_all_events;
   };
 
-  struct alignas(16) DeletedFilesInfo {
+  struct DeletedFilesInfo {
     int32 deleted_files;
     int64 deleted_bytes;
   };

--- a/spoor/runtime/runtime_manager/runtime_manager_test.cc
+++ b/spoor/runtime/runtime_manager/runtime_manager_test.cc
@@ -281,7 +281,7 @@ TEST(RuntimeManager, FlushedTraceFiles) {  // NOLINT
 }
 
 TEST(RuntimeManager, DeleteFlushedTraceFilesOlderThan) {  // NOLINT
-  struct alignas(64) FileInfo {
+  struct FileInfo {
     DirectoryEntryMock entry;
     int64 size_bytes;
     TimestampNanoseconds created_at;

--- a/spoor/runtime/trace/trace.h
+++ b/spoor/runtime/trace/trace.h
@@ -60,7 +60,7 @@ enum class Endian : uint8 {
 constexpr Endian kEndianness{
     absl::little_endian::IsLittleEndian() ? Endian::kLittle : Endian::kBig};
 
-struct alignas(64) Header {
+struct Header {
   MagicNumber magic_number{kMagicNumber};
   Endian endianness{kEndianness};
   CompressionStrategy compression_strategy;
@@ -80,7 +80,7 @@ constexpr auto operator==(const Header& lhs, const Header& rhs) -> bool;
 
 // Aligning to 32 bytes (most efficient) results in an eight-byte space loss per
 // event which is undesirable given the quantity of events generated.
-struct alignas(8) Event {  // NOLINT(altera-struct-pack-align)
+struct alignas(8) Event {
   enum class Type : EventType {
     kFunctionEntry = 1,
     kFunctionExit = 2,
@@ -96,7 +96,7 @@ static_assert(sizeof(Event) == 24);
 
 constexpr auto operator==(const Event& lhs, const Event& rhs) -> bool;
 
-struct alignas(128) TraceFile {
+struct TraceFile {
   Header header;
   std::vector<Event> events;
 };

--- a/spoor/runtime/trace/trace_file_reader.h
+++ b/spoor/runtime/trace/trace_file_reader.h
@@ -14,7 +14,7 @@ namespace spoor::runtime::trace {
 
 class TraceFileReader final : public TraceReader {
  public:
-  struct alignas(16) Options {
+  struct Options {
     std::unique_ptr<util::file_system::FileSystem> file_system;
     std::unique_ptr<util::file_system::FileReader> file_reader;
   };

--- a/spoor/runtime/trace/trace_file_writer.h
+++ b/spoor/runtime/trace/trace_file_writer.h
@@ -17,7 +17,7 @@ namespace spoor::runtime::trace {
 
 class TraceFileWriter final : public TraceWriter {
  public:
-  struct alignas(32) Options {
+  struct Options {
     std::unique_ptr<util::file_system::FileWriter> file_writer;
     util::compression::Strategy compression_strategy;
     util::compression::Compressor::SizeType initial_buffer_capacity;

--- a/spoor/tools/config/config.h
+++ b/spoor/tools/config/config.h
@@ -17,7 +17,7 @@ enum class OutputFormat {
   kSpoorSymbolsCsv,
 };
 
-struct alignas(32) Config {
+struct Config {
   // Alphabetized to match the order printed in --help.
   std::string output_file;
   OutputFormat output_format;

--- a/util/file_system/util.h
+++ b/util/file_system/util.h
@@ -11,7 +11,7 @@
 
 namespace util::file_system {
 
-struct alignas(2) PathExpansionOptions {
+struct PathExpansionOptions {
   bool expand_tilde;
   bool expand_environment_variables;
 };

--- a/util/result.h
+++ b/util/result.h
@@ -10,8 +10,6 @@
 namespace util::result {
 
 // Use `None` to indicate an empty Ok or Err.
-// `__attribute__((aligned(0)))` is not a power of two and `alignas(0)` is
-// always ignored. NOLINTNEXTLINE(altera-struct-pack-align)
 struct None {};
 
 // `Result<T, E>` is the type used to return and propagate errors. It stores


### PR DESCRIPTION
Removes the `altera-struct-pack-align` Clang Tidy check which is not portable across architectures.