### PR TITLE
Dynamic Runtime library xcframework

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -216,9 +216,9 @@ gazelle_dependencies()
 
 http_archive(
     name = "build_bazel_rules_apple",
-    sha256 = "bf14eed4a8b31ad93524e7e49973d66079fb95b16c701a79a744e98d75ee8d53",
-    strip_prefix = "rules_apple-0.33.0",
-    url = "https://github.com/bazelbuild/rules_apple/archive/0.33.0.tar.gz",
+    sha256 = "90bbacabae2720f4c3b5edd4086f925ddf8630c299b2470f683014a8c978a834",
+    strip_prefix = "rules_apple-0.34.0",
+    url = "https://github.com/bazelbuild/rules_apple/archive/0.34.0.tar.gz",
 )
 
 load(

--- a/spoor/runtime/wrappers/apple/BUILD
+++ b/spoor/runtime/wrappers/apple/BUILD
@@ -7,12 +7,19 @@ load(
     "ios_static_framework",
     "ios_unit_test",
 )
+load("@build_bazel_rules_apple//apple:apple.bzl", "apple_xcframework")
 load("@build_bazel_rules_apple//apple:macos.bzl", "macos_unit_test")
 load(
     "@build_bazel_rules_apple//apple:watchos.bzl",
     "watchos_static_framework",
     # TODO(237): Fix watchOS unit tests.
     # "watchos_unit_test",
+)
+load(
+    "//spoor/runtime/wrappers/apple:config.bzl",
+    "RUNTIME_HDRS",
+    "RUNTIME_STUB_TARGET_NAME",
+    "RUNTIME_TARGET_NAME",
 )
 load(
     "//toolchain:config.bzl",
@@ -31,13 +38,6 @@ _LIB_COPTS = SPOOR_DEFAULT_COPTS
 
 _TEST_COPTS = SPOOR_DEFAULT_TEST_COPTS + ["-Wno-gnu-statement-expression"]
 
-_LIB_HDRS = [
-    "SpoorConfig.h",
-    "SpoorDeletedFilesInfo.h",
-    "Runtime.h",
-    "SpoorTypes.h",
-]
-
 _LIB_SRCS = [
     "SpoorConfig.mm",
     "SpoorConfig_private.h",
@@ -52,31 +52,99 @@ _WRAPPER_TEST_SRCS = [
     "SpoorTypesTests.mm",
 ]
 
-_MODULE_NAME = "SpoorRuntime"
+_MODULE_NAME = RUNTIME_TARGET_NAME
 
-_STUB_MODULE_NAME = "SpoorRuntimeStub"
+_STUB_MODULE_NAME = RUNTIME_STUB_TARGET_NAME
 
 ios_static_framework(
     name = "ios_runtime_framework",
-    hdrs = _LIB_HDRS,
+    hdrs = RUNTIME_HDRS,
     bundle_name = _MODULE_NAME,
     minimum_os_version = _MINIMUM_IOS_VERSION,
     visibility = ["//visibility:public"],
     deps = [":runtime_lib"],
 )
 
+_XCFRAMEWORK_BUNDLE_ID_TEMPLATE = "com.microsoft.spoor.{}"
+
+apple_xcframework(
+    name = RUNTIME_TARGET_NAME,
+    bundle_id = _XCFRAMEWORK_BUNDLE_ID_TEMPLATE.format(RUNTIME_TARGET_NAME),
+    families_required = {
+        "ios": [
+            "ipad",
+            "iphone",
+        ],
+    },
+    framework_type = ["dynamic"],
+    infoplists = ["SpoorRuntimeInfo.plist"],
+    ios = {
+        "simulator": [
+            "arm64",
+            "x86_64",
+        ],
+        "device": ["arm64"],
+    },
+    minimum_deployment_os_versions = {
+        "ios": _MINIMUM_IOS_VERSION,
+    },
+    minimum_os_versions = {
+        "ios": _MINIMUM_IOS_VERSION,
+    },
+    public_hdrs = RUNTIME_HDRS,
+    visibility = ["//visibility:public"],
+    deps = [
+        ":runtime_default_config_lib",
+        ":runtime_lib",
+    ],
+)
+
 ios_static_framework(
     name = "ios_runtime_stub_framework",
-    hdrs = _LIB_HDRS,
+    hdrs = RUNTIME_HDRS,
     bundle_name = _STUB_MODULE_NAME,
     minimum_os_version = _MINIMUM_IOS_VERSION,
     visibility = ["//visibility:public"],
     deps = [":runtime_stub_lib"],
 )
 
+apple_xcframework(
+    name = RUNTIME_STUB_TARGET_NAME,
+    bundle_id = _XCFRAMEWORK_BUNDLE_ID_TEMPLATE.format(
+        RUNTIME_STUB_TARGET_NAME,
+    ),
+    families_required = {
+        "ios": [
+            "ipad",
+            "iphone",
+        ],
+    },
+    framework_type = ["dynamic"],
+    infoplists = ["SpoorRuntimeInfo.plist"],
+    ios = {
+        "simulator": [
+            "arm64",
+            "x86_64",
+        ],
+        "device": ["arm64"],
+    },
+    minimum_deployment_os_versions = {
+        "ios": _MINIMUM_IOS_VERSION,
+    },
+    minimum_os_versions = {
+        "ios": _MINIMUM_IOS_VERSION,
+    },
+    public_hdrs = RUNTIME_HDRS,
+    visibility = ["//visibility:public"],
+    deps = [
+        ":runtime_default_config_lib",
+        ":runtime_stub_lib",
+    ],
+)
+
 watchos_static_framework(
     name = "watchos_runtime_framework",
-    hdrs = _LIB_HDRS,
+    hdrs = RUNTIME_HDRS,
     bundle_name = _MODULE_NAME,
     minimum_os_version = _MINIMUM_WATCHOS_VERSION,
     visibility = ["//visibility:public"],
@@ -85,7 +153,7 @@ watchos_static_framework(
 
 watchos_static_framework(
     name = "watchos_runtime_stub_framework",
-    hdrs = _LIB_HDRS,
+    hdrs = RUNTIME_HDRS,
     bundle_name = _STUB_MODULE_NAME,
     minimum_os_version = _MINIMUM_WATCHOS_VERSION,
     visibility = ["//visibility:public"],
@@ -176,7 +244,7 @@ apple_static_library(
 objc_library(
     name = "runtime_lib",
     srcs = _LIB_SRCS,
-    hdrs = _LIB_HDRS,
+    hdrs = RUNTIME_HDRS,
     copts = _LIB_COPTS,
     module_name = _MODULE_NAME,
     visibility = ["//visibility:private"],
@@ -186,7 +254,7 @@ objc_library(
 objc_library(
     name = "runtime_stub_lib",
     srcs = _LIB_SRCS,
-    hdrs = _LIB_HDRS,
+    hdrs = RUNTIME_HDRS,
     copts = _LIB_COPTS,
     module_name = _STUB_MODULE_NAME,
     visibility = ["//visibility:private"],

--- a/spoor/runtime/wrappers/apple/SpoorRuntimeInfo.plist
+++ b/spoor/runtime/wrappers/apple/SpoorRuntimeInfo.plist
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+</dict>
+</plist>
+

--- a/spoor/runtime/wrappers/apple/config.bzl
+++ b/spoor/runtime/wrappers/apple/config.bzl
@@ -1,0 +1,43 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+RUNTIME_TARGET_NAME = "SpoorRuntime"
+
+RUNTIME_STUB_TARGET_NAME = "SpoorRuntimeStub"
+
+RUNTIME_HDRS = [
+    "SpoorConfig.h",
+    "SpoorDeletedFilesInfo.h",
+    "Runtime.h",
+    "SpoorTypes.h",
+]
+
+def _runtime_framework_files(framework_name):
+    headers = ["Headers/{}".format(header) for header in RUNTIME_HDRS]
+    modules = ["Modules/module.modulemap"]
+    info_plists = ["Info.plist"]
+    executables = [framework_name]
+    framework_files = headers + modules + info_plists + executables
+    return [
+        "{}.framework/{}".format(framework_name, file)
+        for file in framework_files
+    ]
+
+def _runtime_xcframework_files(xcframework_name):
+    framework_files = _runtime_framework_files(xcframework_name)
+    xcframework_files = ["Info.plist"]
+    for variant in ["ios-arm64", "ios-arm64_x86_64-simulator"]:
+        xcframework_files += [
+            "{}/{}".format(variant, file)
+            for file in framework_files
+        ]
+    return [
+        "{}.xcframework/{}".format(xcframework_name, file)
+        for file in xcframework_files
+    ]
+
+RUNTIME_XCFRAMEWORK_FILES = _runtime_xcframework_files(RUNTIME_TARGET_NAME)
+
+RUNTIME_STUB_XCFRAMEWORK_FILES = _runtime_xcframework_files(
+    RUNTIME_STUB_TARGET_NAME,
+)

--- a/toolchain/xcode/BUILD
+++ b/toolchain/xcode/BUILD
@@ -3,6 +3,13 @@
 
 load("@rules_python//python:defs.bzl", "py_library", "py_test")
 load("@pip_deps_dev//:requirements.bzl", "requirement")
+load(
+    "//spoor/runtime/wrappers/apple:config.bzl",
+    "RUNTIME_STUB_TARGET_NAME",
+    "RUNTIME_STUB_XCFRAMEWORK_FILES",
+    "RUNTIME_TARGET_NAME",
+    "RUNTIME_XCFRAMEWORK_FILES",
+)
 
 TOOLCHAIN_NAME = "MicrosoftSpoor.xctoolchain"
 
@@ -18,6 +25,12 @@ _INSTRUMENT_APP_TAGS = [
 filegroup(
     name = "toolchain_info",
     srcs = ["ToolchainInfo.plist"],
+    visibility = ["//visibility:private"],
+)
+
+py_library(
+    name = "init",
+    srcs = ["__init__.py"],
     visibility = ["//visibility:private"],
 )
 
@@ -61,10 +74,14 @@ py_library(
 py_test(
     name = "clang_clangxx_test",
     srcs = ["clang_clangxx_test.py"],
-    data = ["//toolchain/xcode/test_data/build_args"],
+    data = [
+        "//toolchain/xcode/test_data/build_args",
+        "//toolchain/xcode/test_data/info_plists",
+    ],
     visibility = ["//visibility:private"],
     deps = [
         ":clang",
+        ":clang_clangxx_shared",
         ":clangxx",
         ":shared",
         requirement("pytest"),
@@ -113,6 +130,10 @@ _TOOLCHAIN_TARGETS_TO_OUTS = [
         TOOLCHAIN_NAME + "/ToolchainInfo.plist",
     ],
     [
+        ":init",
+        TOOLCHAIN_NAME + "/usr/bin/__init__.py",
+    ],
+    [
         ":clang",
         TOOLCHAIN_NAME + "/usr/bin/clang",
     ],
@@ -137,54 +158,55 @@ _TOOLCHAIN_TARGETS_TO_OUTS = [
         TOOLCHAIN_NAME + "/usr/bin/shared.py",
     ],
     [
-        "//spoor/runtime/wrappers/apple:spoor_runtime_ios",
-        TOOLCHAIN_NAME + "/spoor/lib/libspoor_runtime_ios.a",
-    ],
-    [
-        "//spoor/runtime/wrappers/apple:spoor_runtime_macos",
-        TOOLCHAIN_NAME + "/spoor/lib/libspoor_runtime_macos.a",
-    ],
-    [
-        "//spoor/runtime/wrappers/apple:spoor_runtime_watchos",
-        TOOLCHAIN_NAME + "/spoor/lib/libspoor_runtime_watchos.a",
-    ],
-    [
-        "//spoor/runtime/wrappers/apple:spoor_runtime_default_config_ios",
-        TOOLCHAIN_NAME + "/spoor/lib/libspoor_runtime_default_config_ios.a",
-    ],
-    [
-        "//spoor/runtime/wrappers/apple:spoor_runtime_default_config_macos",
-        TOOLCHAIN_NAME + "/spoor/lib/libspoor_runtime_default_config_macos.a",
-    ],
-    [
-        "//spoor/runtime/wrappers/apple:spoor_runtime_default_config_watchos",
-        TOOLCHAIN_NAME + "/spoor/lib/libspoor_runtime_default_config_watchos.a",
-    ],
-    [
         "//spoor/instrumentation/wrappers/apple:spoor_opt",
         TOOLCHAIN_NAME + "/spoor/bin/spoor_opt",
     ],
 ]
 
-_TOOLCHAIN_GENERATED_OUTS = [
-    TOOLCHAIN_NAME + "/usr/bin/__init__.py",
+_RUNTIME_XCFRAMEWORK_TARGET = "//spoor/runtime/wrappers/apple:{}".format(
+    RUNTIME_TARGET_NAME,
+)
+
+_RUNTIME_STUB_XCFRAMEWORK_TARGET = "//spoor/runtime/wrappers/apple:{}".format(
+    RUNTIME_STUB_TARGET_NAME,
+)
+
+_FRAMEWORKS_PATH = "{}/spoor/frameworks".format(TOOLCHAIN_NAME)
+
+_XCFRAMEWORKS_FILES = [
+    "{}/{}".format(_FRAMEWORKS_PATH, file)
+    for file in RUNTIME_XCFRAMEWORK_FILES
+] + [
+    "{}/{}".format(_FRAMEWORKS_PATH, file)
+    for file in RUNTIME_STUB_XCFRAMEWORK_FILES
 ]
 
 genrule(
     name = "toolchain",
-    srcs = [src for (src, _) in _TOOLCHAIN_TARGETS_TO_OUTS],
+    srcs = [src for (src, _) in _TOOLCHAIN_TARGETS_TO_OUTS] + [
+        _RUNTIME_XCFRAMEWORK_TARGET,
+        _RUNTIME_STUB_XCFRAMEWORK_TARGET,
+    ],
     # Note: Bazel forces all outputs to be executable.
     # Ticket: https://github.com/bazelbuild/bazel/issues/3359
     # Additional context:
     #   https://github.com/bazelbuild/bazel/issues/5588#issuecomment-628689827
     outs = [out for (_, out) in _TOOLCHAIN_TARGETS_TO_OUTS] +
-           _TOOLCHAIN_GENERATED_OUTS,
+           _XCFRAMEWORKS_FILES,
     cmd = " && ".join(
         [
             "cp $(location {}) $(@D)/{}".format(src, out)
             for (src, out) in _TOOLCHAIN_TARGETS_TO_OUTS
-        ] +
-        ["touch $(@D)/{}".format(out) for out in _TOOLCHAIN_GENERATED_OUTS],
+        ] + [
+            "unzip $(location {}) -d $(@D)/{}".format(
+                _RUNTIME_XCFRAMEWORK_TARGET,
+                _FRAMEWORKS_PATH,
+            ),
+            "unzip $(location {}) -d $(@D)/{}".format(
+                _RUNTIME_STUB_XCFRAMEWORK_TARGET,
+                _FRAMEWORKS_PATH,
+            ),
+        ],
     ),
     visibility = ["//visibility:public"],
 )

--- a/toolchain/xcode/__init__.py
+++ b/toolchain/xcode/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.

--- a/toolchain/xcode/clang.py
+++ b/toolchain/xcode/clang.py
@@ -5,7 +5,8 @@
 runtime library.'''
 
 from clang_clangxx_shared import parse_clang_clangxx_args
-from shared import DEFAULT_CLANG, DEFAULT_CLANGXX, SPOOR_LIBRARY_PATH, SPOOR_OPT
+from shared import DEFAULT_CLANG, DEFAULT_CLANGXX, SPOOR_FRAMEWORKS_PATH
+from shared import SPOOR_OPT
 from shared import instrument_and_compile_ir
 import subprocess
 import sys
@@ -29,5 +30,5 @@ def main(argv, frontend_clang, spoor_opt, backend_clangxx, spoor_library_path):
 
 if __name__ == '__main__':
   return_code = main(sys.argv, DEFAULT_CLANG, SPOOR_OPT, DEFAULT_CLANGXX,
-                     SPOOR_LIBRARY_PATH)
+                     SPOOR_FRAMEWORKS_PATH)
   sys.exit(return_code)

--- a/toolchain/xcode/clangxx.py
+++ b/toolchain/xcode/clangxx.py
@@ -5,7 +5,7 @@
 runtime library.'''
 
 from clang_clangxx_shared import parse_clang_clangxx_args
-from shared import DEFAULT_CLANGXX, SPOOR_LIBRARY_PATH, SPOOR_OPT
+from shared import DEFAULT_CLANGXX, SPOOR_FRAMEWORKS_PATH, SPOOR_OPT
 from shared import instrument_and_compile_ir
 import subprocess
 import sys
@@ -31,5 +31,5 @@ def main(argv, frontend_clangxx, spoor_opt, backend_clangxx,
 
 if __name__ == '__main__':
   return_code = main(sys.argv, DEFAULT_CLANGXX, SPOOR_OPT, DEFAULT_CLANGXX,
-                     SPOOR_LIBRARY_PATH)
+                     SPOOR_FRAMEWORKS_PATH)
   sys.exit(return_code)

--- a/toolchain/xcode/shared.py
+++ b/toolchain/xcode/shared.py
@@ -7,6 +7,7 @@ import operator
 import os
 import pathlib
 import subprocess
+import re
 
 DEVELOPER_PATH = os.getenv('DEVELOPER_DIR',
                            '/Applications/Xcode.app/Contents/Developer')
@@ -20,7 +21,7 @@ DEFAULT_SWIFTC = f'{DEFAULT_TOOLCHAIN_PATH}/usr/bin/swiftc'
 CUSTOM_TOOLCHAIN_PATH = pathlib.Path(
     *pathlib.Path(__file__).parent.absolute().parts[:-2])
 SPOOR_OPT = f'{CUSTOM_TOOLCHAIN_PATH}/spoor/bin/spoor_opt'
-SPOOR_LIBRARY_PATH = f'{CUSTOM_TOOLCHAIN_PATH}/spoor/lib'
+SPOOR_FRAMEWORKS_PATH = f'{CUSTOM_TOOLCHAIN_PATH}/spoor/frameworks'
 WRAPPED_SWIFT = f'{CUSTOM_TOOLCHAIN_PATH}/usr/bin/swift'
 
 CLANG_CLANGXX_INPUT_STDIN_VALUE = '-'
@@ -57,6 +58,27 @@ class ArgsInfo:
     self.output_files = output_files
     self.target = target
     self.instrument = instrument
+
+
+class Target:
+  '''Parses a target string's components.'''
+
+  def __init__(self, target_string):
+    components = target_string.split('-')
+    if len(components) == 3:
+      architecture, vendor, platform = components
+      platform_variant = None
+    elif len(components) == 4:
+      architecture, vendor, platform, platform_variant = components
+    else:
+      raise ValueError(f'Cannot parse target "{target_string}".')
+    self.string = target_string
+    self.architecture = architecture
+    self.vendor = vendor
+    platform_components = re.search('([a-zA-Z]+)([0-9.]+)', platform)
+    self.platform = platform_components.group(1)
+    self.platform_version = platform_components.group(2)
+    self.platform_variant = platform_variant
 
 
 def arg_after(arg, args):

--- a/toolchain/xcode/shared_test.py
+++ b/toolchain/xcode/shared_test.py
@@ -2,12 +2,42 @@
 # Licensed under the MIT License.
 '''Tests for shared wrapper logic.'''
 
-from shared import arg_after, flatten, instrument_and_compile_ir
+from shared import Target, arg_after, flatten, instrument_and_compile_ir
 from unittest import mock
 from unittest.mock import patch
 import pytest
 import subprocess
 import sys
+
+
+def test_target_parses_string_without_platform_variant():
+  target_string = 'arm64-apple-ios15.0'
+  target = Target(target_string)
+  assert target.string == target_string
+  assert target.architecture == 'arm64'
+  assert target.vendor == 'apple'
+  assert target.platform == 'ios'
+  assert target.platform_version == '15.0'
+  assert target.platform_variant is None
+
+
+def test_target_parses_string_with_platform_variant():
+  target_string = 'x86_64-apple-ios15.0-simulator'
+  target = Target(target_string)
+  assert target.string == target_string
+  assert target.architecture == 'x86_64'
+  assert target.vendor == 'apple'
+  assert target.platform == 'ios'
+  assert target.platform_version == '15.0'
+  assert target.platform_variant == 'simulator'
+
+
+def test_target_fails_to_parse_bad_target_string():
+  target_string = 'foo'
+  expected_error = f'Cannot parse target "{target_string}".'
+  with pytest.raises(ValueError) as error:
+    _ = Target(target_string)
+  assert str(error.value) == expected_error
 
 
 def test_arg_after():

--- a/toolchain/xcode/test_data/info_plists/BUILD
+++ b/toolchain/xcode/test_data/info_plists/BUILD
@@ -1,0 +1,12 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+filegroup(
+    name = "info_plists",
+    testonly = True,
+    srcs = [
+        "spoor_runtime_xctoolchain_info.plist",
+        "unknown_xctoolchain_version.plist",
+    ],
+    visibility = ["//toolchain/xcode:__subpackages__"],
+)

--- a/toolchain/xcode/test_data/info_plists/spoor_runtime_xctoolchain_info.plist
+++ b/toolchain/xcode/test_data/info_plists/spoor_runtime_xctoolchain_info.plist
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>AvailableLibraries</key>
+	<array>
+		<dict>
+			<key>LibraryIdentifier</key>
+			<string>ios-arm64</string>
+			<key>LibraryPath</key>
+			<string>SpoorRuntime.framework</string>
+			<key>SupportedArchitectures</key>
+			<array>
+				<string>arm64</string>
+			</array>
+			<key>SupportedPlatform</key>
+			<string>ios</string>
+		</dict>
+		<dict>
+			<key>LibraryIdentifier</key>
+			<string>ios-arm64_x86_64-simulator</string>
+			<key>LibraryPath</key>
+			<string>SpoorRuntime.framework</string>
+			<key>SupportedArchitectures</key>
+			<array>
+				<string>arm64</string>
+				<string>x86_64</string>
+			</array>
+			<key>SupportedPlatform</key>
+			<string>ios</string>
+			<key>SupportedPlatformVariant</key>
+			<string>simulator</string>
+		</dict>
+	</array>
+	<key>CFBundlePackageType</key>
+	<string>XFWK</string>
+	<key>XCFrameworkFormatVersion</key>
+	<string>1.0</string>
+</dict>
+</plist>

--- a/toolchain/xcode/test_data/info_plists/unknown_xctoolchain_version.plist
+++ b/toolchain/xcode/test_data/info_plists/unknown_xctoolchain_version.plist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>AvailableLibraries</key>
+	<array></array>
+	<key>CFBundlePackageType</key>
+	<string>XFWK</string>
+	<key>XCFrameworkFormatVersion</key>
+	<string>2.0</string>
+</dict>
+</plist>
+


### PR DESCRIPTION
* Creates a dynamic variant of Spoor's runtime library packaged as an `xcframework`.
* Changes the toolchain to link against the dynamic version of the runtime library.
* Upgrades `rules_apple`.
* Introduces #257 by dropping watchOS and macOS support for the instrumentation because those platforms are not yet supported by the `apple_xcframework` rule.