### PR TITLE
Revert RuntimeManager premain guard

### DIFF
--- a/spoor/runtime/runtime_manager/runtime_manager.cc
+++ b/spoor/runtime/runtime_manager/runtime_manager.cc
@@ -92,8 +92,6 @@ auto RuntimeManager::Unsubscribe(
 }
 
 auto RuntimeManager::LogEvent(const trace::Event event) -> void {
-  if (!enabled_) return;
-
   thread_local event_logger::EventLogger event_logger{
       {.flush_queue = options_.flush_queue,
        .preferred_capacity = options_.thread_event_buffer_capacity,
@@ -116,8 +114,6 @@ auto RuntimeManager::LogEvent(
 auto RuntimeManager::LogEvent(const trace::EventType type,
                               const uint64 payload_1, const uint32 payload_2)
     -> void {
-  if (!enabled_) return;
-
   const auto now = options_.steady_clock->Now();
   const auto now_nanoseconds =
       std::chrono::duration_cast<std::chrono::nanoseconds>(

--- a/spoor/runtime/runtime_manager/runtime_manager.h
+++ b/spoor/runtime/runtime_manager/runtime_manager.h
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include <atomic>
 #include <chrono>
 #include <filesystem>
 #include <functional>
@@ -100,12 +99,7 @@ class RuntimeManager final : public event_logger::EventLoggerNotifier {
   std::unique_ptr<Pool> pool_;
   std::unordered_set<event_logger::EventLogger*> event_loggers_;
   bool initialized_;
-
-  // std::atomic_bool's zero-initialization value ensures that the runtime
-  // library is not enabled pre-main. The flag guards the logging methods
-  // against pre-main calls and prevents a crash where they might otherwise
-  // operate on uninitialized data.
-  std::atomic_bool enabled_;
+  bool enabled_;
 };
 
 template <class ConstIterator>

--- a/spoor/runtime/runtime_manager/runtime_manager_test.cc
+++ b/spoor/runtime/runtime_manager/runtime_manager_test.cc
@@ -357,47 +357,4 @@ TEST(RuntimeManagerDeletedFilesInfo, Equality) {  // NOLINT
   ASSERT_NE(info_b, info_c);
 }
 
-namespace pre_main_crash_test {
-// Operating on uninitialized data results in a crash.
-
-// clang-format off NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables, fuchsia-statically-constructed-objects) clang-format on
-SteadyClockMock steady_clock_{};
-
-// clang-format off NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables, fuchsia-statically-constructed-objects) clang-format on
-FlushQueueMock flush_queue_{};
-
-// clang-format off NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables, fuchsia-statically-constructed-objects) clang-format on
-RuntimeManager runtime_manager_{{.steady_clock = &steady_clock_,
-                                 .flush_queue = &flush_queue_,
-                                 .thread_event_buffer_capacity = 0,
-                                 .reserved_pool_capacity = 0,
-                                 .reserved_pool_max_slice_capacity = 0,
-                                 .dynamic_pool_capacity = 0,
-                                 .dynamic_pool_max_slice_capacity = 0,
-                                 .dynamic_pool_borrow_cas_attempts = 0,
-                                 .max_buffer_flush_attempts = 0,
-                                 .flush_all_events = false}};
-
-__attribute__((constructor)) auto TestIgnoresLogEventPreMain() -> void {
-  std::cerr << "pre-main crash test: Started\n";
-  std::cerr << "A console message such as `libc++abi: terminating` indicates a "
-               "test failure.\n";
-
-  runtime_manager_.LogFunctionEntry(0);
-  runtime_manager_.LogFunctionExit(0);
-  runtime_manager_.LogEvent(1, 2, 3);
-  runtime_manager_.LogEvent(1, 2, 3, 4);
-
-  constexpr Event event{
-      .steady_clock_timestamp = 0,
-      .payload_1 = 1,
-      .type = static_cast<EventType>(Event::Type::kFunctionEntry),
-      .payload_2 = 0};
-  runtime_manager_.LogEvent(event);
-
-  std::cerr << "pre-main crash test: Passed.\n";
-}
-
-}  // namespace pre_main_crash_test
-
 }  // namespace


### PR DESCRIPTION
Reverts #160, a temporary patch for calls to the runtime manager pre-main (before it had been initialized). #222 changed the runtime manager's initialization strategy which supports pre-main calls.