### PR TITLE
Add security page reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ see the [Code of Conduct FAQ][code-of-conduct-faq] or contact
 [opencode@microsoft.com][opencode-email] with any additional questions or
 comments.
 
+## Security
+
+Please do not report security vulnerabilities through public GitHub issues.
+Instead, report them to the Microsoft Security Response Center.
+[Details][security].
+
 ## Trademarks
 
 This project may contain trademarks or logos for projects, products, or
@@ -55,6 +61,7 @@ trademarks or logos are subject to those third-party’s policies.
 [code-of-conduct]: https://opensource.microsoft.com/codeofconduct/
 [microsoft-cla]: https://cla.opensource.microsoft.com
 [opencode-email]: mailto:opencode@microsoft.com
+[security]: SECURITY.md
 [site-instrumentation]: https://www.spoor.dev/reference/instrumentation
 [site-postprocessing]: https://www.spoor.dev/reference/postprocessing
 [site-runtime]: https://www.spoor.dev/reference/runtime

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -15,8 +15,8 @@ improve. For example:
 ### Security
 
 Please do _not_ report security vulnerabilities through public GitHub issues.
-Instead, report them to the Microsoft Security Response Center at
-[msrc.microsoft.com/create-report][msrc-create-report].
+Instead, report them to the Microsoft Security Response Center.
+[Details][security].
 
 ## Contribute code
 
@@ -69,7 +69,7 @@ trademarks or logos are subject to those third-party’s policies.
 [github-pr]: https://github.com/microsoft/spoor/issues
 [github]: https://github.com/microsoft/spoor
 [microsoft-cla]: https://cla.opensource.microsoft.com
-[msrc-create-report]: https://msrc.microsoft.com/create-report
 [opencode-email]: mailto:opencode@microsoft.com
+[security]: security.md
 [style-guide]: style-guide.md
 [trademark-brand-guidelines]: https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks


### PR DESCRIPTION
Adds a reference to the SECURITY.md page from README.md and the contributing index page.