### PR TITLE
Bundle multi-architecture spoor_opt with Xcode toolchain

### DIFF
--- a/spoor/instrumentation/BUILD
+++ b/spoor/instrumentation/BUILD
@@ -33,12 +33,15 @@ cc_test(
     ],
 )
 
-cc_binary(
-    name = "spoor_opt",
+cc_library(
+    name = "spoor_opt_lib",
     srcs = ["spoor_opt.cc"],
     copts = SPOOR_DEFAULT_COPTS,
     linkopts = SPOOR_DEFAULT_LINKOPTS,
-    visibility = ["//visibility:public"],
+    visibility = [
+        "//spoor/instrumentation/wrappers/apple:__pkg__",
+        "//spoor_instrumentation:__pkg__",
+    ],
     deps = [
         ":instrumentation_info",
         "//spoor/instrumentation/config",
@@ -60,6 +63,14 @@ cc_binary(
         "@llvm-project//llvm:Support",
         "@llvm-project//llvm:config",
     ],
+)
+
+cc_binary(
+    name = "spoor_opt",
+    copts = SPOOR_DEFAULT_COPTS,
+    linkopts = SPOOR_DEFAULT_LINKOPTS,
+    visibility = ["//visibility:public"],
+    deps = [":spoor_opt_lib"],
 )
 
 # TODO(#131): Fix `opt` pass plugin support for IR instrumentation. Spoor pass

--- a/spoor/instrumentation/wrappers/BUILD
+++ b/spoor/instrumentation/wrappers/BUILD
@@ -1,0 +1,2 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.

--- a/spoor/instrumentation/wrappers/apple/BUILD
+++ b/spoor/instrumentation/wrappers/apple/BUILD
@@ -1,0 +1,18 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+load(
+    "@build_bazel_rules_apple//apple:macos.bzl",
+    "macos_command_line_application",
+)
+load("//toolchain:config.bzl", "SPOOR_DEFAULT_LINKOPTS")
+
+_MINIMUM_MACOS_VERSION = "10.15"
+
+macos_command_line_application(
+    name = "spoor_opt",
+    minimum_deployment_os_version = _MINIMUM_MACOS_VERSION,
+    minimum_os_version = _MINIMUM_MACOS_VERSION,
+    visibility = ["//visibility:public"],
+    deps = ["//spoor/instrumentation:spoor_opt_lib"],
+)

--- a/toolchain/xcode/BUILD
+++ b/toolchain/xcode/BUILD
@@ -161,7 +161,7 @@ _TOOLCHAIN_TARGETS_TO_OUTS = [
         TOOLCHAIN_NAME + "/spoor/lib/libspoor_runtime_default_config_watchos.a",
     ],
     [
-        "//spoor/instrumentation:spoor_opt",
+        "//spoor/instrumentation/wrappers/apple:spoor_opt",
         TOOLCHAIN_NAME + "/spoor/bin/spoor_opt",
     ],
 ]


### PR DESCRIPTION
Bundles a multi-architecture (fat) `spoor_opt` executable with the Xcode toolchain.