### PR TITLE
Set DEVELOPER_PATH to active developer directory

### DIFF
--- a/spoor/toolchains/xcode/shared.py
+++ b/spoor/toolchains/xcode/shared.py
@@ -9,8 +9,19 @@ import pathlib
 import subprocess
 import re
 
-DEVELOPER_PATH = os.getenv('DEVELOPER_DIR',
-                           '/Applications/Xcode.app/Contents/Developer')
+
+def get_developer_path():
+  developer_dir = os.getenv('DEVELOPER_DIR')
+  if developer_dir:
+    return developer_dir
+  result = subprocess.run(['xcode-select', '--print-path'],
+                          stdout=subprocess.PIPE,
+                          check=True,
+                          text=True)
+  return result.stdout.strip()
+
+
+DEVELOPER_PATH = get_developer_path()
 DEFAULT_TOOLCHAIN_PATH = f'{DEVELOPER_PATH}/Toolchains/XcodeDefault.xctoolchain'
 DEFAULT_CLANG = f'{DEFAULT_TOOLCHAIN_PATH}/usr/bin/clang'
 DEFAULT_CLANGXX = f'{DEFAULT_TOOLCHAIN_PATH}/usr/bin/clang++'

--- a/spoor/toolchains/xcode/shared_test.py
+++ b/spoor/toolchains/xcode/shared_test.py
@@ -2,12 +2,34 @@
 # Licensed under the MIT License.
 '''Tests for shared wrapper logic.'''
 
-from shared import Target, arg_after, flatten, instrument_and_compile_ir
+from shared import arg_after, flatten, get_developer_path
+from shared import instrument_and_compile_ir
+from shared import Target
 from unittest import mock
 from unittest.mock import patch
 import pytest
 import subprocess
 import sys
+
+
+@patch('subprocess.run')
+@patch.dict('os.environ', {})
+def test_get_developer_path(run_mock):
+  type(run_mock.return_value).stdout = '/foo/bar\n'
+  developer_dir = get_developer_path()
+  run_mock.assert_called_once_with(['xcode-select', '--print-path'],
+                                   stdout=subprocess.PIPE,
+                                   check=True,
+                                   text=True)
+  assert developer_dir == '/foo/bar'
+
+
+@patch('subprocess.run')
+@patch.dict('os.environ', {'DEVELOPER_DIR': '/foo/bar'})
+def test_get_developer_path_env_override(run_mock):
+  developer_dir = get_developer_path()
+  run_mock.assert_not_called()
+  assert developer_dir == '/foo/bar'
 
 
 def test_target_parses_string_without_platform_variant():


### PR DESCRIPTION
Xcode does not set the `DEVELOPER_DIR` environment variable when invoking its toolchain commands. Therefore, the previous logic always fell back to the default path of `/Applications/Xcode.app/Contents/Developer` which does not work for customized Xcode installations. This PR sets the `DEVELOPER_PATH` to the active developer directory retrieved from `xcode-select --print-path`. The value can still be overridden by setting `DEVELOPER_DIR`.