### PR TITLE
Ignore analyze arg in clang wrapper

### DIFF
--- a/toolchain/xcode/clang_clangxx_shared.py
+++ b/toolchain/xcode/clang_clangxx_shared.py
@@ -17,6 +17,7 @@ from shared import SPOOR_INSTRUMENTATION_INJECT_INSTRUMENTATION_KEY
 import argparse
 import os
 
+CLANG_CLANGXX_ANALYZE_ARG = '--analyze'
 CLANG_CLANGXX_EMIT_LLVM_ARG = '-emit-llvm'
 CLANG_CLANGXX_INCREMENTAL_LINK_ARG = '-r'
 CLANG_CLANGXX_LIBRARY_SEARCH_PATH_ARG = '-L'
@@ -91,8 +92,9 @@ def _runtime_config_for_target(target):
 
 
 def _link_spoor_runtime(args):
-  return CLANG_CLANGXX_ONLY_PREPROCESS_COMPILE_AND_ASSEMBLE_ARG not in args \
-          and CLANG_CLANGXX_INCREMENTAL_LINK_ARG not in args
+  return (CLANG_CLANGXX_ONLY_PREPROCESS_COMPILE_AND_ASSEMBLE_ARG not in args and
+          CLANG_CLANGXX_INCREMENTAL_LINK_ARG not in args and
+          CLANG_CLANGXX_ANALYZE_ARG not in args)
 
 
 def parse_clang_clangxx_args(args, spoor_library_path):

--- a/toolchain/xcode/clang_clangxx_test.py
+++ b/toolchain/xcode/clang_clangxx_test.py
@@ -253,6 +253,36 @@ def test_clang_does_not_link_spoor_for_incremental_link(popen_mock):
     popen_mock.reset_mock()
 
 
+def _test_does_not_link_analyze(main, popen_mock):
+  input_args = [
+      '-target',
+      'arm64-apple-ios15.0',
+      '--analyze',
+      'source.m',
+      '-o',
+      'out.plist',
+  ]
+  popen_handle = popen_mock.return_value.__enter__
+  popen_handle.return_value.returncode = 0
+
+  return_code = main(['clang_clangxx'] + input_args, 'default_clang_clangxx',
+                     'spoor_opt', 'default_clangxx', '/spoor/library/path')
+
+  popen_handle.assert_called_once()
+  popen_handle.return_value.wait.assert_called_once()
+  assert return_code == 0
+  popen_args = popen_mock.call_args.args[0]
+  assert popen_args == ['default_clang_clangxx'] + input_args
+
+
+@patch('subprocess.Popen')
+@patch.dict('os.environ', {})
+def test_clang_does_not_link_analyze(popen_mock):
+  for main in [clang.main, clangxx.main]:
+    _test_does_not_link_analyze(main, popen_mock)
+    popen_mock.reset_mock()
+
+
 def _test_link_return_code(main, popen_mock):
   input_args = [
       '-target', 'arm64-apple-ios15.0', '-o', 'a.o', '-r', 'foo', 'bar'


### PR DESCRIPTION
Do not try to instrument code with the `--analyze` argument in the `clang` and `clang++` wrapper scripts.

We'll eventually need a more scalable option than this one-off argument handling.