### PR TITLE
Add version to runtime framework Info.plist

### DIFF
--- a/spoor/runtime/wrappers/apple/SpoorRuntimeInfo.plist
+++ b/spoor/runtime/wrappers/apple/SpoorRuntimeInfo.plist
@@ -14,6 +14,10 @@
 	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>0.0.0</string>
+	<key>CFBundleVersion</key>
+	<string>0.0.0</string>
 </dict>
 </plist>
 


### PR DESCRIPTION
Add `CFBundleShortVersionString` and `CFBundleVersion` to the runtime framework's Info.plist