### PR TITLE
Disable Swift Driver integration in example app

### DIFF
--- a/spoor/toolchains/xcode/test_data/minimal_swift_ios_app/MinimalSwiftApp.xcodeproj/project.pbxproj
+++ b/spoor/toolchains/xcode/test_data/minimal_swift_ios_app/MinimalSwiftApp.xcodeproj/project.pbxproj
@@ -212,6 +212,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_USE_INTEGRATED_DRIVER = NO;
 			};
 			name = Debug;
 		};
@@ -267,6 +268,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = singlefile;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_USE_INTEGRATED_DRIVER = NO;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;


### PR DESCRIPTION
This is needed for our `swift` wrapper to be called correctly.