### PR TITLE
Bundle generated header in xcframework

### DIFF
--- a/spoor/runtime/wrappers/apple/config.bzl
+++ b/spoor/runtime/wrappers/apple/config.bzl
@@ -13,7 +13,10 @@ RUNTIME_HDRS = [
 ]
 
 def _runtime_framework_files(framework_name):
-    headers = ["Headers/{}".format(header) for header in RUNTIME_HDRS]
+    headers = [
+        "Headers/{}".format(header)
+        for header in RUNTIME_HDRS + ["{}.h".format(framework_name)]
+    ]
     modules = ["Modules/module.modulemap"]
     info_plists = ["Info.plist"]
     executables = [framework_name]


### PR DESCRIPTION
Add the generated [framework_name].h framework header to the copied toolchain runtime framework headers.