### PR TITLE
Make trace file path

### DIFF
--- a/docs/configuration/runtime.md
+++ b/docs/configuration/runtime.md
@@ -24,9 +24,6 @@ Source               | Key
 Environment variable | `SPOOR_RUNTIME_TRACE_FILE_PATH`
 Config file          | `trace_file_path`
 
-!!! warning "Path requirements"
-    The path must exist and end with a trailing `/`.
-
 !!! tip "Environment variable expansion"
     Spoor automatically expands environment variables. A tilde (i.e., `~`)
     expands to the value of `$HOME`.

--- a/spoor/runtime/config/BUILD
+++ b/spoor/runtime/config/BUILD
@@ -54,6 +54,7 @@ cc_library(
         "//util/compression",
         "//util/env",
         "//util/file_system",
+        "@com_google_absl//absl/strings",
     ],
 )
 

--- a/spoor/runtime/config/config_test.cc
+++ b/spoor/runtime/config/config_test.cc
@@ -44,6 +44,7 @@ TEST(Config, Default) {  // NOLINT
       .max_flush_buffer_to_file_attempts = 2,
       .flush_all_events = true,
   };
+  ASSERT_EQ(default_config, expected_default_config);
 }
 
 TEST(Config, UsesDefaultConfigWithNoSource) {  // NOLINT
@@ -410,6 +411,30 @@ TEST(Config, ExpandsEnvironmentVariables) {  // NOLINT
   const auto config_b =
       Config::FromSourcesOrDefault(std::move(sources), default_config, get_env);
   ASSERT_EQ(config_b, expected_config);
+}
+
+TEST(Config, AddsTrailingSlash) {  // NOLINT
+  const auto get_env = [](const char* /*unused*/) { return nullptr; };
+  const auto input_path =
+      std::filesystem::path{"/path/to/trace"}.make_preferred();
+  const auto parsed_path =
+      std::filesystem::path{"/path/to/trace/"}.make_preferred();
+  const Config default_config{
+      .trace_file_path = input_path,
+      .compression_strategy = util::compression::Strategy::kNone,
+      .session_id = 1,
+      .thread_event_buffer_capacity = 2,
+      .max_reserved_event_buffer_slice_capacity = 3,
+      .max_dynamic_event_buffer_slice_capacity = 4,
+      .reserved_event_pool_capacity = 5,
+      .dynamic_event_pool_capacity = 6,
+      .dynamic_event_slice_borrow_cas_attempts = 7,
+      .event_buffer_retention_duration_nanoseconds = 8,
+      .max_flush_buffer_to_file_attempts = 9,
+      .flush_all_events = false,
+  };
+  const auto config = Config::FromSourcesOrDefault({}, default_config, get_env);
+  ASSERT_EQ(config.trace_file_path, parsed_path);
 }
 
 }  // namespace

--- a/spoor/runtime/flush_queue/disk_flush_queue.cc
+++ b/spoor/runtime/flush_queue/disk_flush_queue.cc
@@ -4,11 +4,11 @@
 #include "spoor/runtime/flush_queue/disk_flush_queue.h"
 
 #include <chrono>
-#include <filesystem>
 #include <functional>
 #include <mutex>
 #include <queue>
 #include <shared_mutex>
+#include <string>
 #include <thread>
 
 #include "absl/strings/str_format.h"
@@ -140,14 +140,13 @@ auto DiskFlushQueue::Size() const -> DiskFlushQueue::SizeType {
 auto DiskFlushQueue::Empty() const -> bool { return queue_size_ == 0; }
 
 auto DiskFlushQueue::TraceFilePath(const FlushInfo& flush_info) const
-    -> std::filesystem::path {
+    -> std::string {
   const auto timestamp = std::chrono::duration_cast<std::chrono::nanoseconds>(
                              flush_info.flush_timestamp.time_since_epoch())
                              .count();
-  const auto file_name = absl::StrFormat(
-      "%016x-%016x-%016x.%s", options_.session_id, flush_info.thread_id,
-      timestamp, trace::kTraceFileExtension);
-  return options_.trace_file_path / file_name;
+  return absl::StrFormat("%016x-%016x-%016x.%s", options_.session_id,
+                         flush_info.thread_id, timestamp,
+                         trace::kTraceFileExtension);
 }
 
 auto DiskFlushQueue::TraceFileHeader(const FlushInfo& flush_info) const

--- a/spoor/runtime/flush_queue/disk_flush_queue.h
+++ b/spoor/runtime/flush_queue/disk_flush_queue.h
@@ -12,7 +12,7 @@
 #include <mutex>
 #include <optional>
 #include <shared_mutex>
-#include <string_view>
+#include <string>
 #include <thread>
 #include <unordered_set>
 
@@ -33,7 +33,6 @@ class DiskFlushQueue final
   using SizeType = Buffer::SizeType;
 
   struct Options {
-    std::filesystem::path trace_file_path;
     std::chrono::nanoseconds buffer_retention_duration;
     gsl::not_null<util::time::SystemClock*> system_clock;
     gsl::not_null<util::time::SteadyClock*> steady_clock;
@@ -86,8 +85,7 @@ class DiskFlushQueue final
   std::atomic_bool running_;
   std::atomic_bool draining_;
 
-  auto TraceFilePath(const FlushInfo& flush_info) const
-      -> std::filesystem::path;
+  auto TraceFilePath(const FlushInfo& flush_info) const -> std::string;
   auto TraceFileHeader(const FlushInfo& flush_info) const -> trace::Header;
   auto RunCompletionIfPossible() -> void;
 };

--- a/spoor/runtime/runtime.cc
+++ b/spoor/runtime/runtime.cc
@@ -186,10 +186,13 @@ auto TraceFileReader::Instance() -> spoor::runtime::trace::TraceFileReader& {
 
 auto TraceFileWriter::Instance() -> spoor::runtime::trace::TraceFileWriter& {
   static spoor::runtime::trace::TraceFileWriter trace_file_writer{{
+      .file_system{std::make_unique<util::file_system::LocalFileSystem>()},
       .file_writer{std::make_unique<util::file_system::LocalFileWriter>()},
       .compression_strategy = Config::Instance().compression_strategy,
       .initial_buffer_capacity =
           Config::Instance().thread_event_buffer_capacity,
+      .directory = Config::Instance().trace_file_path,
+      .create_directory = true,
   }};
   return trace_file_writer;
 }
@@ -222,7 +225,6 @@ auto Config::Instance() -> const spoor::runtime::config::Config& {
 auto RuntimeManager::Instance()
     -> spoor::runtime::runtime_manager::RuntimeManager& {
   static spoor::runtime::flush_queue::DiskFlushQueue flush_queue{{
-      .trace_file_path = Config::Instance().trace_file_path,
       .buffer_retention_duration =
           std::chrono::nanoseconds{
               Config::Instance().event_buffer_retention_duration_nanoseconds},

--- a/spoor/runtime/trace/trace_file_writer.h
+++ b/spoor/runtime/trace/trace_file_writer.h
@@ -5,12 +5,14 @@
 
 #include <filesystem>
 #include <memory>
+#include <string>
 #include <vector>
 
 #include "gsl/gsl"
 #include "spoor/runtime/trace/trace.h"
 #include "spoor/runtime/trace/trace_writer.h"
 #include "util/compression/compressor.h"
+#include "util/file_system/file_system.h"
 #include "util/file_system/file_writer.h"
 
 namespace spoor::runtime::trace {
@@ -18,19 +20,23 @@ namespace spoor::runtime::trace {
 class TraceFileWriter final : public TraceWriter {
  public:
   struct Options {
+    std::unique_ptr<util::file_system::FileSystem> file_system;
     std::unique_ptr<util::file_system::FileWriter> file_writer;
     util::compression::Strategy compression_strategy;
     util::compression::Compressor::SizeType initial_buffer_capacity;
+    std::filesystem::path directory;
+    bool create_directory;
   };
 
   explicit TraceFileWriter(Options options);
-  auto Write(const std::filesystem::path& file_path, Header header,
+  auto Write(const std::string& file_name, Header header,
              gsl::not_null<Events*> events) -> Result override;
 
  private:
   Options options_;
   std::unique_ptr<util::compression::Compressor> compressor_;
   std::vector<Event> buffer_;
+  bool created_directory_;
 };
 
 }  // namespace spoor::runtime::trace

--- a/spoor/runtime/trace/trace_file_writer_test.cc
+++ b/spoor/runtime/trace/trace_file_writer_test.cc
@@ -3,6 +3,10 @@
 
 #include "spoor/runtime/trace/trace_file_writer.h"
 
+#include <algorithm>
+#include <filesystem>
+#include <string>
+
 #include "gmock/gmock.h"
 #include "gsl/gsl"
 #include "gtest/gtest.h"
@@ -11,6 +15,7 @@
 #include "trace.h"
 #include "util/compression/compressor.h"
 #include "util/compression/compressor_factory.h"
+#include "util/file_system/file_system_mock.h"
 #include "util/file_system/file_writer_mock.h"
 
 namespace {
@@ -23,8 +28,10 @@ using spoor::runtime::trace::kMagicNumber;
 using spoor::runtime::trace::kTraceFileVersion;
 using spoor::runtime::trace::TraceFileWriter;
 using testing::_;
+using testing::AnyNumber;
 using testing::Return;
 using util::compression::MakeCompressor;
+using util::file_system::testing::FileSystemMock;
 using util::file_system::testing::FileWriterMock;
 using CircularSliceBuffer = spoor::runtime::buffer::CircularSliceBuffer<Event>;
 using Pool = spoor::runtime::buffer::ReservedBufferSlicePool<Event>;
@@ -49,32 +56,42 @@ MATCHER_P2(MatchesEvents, expected_events, compressor, "") {  // NOLINT
 }
 
 TEST(TraceFileWriter, Write) {  // NOLINT
-  const std::filesystem::path path{"/path/to/file.spoor"};
+  const std::filesystem::path directory{"/path/to/file/"};
+  const std::string file_name{"file.spoor"};
+  const auto path = directory / file_name;
+
   constexpr std::array<Event, 4> raw_events{{
       {.steady_clock_timestamp = 0, .payload_1 = 1, .type = 1, .payload_2 = 2},
       {.steady_clock_timestamp = 1, .payload_1 = 3, .type = 2, .payload_2 = 4},
       {.steady_clock_timestamp = 2, .payload_1 = 5, .type = 2, .payload_2 = 6},
       {.steady_clock_timestamp = 3, .payload_1 = 9, .type = 1, .payload_2 = 8},
   }};
-  Pool pool{
-      {.max_slice_capacity = raw_events.size(), .capacity = raw_events.size()}};
-  CircularSliceBuffer events{
-      {.buffer_slice_pool = &pool, .capacity = raw_events.size()}};
+  Pool pool{{
+      .max_slice_capacity = raw_events.size(),
+      .capacity = raw_events.size(),
+  }};
+  CircularSliceBuffer events{{
+      .buffer_slice_pool = &pool,
+      .capacity = raw_events.size(),
+  }};
   std::for_each(std::cbegin(raw_events), std ::cend(raw_events),
                 [&events](const auto event) { events.Push(event); });
   for (const auto compression_strategy : util::compression::kStrategies) {
-    const Header header{.magic_number = kMagicNumber,
-                        .endianness = kEndianness,
-                        .compression_strategy = compression_strategy,
-                        .version = kTraceFileVersion,
-                        .session_id = 1,
-                        .process_id = 2,
-                        .thread_id = 3,
-                        .system_clock_timestamp = 4,
-                        .steady_clock_timestamp = 5,
-                        .event_count = raw_events.size()};
+    const Header header{
+        .magic_number = kMagicNumber,
+        .endianness = kEndianness,
+        .compression_strategy = compression_strategy,
+        .version = kTraceFileVersion,
+        .session_id = 1,
+        .process_id = 2,
+        .thread_id = 3,
+        .system_clock_timestamp = 4,
+        .steady_clock_timestamp = 5,
+        .event_count = raw_events.size(),
+    };
     auto compressor =
         MakeCompressor(compression_strategy, raw_events.size() * sizeof(Event));
+    auto file_system = std::make_unique<FileSystemMock>();
     auto file_writer = std::make_unique<FileWriterMock>();
     EXPECT_CALL(*file_writer, Open(path, std::ios::trunc | std::ios::binary));
     EXPECT_CALL(*file_writer, IsOpen()).WillOnce(Return(true));
@@ -82,21 +99,30 @@ TEST(TraceFileWriter, Write) {  // NOLINT
     EXPECT_CALL(*file_writer,
                 Write(MatchesEvents(raw_events, compressor.get())));
     EXPECT_CALL(*file_writer, Close());
-    TraceFileWriter trace_file_writer{
-        {.file_writer = std::move(file_writer),
-         .compression_strategy = compression_strategy,
-         .initial_buffer_capacity = raw_events.size()}};
-    const auto result = trace_file_writer.Write(path, header, &events);
+    TraceFileWriter trace_file_writer{{
+        .file_system = std::move(file_system),
+        .file_writer = std::move(file_writer),
+        .compression_strategy = compression_strategy,
+        .initial_buffer_capacity = raw_events.size(),
+        .directory = directory,
+        .create_directory = false,
+    }};
+    const auto result = trace_file_writer.Write(file_name, header, &events);
     ASSERT_TRUE(result.IsOk());
   }
 }
 
 TEST(TraceFileWriter, SetsHeaderCompressionStrategy) {  // NOLINT
-  const std::filesystem::path path{"/path/to/file.spoor"};
-  constexpr std::array<Event, 1> raw_events{{{.steady_clock_timestamp = 0,
-                                              .payload_1 = 1,
-                                              .type = 2,
-                                              .payload_2 = 3}}};
+  const std::filesystem::path directory{"/path/to/file/"};
+  const std::string file_name{"file.spoor"};
+  const auto path = directory / file_name;
+
+  constexpr std::array<Event, 1> raw_events{{{
+      .steady_clock_timestamp = 0,
+      .payload_1 = 1,
+      .type = 2,
+      .payload_2 = 3,
+  }}};
   constexpr Header input_header{
       .magic_number = kMagicNumber,
       .endianness = kEndianness,
@@ -107,7 +133,8 @@ TEST(TraceFileWriter, SetsHeaderCompressionStrategy) {  // NOLINT
       .thread_id = 3,
       .system_clock_timestamp = 4,
       .steady_clock_timestamp = 5,
-      .event_count = raw_events.size()};
+      .event_count = raw_events.size(),
+  };
   constexpr auto compression_strategy{CompressionStrategy::kSnappy};
   constexpr Header expected_header{
       .magic_number = input_header.magic_number,
@@ -119,135 +146,249 @@ TEST(TraceFileWriter, SetsHeaderCompressionStrategy) {  // NOLINT
       .thread_id = input_header.thread_id,
       .system_clock_timestamp = input_header.system_clock_timestamp,
       .steady_clock_timestamp = input_header.steady_clock_timestamp,
-      .event_count = input_header.event_count};
+      .event_count = input_header.event_count,
+  };
   ASSERT_NE(input_header.compression_strategy,
             expected_header.compression_strategy);
-  Pool pool{
-      {.max_slice_capacity = raw_events.size(), .capacity = raw_events.size()}};
-  CircularSliceBuffer events{
-      {.buffer_slice_pool = &pool, .capacity = raw_events.size()}};
+  Pool pool{{
+      .max_slice_capacity = raw_events.size(),
+      .capacity = raw_events.size(),
+  }};
+  CircularSliceBuffer events{{
+      .buffer_slice_pool = &pool,
+      .capacity = raw_events.size(),
+  }};
   std::for_each(std::cbegin(raw_events), std ::cend(raw_events),
                 [&events](const auto event) { events.Push(event); });
   auto compressor =
       MakeCompressor(compression_strategy, raw_events.size() * sizeof(Event));
+  auto file_system = std::make_unique<FileSystemMock>();
   auto file_writer = std::make_unique<FileWriterMock>();
   EXPECT_CALL(*file_writer, Open(path, std::ios::trunc | std::ios::binary));
   EXPECT_CALL(*file_writer, IsOpen()).WillOnce(Return(true));
   EXPECT_CALL(*file_writer, Write(MatchesHeader(expected_header)));
   EXPECT_CALL(*file_writer, Write(MatchesEvents(raw_events, compressor.get())));
   EXPECT_CALL(*file_writer, Close());
-  TraceFileWriter trace_file_writer{
-      {.file_writer = std::move(file_writer),
-       .compression_strategy = CompressionStrategy::kSnappy,
-       .initial_buffer_capacity = raw_events.size()}};
-  const auto result = trace_file_writer.Write(path, input_header, &events);
+  TraceFileWriter trace_file_writer{{
+      .file_system = std::move(file_system),
+      .file_writer = std::move(file_writer),
+      .compression_strategy = CompressionStrategy::kSnappy,
+      .initial_buffer_capacity = raw_events.size(),
+      .directory = directory,
+      .create_directory = false,
+  }};
+  const auto result = trace_file_writer.Write(file_name, input_header, &events);
   ASSERT_TRUE(result.IsOk());
 }
 
 TEST(TraceFileWriter, DoesNotWriteZeroEvents) {  // NOLINT
-  const std::filesystem::path path{"/path/to/file.spoor"};
+  const std::filesystem::path directory{"/path/to/file/"};
+  const std::string file_name{"file.spoor"};
+  const auto path = directory / file_name;
+
   constexpr auto compression_strategy{CompressionStrategy::kNone};
   constexpr std::array<Event, 0> raw_events{};
-  constexpr Header header{.magic_number = kMagicNumber,
-                          .endianness = kEndianness,
-                          .compression_strategy = compression_strategy,
-                          .version = kTraceFileVersion,
-                          .session_id = 1,
-                          .process_id = 2,
-                          .thread_id = 3,
-                          .system_clock_timestamp = 4,
-                          .steady_clock_timestamp = 5,
-                          .event_count = raw_events.size()};
+  constexpr Header header{
+      .magic_number = kMagicNumber,
+      .endianness = kEndianness,
+      .compression_strategy = compression_strategy,
+      .version = kTraceFileVersion,
+      .session_id = 1,
+      .process_id = 2,
+      .thread_id = 3,
+      .system_clock_timestamp = 4,
+      .steady_clock_timestamp = 5,
+      .event_count = raw_events.size(),
+  };
   Pool pool{{.max_slice_capacity = 0, .capacity = 0}};
   CircularSliceBuffer events{{.buffer_slice_pool = &pool, .capacity = 0}};
+  auto file_system = std::make_unique<FileSystemMock>();
   auto file_writer = std::make_unique<FileWriterMock>();
   EXPECT_CALL(*file_writer, Open(_, _)).Times(0);
   EXPECT_CALL(*file_writer, IsOpen()).Times(0);
   EXPECT_CALL(*file_writer, Write(_)).Times(0);
   EXPECT_CALL(*file_writer, Close()).Times(0);
-  TraceFileWriter trace_file_writer{
-      {.file_writer = std::move(file_writer),
-       .compression_strategy = compression_strategy,
-       .initial_buffer_capacity = raw_events.size()}};
-  const auto result = trace_file_writer.Write(path, header, &events);
+  TraceFileWriter trace_file_writer{{
+      .file_system = std::move(file_system),
+      .file_writer = std::move(file_writer),
+      .compression_strategy = compression_strategy,
+      .initial_buffer_capacity = raw_events.size(),
+      .directory = directory,
+      .create_directory = false,
+  }};
+  const auto result = trace_file_writer.Write(file_name, header, &events);
   ASSERT_TRUE(result.IsOk());
 }
 
 TEST(TraceFileWriter, WritesUncompressedIfCompressedIsLarger) {  // NOLINT
-  const std::filesystem::path path{"/path/to/file.spoor"};
-  constexpr std::array<Event, 1> raw_events{
-      {{.steady_clock_timestamp = 0x0123456789abcdef,
-        .payload_1 = 0xfedcba9876543210,
-        .type = 0xabab,
-        .payload_2 = 0x1a2b3c4d}}};
-  constexpr Header header{.magic_number = kMagicNumber,
-                          .endianness = kEndianness,
-                          .compression_strategy = CompressionStrategy::kNone,
-                          .version = kTraceFileVersion,
-                          .session_id = 1,
-                          .process_id = 2,
-                          .thread_id = 3,
-                          .system_clock_timestamp = 4,
-                          .steady_clock_timestamp = 5,
-                          .event_count = raw_events.size()};
-  Pool pool{
-      {.max_slice_capacity = raw_events.size(), .capacity = raw_events.size()}};
-  CircularSliceBuffer events{
-      {.buffer_slice_pool = &pool, .capacity = raw_events.size()}};
+  const std::filesystem::path directory{"/path/to/file/"};
+  const std::string file_name{"file.spoor"};
+  const auto path = directory / file_name;
+
+  constexpr std::array<Event, 1> raw_events{{{
+      .steady_clock_timestamp = 0x0123456789abcdef,
+      .payload_1 = 0xfedcba9876543210,
+      .type = 0xabab,
+      .payload_2 = 0x1a2b3c4d,
+  }}};
+  constexpr Header header{
+      .magic_number = kMagicNumber,
+      .endianness = kEndianness,
+      .compression_strategy = CompressionStrategy::kNone,
+      .version = kTraceFileVersion,
+      .session_id = 1,
+      .process_id = 2,
+      .thread_id = 3,
+      .system_clock_timestamp = 4,
+      .steady_clock_timestamp = 5,
+      .event_count = raw_events.size(),
+  };
+  Pool pool{{
+      .max_slice_capacity = raw_events.size(),
+      .capacity = raw_events.size(),
+  }};
+  CircularSliceBuffer events{{
+      .buffer_slice_pool = &pool,
+      .capacity = raw_events.size(),
+  }};
   std::for_each(std::cbegin(raw_events), std ::cend(raw_events),
                 [&events](const auto event) { events.Push(event); });
   auto compressor = MakeCompressor(CompressionStrategy::kNone,
                                    raw_events.size() * sizeof(Event));
   ASSERT_EQ(header.compression_strategy, compressor->Strategy());
+  auto file_system = std::make_unique<FileSystemMock>();
   auto file_writer = std::make_unique<FileWriterMock>();
   EXPECT_CALL(*file_writer, Open(path, std::ios::trunc | std::ios::binary));
   EXPECT_CALL(*file_writer, IsOpen()).WillOnce(Return(true));
   EXPECT_CALL(*file_writer, Write(MatchesHeader(header)));
   EXPECT_CALL(*file_writer, Write(MatchesEvents(raw_events, compressor.get())));
   EXPECT_CALL(*file_writer, Close());
-  TraceFileWriter trace_file_writer{
-      {.file_writer = std::move(file_writer),
-       .compression_strategy = CompressionStrategy::kSnappy,
-       .initial_buffer_capacity = raw_events.size()}};
-  const auto result = trace_file_writer.Write(path, header, &events);
+  TraceFileWriter trace_file_writer{{
+      .file_system = std::move(file_system),
+      .file_writer = std::move(file_writer),
+      .compression_strategy = CompressionStrategy::kSnappy,
+      .initial_buffer_capacity = raw_events.size(),
+      .directory = directory,
+      .create_directory = false,
+  }};
+  const auto result = trace_file_writer.Write(file_name, header, &events);
   ASSERT_TRUE(result.IsOk());
 }
 
 TEST(TraceFileWriter, FailsIfFileCannotBeOpened) {  // NOLINT
-  const std::filesystem::path path{"/path/to/bad/file.spoor"};
+  const std::filesystem::path directory{"/path/to/file/"};
+  const std::string file_name{"bad.spoor"};
+  const auto path = directory / file_name;
+
   constexpr auto compression_strategy{CompressionStrategy::kNone};
-  constexpr std::array<Event, 1> raw_events{{{.steady_clock_timestamp = 0,
-                                              .payload_1 = 1,
-                                              .type = 2,
-                                              .payload_2 = 3}}};
-  constexpr Header header{.magic_number = kMagicNumber,
-                          .endianness = kEndianness,
-                          .compression_strategy = compression_strategy,
-                          .version = kTraceFileVersion,
-                          .session_id = 1,
-                          .process_id = 2,
-                          .thread_id = 3,
-                          .system_clock_timestamp = 4,
-                          .steady_clock_timestamp = 5,
-                          .event_count = raw_events.size()};
-  Pool pool{
-      {.max_slice_capacity = raw_events.size(), .capacity = raw_events.size()}};
-  CircularSliceBuffer events{
-      {.buffer_slice_pool = &pool, .capacity = raw_events.size()}};
+  constexpr std::array<Event, 1> raw_events{{{
+      .steady_clock_timestamp = 0,
+      .payload_1 = 1,
+      .type = 2,
+      .payload_2 = 3,
+  }}};
+  constexpr Header header{
+      .magic_number = kMagicNumber,
+      .endianness = kEndianness,
+      .compression_strategy = compression_strategy,
+      .version = kTraceFileVersion,
+      .session_id = 1,
+      .process_id = 2,
+      .thread_id = 3,
+      .system_clock_timestamp = 4,
+      .steady_clock_timestamp = 5,
+      .event_count = raw_events.size(),
+  };
+  Pool pool{{
+      .max_slice_capacity = raw_events.size(),
+      .capacity = raw_events.size(),
+  }};
+  CircularSliceBuffer events{{
+      .buffer_slice_pool = &pool,
+      .capacity = raw_events.size(),
+  }};
   std::for_each(std::cbegin(raw_events), std ::cend(raw_events),
                 [&events](const auto event) { events.Push(event); });
-  auto file_writer = std::make_unique<FileWriterMock>();
-  EXPECT_CALL(*file_writer, Open(path, std::ios::trunc | std::ios::binary));
-  EXPECT_CALL(*file_writer, IsOpen()).WillOnce(Return(false));
-  EXPECT_CALL(*file_writer, Write(_)).Times(0);
-  EXPECT_CALL(*file_writer, Close()).Times(0);
-  TraceFileWriter trace_file_writer{
-      {.file_writer = std::move(file_writer),
-       .compression_strategy = compression_strategy,
-       .initial_buffer_capacity = raw_events.size()}};
-  const auto result = trace_file_writer.Write(path, header, &events);
-  ASSERT_TRUE(result.IsErr());
-  ASSERT_EQ(result.Err(), TraceFileWriter::Error::kFailedToOpenFile);
+  for (const auto created_directories : {false, true}) {
+    auto file_system = std::make_unique<FileSystemMock>();
+    EXPECT_CALL(*file_system, CreateDirectories(directory))
+        .WillOnce(Return(created_directories));
+    auto file_writer = std::make_unique<FileWriterMock>();
+    EXPECT_CALL(*file_writer, Open(path, std::ios::trunc | std::ios::binary));
+    EXPECT_CALL(*file_writer, IsOpen()).WillOnce(Return(false));
+    EXPECT_CALL(*file_writer, Write(_)).Times(0);
+    EXPECT_CALL(*file_writer, Close()).Times(0);
+    TraceFileWriter trace_file_writer{{
+        .file_system = std::move(file_system),
+        .file_writer = std::move(file_writer),
+        .compression_strategy = compression_strategy,
+        .initial_buffer_capacity = raw_events.size(),
+        .directory = directory,
+        .create_directory = true,
+    }};
+    const auto result = trace_file_writer.Write(file_name, header, &events);
+    ASSERT_TRUE(result.IsErr());
+    ASSERT_EQ(result.Err(), TraceFileWriter::Error::kFailedToOpenFile);
+  }
+}
+
+TEST(TraceFileWriter, CreatesDirectoryOnce) {  // NOLINT
+  const std::filesystem::path directory{"/path/to/file/"};
+  const std::string file_name{"file.spoor"};
+  const auto path = directory / file_name;
+
+  constexpr auto compression_strategy{CompressionStrategy::kNone};
+  constexpr std::array<Event, 1> raw_events{{{
+      .steady_clock_timestamp = 0,
+      .payload_1 = 1,
+      .type = 2,
+      .payload_2 = 3,
+  }}};
+  constexpr Header header{
+      .magic_number = kMagicNumber,
+      .endianness = kEndianness,
+      .compression_strategy = compression_strategy,
+      .version = kTraceFileVersion,
+      .session_id = 1,
+      .process_id = 2,
+      .thread_id = 3,
+      .system_clock_timestamp = 4,
+      .steady_clock_timestamp = 5,
+      .event_count = raw_events.size(),
+  };
+  Pool pool{{
+      .max_slice_capacity = raw_events.size(),
+      .capacity = raw_events.size(),
+  }};
+  CircularSliceBuffer events{{
+      .buffer_slice_pool = &pool,
+      .capacity = raw_events.size(),
+  }};
+  std::for_each(std::cbegin(raw_events), std ::cend(raw_events),
+                [&events](const auto event) { events.Push(event); });
+  for (const auto created_directories : {false, true}) {
+    auto file_system = std::make_unique<FileSystemMock>();
+    EXPECT_CALL(*file_system, CreateDirectories(directory))
+        .WillOnce(Return(created_directories));
+    auto file_writer = std::make_unique<FileWriterMock>();
+    EXPECT_CALL(*file_writer, Open(path, std::ios::trunc | std::ios::binary))
+        .Times(AnyNumber());
+    EXPECT_CALL(*file_writer, IsOpen()).WillRepeatedly(Return(true));
+    EXPECT_CALL(*file_writer, Write(_)).Times(AnyNumber());
+    EXPECT_CALL(*file_writer, Close()).Times(AnyNumber());
+    TraceFileWriter trace_file_writer{{
+        .file_system = std::move(file_system),
+        .file_writer = std::move(file_writer),
+        .compression_strategy = compression_strategy,
+        .initial_buffer_capacity = raw_events.size(),
+        .directory = directory,
+        .create_directory = true,
+    }};
+    const auto result_a = trace_file_writer.Write(file_name, header, &events);
+    ASSERT_TRUE(result_a.IsOk());
+    const auto result_b = trace_file_writer.Write(file_name, header, &events);
+    ASSERT_TRUE(result_b.IsOk());
+  }
 }
 
 }  // namespace

--- a/spoor/runtime/trace/trace_writer.h
+++ b/spoor/runtime/trace/trace_writer.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <filesystem>
+#include <string>
 
 #include "gsl/gsl"
 #include "spoor/runtime/buffer/circular_slice_buffer.h"
@@ -28,7 +28,9 @@ class TraceWriter {
   constexpr auto operator=(TraceWriter&&) -> TraceWriter& = default;
   virtual ~TraceWriter() = default;
 
-  virtual auto Write(const std::filesystem::path& file_path, Header header,
+  // Passing `const std::string&` instead of `std::string_view` for gMock
+  // compatibility.
+  virtual auto Write(const std::string& file_name, Header header,
                      gsl::not_null<Events*> events) -> Result = 0;
 };
 

--- a/spoor/runtime/trace/trace_writer_mock.h
+++ b/spoor/runtime/trace/trace_writer_mock.h
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#include <filesystem>
+#include <string>
 
 #include "gmock/gmock.h"
 #include "gsl/gsl"
@@ -13,7 +13,7 @@ class TraceWriterMock final : public TraceWriter {
  public:
   MOCK_METHOD(  // NOLINT
       Result, Write,
-      (const std::filesystem::path& file_path, Header header,
+      (const std::string& file_name, Header header,
        gsl::not_null<Events*> events),
       (override));
 };


### PR DESCRIPTION
Creates the trace file path if one does not exist. Additionally, eliminates the need for a trailing slash at the end of the path config.