### PR TITLE
Drop old architectures

### DIFF
--- a/.build/ci.bazelrc
+++ b/.build/ci.bazelrc
@@ -4,9 +4,9 @@
 build --copt="-fembed-bitcode"
 # Note: We cannot simultaneously build with both `arm64` and `sim_arm64` because
 # fat files cannot contain two binaries with the same architecture.
-build --ios_multi_cpus=arm64,armv7,i386,x86_64
-build --macos_cpus=arm64,arm64e,x86_64
-build --watchos_cpus=arm64,arm64_32,armv7k,i386,x86_64
+build --ios_multi_cpus=arm64,x86_64
+build --macos_cpus=arm64,x86_64
+build --watchos_cpus=arm64,arm64_32,x86_64
 
 build --output_filter='^external/*'
 test --test_output=all


### PR DESCRIPTION
Drops architectures from old Apple devices. Bundling old architectures increases the toolchain's size and can cause problems when trying to execute fat binaries, e.g., when both arm64 and arm64e are inside a macOS executable.