### PR TITLE
Failable find file config

### DIFF
--- a/spoor/instrumentation/config/file_source.h
+++ b/spoor/instrumentation/config/file_source.h
@@ -9,6 +9,7 @@
 #include <optional>
 #include <string>
 #include <string_view>
+#include <system_error>
 #include <vector>
 
 #include "gsl/gsl"
@@ -17,6 +18,7 @@
 #include "util/env/env.h"
 #include "util/file_system/file_reader.h"
 #include "util/file_system/util.h"
+#include "util/result.h"
 
 namespace spoor::instrumentation::config {
 
@@ -63,7 +65,8 @@ class FileSource final : public Source {
 
   [[nodiscard]] static auto FindConfigFile(
       const std::filesystem::path& deepest_search_path)
-      -> std::optional<std::filesystem::path>;
+      -> util::result::Result<std::optional<std::filesystem::path>,
+                              std::error_code>;
 
   [[nodiscard]] auto Read() -> std::vector<ReadError> override;
   [[nodiscard]] auto IsRead() const -> bool override;

--- a/spoor/instrumentation/spoor_instrumentation_pass.cc
+++ b/spoor/instrumentation/spoor_instrumentation_pass.cc
@@ -74,11 +74,11 @@ auto PluginInfo() -> llvm::PassPluginLibraryInfo {
           auto current_path = file_system.CurrentPath();
           const auto config_file_path =
               FileSource::FindConfigFile(current_path.Ok());
-          if (config_file_path.has_value()) {
+          if (config_file_path.IsOk() && config_file_path.Ok().has_value()) {
             FileSource::Options file_source_options{
                 .file_reader{std::make_unique<LocalFileReader>()},
                 .path_expansion_options{path_expansion_options},
-                .file_path{config_file_path.value()},
+                .file_path{config_file_path.Ok().value()},
             };
             sources.emplace_back(
                 std::make_unique<FileSource>(std::move(file_source_options)));

--- a/spoor/instrumentation/spoor_opt.cc
+++ b/spoor/instrumentation/spoor_opt.cc
@@ -128,7 +128,15 @@ auto main(int argc, char** argv) -> int {
                  << "Try --help to list available flags.\n";
     return EXIT_FAILURE;
   }
-  const auto config_file_path = FileSource::FindConfigFile(current_path.Ok());
+  const auto config_file_result = FileSource::FindConfigFile(current_path.Ok());
+  if (config_file_result.IsErr()) {
+    llvm::WithColor::error();
+    llvm::errs() << config_file_result.Err().message() << "\n\n"
+                 << absl::ProgramUsageMessage() << "\n\n"
+                 << "Try --help to list available flags.\n";
+    return EXIT_FAILURE;
+  }
+  const auto& config_file_path = config_file_result.Ok();
   if (config_file_path.has_value()) {
     FileSource::Options file_source_options{
         .file_reader{std::make_unique<util::file_system::LocalFileReader>()},


### PR DESCRIPTION
Refactor `FileSource::FindConfigFile` to return a `Result`. Returns a `std::error_code` if the directory iterator fails to construct due to a nonexistent file or directory.